### PR TITLE
feat: add lerd cpx

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -156,6 +156,7 @@ func main() {
 	root.AddCommand(cli.NewNpmCmd())
 	root.AddCommand(cli.NewNpxCmd())
 	root.AddCommand(cli.NewComposerCmd())
+	root.AddCommand(cli.NewCpxCmd())
 	root.AddCommand(cli.NewAuthCmd())
 	root.AddCommand(cli.NewServiceCmd())
 	root.AddCommand(cli.NewStatusCmd())

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -351,6 +351,7 @@ Activity-driven worker suspension: lerd gracefully stops each site's suspendable
 | `lerd a [args...]` | Short alias for `lerd console` / `lerd artisan` |
 | `lerd test [args...]` | Shortcut for `lerd artisan test` |
 | `lerd <vendor-bin> [args...]` | Run any composer-installed binary from the project's `vendor/bin` directory (e.g. `lerd pest`, `lerd pint`, `lerd phpstan`). Real lerd commands always win over vendor binaries with the same name. |
+| `lerd cpx <package> [args...]` | Run a command from any Composer package without adding it to the project, [cpx](https://cpx.dev) being to Composer what npx is to npm. Uses the globally required binary (`lerd composer global require cpx/cpx`) and runs it on the PHP version the project is registered on |
 | `lerd shell` | Open an interactive shell inside the project's PHP-FPM container |
 
 ## AI integration

--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -76,6 +76,19 @@ lerd rector process
 
 These run inside the project's PHP-FPM container with the project's working directory mounted, so configuration files (`pest.xml`, `pint.json`, `phpstan.neon`, etc.) are picked up automatically. Real lerd commands always take precedence; if you have a `vendor/bin/composer`, `lerd composer` still resolves to the built-in command.
 
+### Running a package you have not installed
+
+[cpx](https://cpx.dev) is to Composer what npx is to npm: it runs a command from any Composer package without adding it to the project. Require it once, and `lerd cpx` runs it inside the project's container:
+
+```bash
+lerd composer global require cpx/cpx
+lerd cpx phpstan/phpstan analyse
+```
+
+The package runs on the PHP version the site is registered on rather than whatever PHP is on the host, which is the whole reason to route it through lerd. Fetched packages are cached under `~/.cpx` on the host, so they survive a container restart and are shared with any cpx you run outside lerd.
+
+Requiring it globally also puts a `cpx` shim on your PATH, so bare `cpx` works too and runs through the same container. `lerd cpx` is the explicit form, and the one that tells you what to install when cpx is missing.
+
 The MCP integration exposes the same surface through two tools, `vendor_bins` (list available binaries) and `vendor_run` (execute one), so AI assistants can discover and run project tooling without per-project configuration.
 
 ### IDE quality tools

--- a/internal/cli/cpx_exec.go
+++ b/internal/cli/cpx_exec.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCpxCmd returns the cpx command. cpx is to Composer what npx is to npm: it
+// runs a command from any Composer package without adding it to the project.
+// lerd runs the globally required binary inside the project's FPM container, so
+// the package it fetches runs on the PHP version that project is registered on
+// rather than whatever PHP happens to be on the host.
+func NewCpxCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:                "cpx [args...]",
+		Short:              "Run cpx (Composer's npx) in the project's container",
+		DisableFlagParsing: true,
+		SilenceUsage:       true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runCpx(args)
+		},
+	}
+}
+
+// cpxBinPath is where `composer global require cpx/cpx` drops the binary.
+func cpxBinPath() string {
+	return filepath.Join(composerGlobalBinDir(), "cpx")
+}
+
+func runCpx(args []string) error {
+	bin := cpxBinPath()
+	if _, err := os.Stat(bin); err != nil {
+		return fmt.Errorf("cpx is not installed: run `lerd composer global require cpx/cpx`")
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	// cpx caches the packages it fetches under $HOME/.cpx, and lerd already
+	// execs with HOME set to the host's home, so the cache is shared with the
+	// host and survives a container restart. Nothing to pass here.
+	code, runErr := RunPHPCaptureEnv(cwd, append([]string{bin}, args...), nil)
+	if runErr != nil {
+		return runErr
+	}
+	if code != 0 {
+		os.Exit(code)
+	}
+	return nil
+}

--- a/internal/cli/cpx_exec_test.go
+++ b/internal/cli/cpx_exec_test.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// cpx is only ever the globally required binary (#1543), so the resolver has to
+// look where `lerd composer global require` actually puts it and say so plainly
+// when it is not there, rather than failing inside the container with "could
+// not open input file".
+func TestCpxBinPath_followsComposerHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COMPOSER_HOME", home)
+
+	want := filepath.Join(home, "vendor", "bin", "cpx")
+	if got := cpxBinPath(); got != want {
+		t.Errorf("cpxBinPath() = %q, want %q", got, want)
+	}
+}
+
+func TestCpxBinPath_honoursXDG(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COMPOSER_HOME", "")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+
+	want := filepath.Join(home, "xdg", "composer", "vendor", "bin", "cpx")
+	if got := cpxBinPath(); got != want {
+		t.Errorf("cpxBinPath() = %q, want %q", got, want)
+	}
+}
+
+func TestRunCpx_missingBinaryNamesTheFix(t *testing.T) {
+	t.Setenv("COMPOSER_HOME", t.TempDir())
+
+	err := runCpx([]string{"--version"})
+	if err == nil {
+		t.Fatal("expected an error when cpx is not installed")
+	}
+	if !strings.Contains(err.Error(), "composer global require cpx/cpx") {
+		t.Errorf("error should name the command that installs it, got: %v", err)
+	}
+}


### PR DESCRIPTION
cpx is to Composer what npx is to npm, a way to run a command from any Composer package without adding it to the project. Routing it through lerd is what makes it run on the PHP version the site is registered on rather than whatever PHP the host happens to have, the same reason lerd wraps composer and artisan.

Worth saying plainly: most of this already worked before the command existed. Requiring cpx globally makes lerd sync a shim onto PATH like it does for any composer global binary, and lerd already execs with HOME set to the host's home, so the packages cpx fetches cache under ~/.cpx and survive a container restart. What the command adds is the explicit form and an error worth reading, since without it a missing cpx fails inside the container with "could not open input file" rather than naming the one command that fixes it.

The binary is resolved through the same COMPOSER_HOME and XDG lookup the global bin sync uses, so a non-default composer home is followed rather than guessed at.

Confirmed against a real project on 8.5, running a package the project does not have:

    $ lerd cpx phpstan/phpstan analyse app --level=1
    {"tool":"phpstan","result":"passed","errors":0}

Note the package is cpx/cpx, not laravel/cpx as the repo name suggests.

Closes #1543
