### PR TITLE
fix: keep lerd services off the Xdebug port

### DIFF
--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -183,6 +183,12 @@ Xdebug is configured with:
 
 Set your IDE to listen on port `9003`. In VS Code, the default PHP Debug configuration works without changes. In PhpStorm, set **Settings > PHP > Debug > Debug port** to `9003`.
 
+Port `9003` is reserved: no lerd service is ever published on it, because a container that held it would answer Xdebug's connect-back itself and your IDE would simply never see a session. An install that already shifted a service onto it before this was reserved keeps it, so `lerd doctor` names the service and the command that moves it:
+
+```bash
+lerd service port rustfs 9004 --container 9001
+```
+
 `host.containers.internal` is resolved via a real reachability probe: when lerd writes the shared hosts file it tries each candidate IP (netavark's `host.containers.internal` entry, the host's primary LAN IP, slirp4netns's `10.0.2.2`) by opening a TCP connection to lerd-ui on port 7073 from inside lerd-nginx, and writes the first one that succeeds. If none succeed, `lerd doctor` reports the failure so you get a real diagnosis instead of Xdebug silently timing out with `Time-out connecting to debugging client`.
 :::
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -437,6 +437,17 @@ func runDoctorInto(w io.Writer, useColor bool) (DoctorReport, error) {
 		}
 	}
 
+	// Xdebug connects back to the IDE on this port, so a lerd container that
+	// publishes it answers the debugger itself and the IDE never sees a session.
+	// The connection succeeds, which is why nothing else reports it (#1555).
+	if owner, taken := podman.PublishedPortOwner(config.XdebugClientPort); taken {
+		warn(fmt.Sprintf("xdebug port %d", config.XdebugClientPort),
+			fmt.Sprintf("published by %s, so breakpoints never reach your IDE (move it: lerd service port %s %d --container %d)",
+				owner.Unit, owner.Service, config.XdebugClientPort+1, owner.ContainerPort))
+	} else {
+		ok(fmt.Sprintf("port %d (free for xdebug)", config.XdebugClientPort))
+	}
+
 	// ── Stopped service ports ────────────────────────────────────────────────
 	// Surfaces the same diagnosis the UI shows on inactive service cards: if
 	// a service unit is installed but stopped and its host port is already

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -531,6 +531,11 @@ func ServiceEntryOrphaned(name string) bool {
 	return !IsDefaultPreset(name) && !CustomServiceExists(name)
 }
 
+// XdebugClientPort is the port Xdebug connects back to on the host, written into
+// every PHP image's ini by the image build. It is reserved against every host
+// port lerd hands out, since the debugger and the IDE have to meet there.
+const XdebugClientPort = 9003
+
 // ReservedHostPorts returns every host port a lerd service may bind: each
 // configured service entry's effective ports (HostPorts), every bundled preset's
 // default ports (including optional presets not in the default set), and every
@@ -542,6 +547,10 @@ func ServiceEntryOrphaned(name string) bool {
 // and customs.
 func ReservedHostPorts() map[int]bool {
 	reserved := map[int]bool{}
+	// The IDE listens on the Xdebug port, so no container may publish it: one
+	// that did would answer the debugger's connect-back itself and the IDE would
+	// simply never see a session (#1555).
+	reserved[XdebugClientPort] = true
 	cfg, _ := LoadGlobal()
 	add := func(n int) {
 		if n > 0 {

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -911,3 +911,15 @@ func TestHostPortsFor_UnknownService(t *testing.T) {
 		t.Errorf("HostPortsFor(unknown) = %v, want nil", got)
 	}
 }
+
+// The IDE listens on the Xdebug port, so no allocator may hand it to a
+// container: one that published it would answer the debugger's connect-back
+// itself and the IDE would never see a session (#1555).
+func TestReservedHostPorts_ReservesTheXdebugPort(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	if !ReservedHostPorts()[XdebugClientPort] {
+		t.Errorf("port %d is not reserved, so a service shift can land on it", XdebugClientPort)
+	}
+}

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -806,7 +806,7 @@ func WriteXdebugIni(version, mode, start string) error {
 	if start == "" {
 		start = "yes"
 	}
-	content := fmt.Sprintf("[xdebug]\nxdebug.mode=%s\nxdebug.start_with_request=%s\nxdebug.client_host=host.containers.internal\nxdebug.client_port=9003\n", mode, start)
+	content := fmt.Sprintf("[xdebug]\nxdebug.mode=%s\nxdebug.start_with_request=%s\nxdebug.client_host=host.containers.internal\nxdebug.client_port=%d\n", mode, start, config.XdebugClientPort)
 	return os.WriteFile(path, []byte(content), 0644)
 }
 

--- a/internal/podman/published_ports.go
+++ b/internal/podman/published_ports.go
@@ -1,0 +1,56 @@
+package podman
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// PortOwner names the lerd unit that publishes a host port and the
+// container-internal port it maps to, which is what `lerd service port` needs to
+// move a secondary mapping.
+type PortOwner struct {
+	Unit          string
+	Service       string
+	ContainerPort int
+}
+
+// PublishedPortOwner reports which lerd unit publishes hostPort. It reads the
+// quadlets rather than the running containers, so a stopped service that will
+// claim the port at its next boot counts too, which is exactly the case a port
+// conflict has to be caught in.
+func PublishedPortOwner(hostPort int) (PortOwner, bool) {
+	if hostPort <= 0 {
+		return PortOwner{}, false
+	}
+	entries, err := filepath.Glob(filepath.Join(config.QuadletDir(), "lerd-*.container"))
+	if err != nil {
+		return PortOwner{}, false
+	}
+	for _, path := range entries {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			spec, ok := strings.CutPrefix(strings.TrimSpace(line), "PublishPort=")
+			if !ok {
+				continue
+			}
+			// The IPv6 form of the same mapping is published alongside the IPv4
+			// one and parses to 0 here, so matching either is enough.
+			if PrimaryHostPort([]string{spec}) != hostPort {
+				continue
+			}
+			unit := strings.TrimSuffix(filepath.Base(path), ".container")
+			return PortOwner{
+				Unit:          unit,
+				Service:       strings.TrimPrefix(unit, "lerd-"),
+				ContainerPort: ContainerPort(spec),
+			}, true
+		}
+	}
+	return PortOwner{}, false
+}

--- a/internal/podman/published_ports_test.go
+++ b/internal/podman/published_ports_test.go
@@ -1,0 +1,78 @@
+package podman
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// writeQuadlet drops a container unit carrying the given PublishPort lines into
+// the isolated quadlet dir, so the lookup reads the same file the port guard and
+// the launchd translator do.
+func writeQuadlet(t *testing.T, unit string, publish ...string) {
+	t.Helper()
+	dir := config.QuadletDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	body := "[Container]\nImage=example\nContainerName=" + unit + "\n"
+	for _, p := range publish {
+		body += "PublishPort=" + p + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, unit+".container"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A service publishing the Xdebug port answers the debugger's connect-back
+// itself, so the owner has to be nameable, along with the container-internal
+// port `lerd service port --container` needs to move the right mapping (#1555).
+func TestPublishedPortOwner_NamesTheServiceAndMapping(t *testing.T) {
+	setupConfigHome(t)
+	writeQuadlet(t, "lerd-rustfs", "127.0.0.1:9002:9000", "[::1]:9002:9000", "127.0.0.1:9003:9001", "[::1]:9003:9001")
+
+	owner, found := PublishedPortOwner(config.XdebugClientPort)
+	if !found {
+		t.Fatal("the service publishing the xdebug port was not found")
+	}
+	if owner.Unit != "lerd-rustfs" || owner.Service != "rustfs" {
+		t.Errorf("owner = %+v, want unit lerd-rustfs / service rustfs", owner)
+	}
+	if owner.ContainerPort != 9001 {
+		t.Errorf("container port = %d, want 9001: the secondary mapping is the one to move", owner.ContainerPort)
+	}
+}
+
+// Nothing publishing the port is the ordinary case and must not be reported as
+// a conflict.
+func TestPublishedPortOwner_QuietWhenPortIsFree(t *testing.T) {
+	setupConfigHome(t)
+	writeQuadlet(t, "lerd-mysql", "127.0.0.1:3306:3306")
+
+	if owner, found := PublishedPortOwner(config.XdebugClientPort); found {
+		t.Errorf("reported %+v as publishing a free port", owner)
+	}
+}
+
+// The ini the image reads and the port lerd reserves have to be the same number,
+// or the reservation protects a port nothing debugs on.
+func TestWriteXdebugIni_UsesTheReservedPort(t *testing.T) {
+	setupConfigHome(t)
+	if err := WriteXdebugIni("8.4", "debug", "yes"); err != nil {
+		t.Fatalf("WriteXdebugIni: %v", err)
+	}
+	body, err := os.ReadFile(config.PHPConfFile("8.4"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "xdebug.client_port=9003"
+	if !strings.Contains(string(body), want) {
+		t.Errorf("ini does not carry %q:\n%s", want, body)
+	}
+	if config.XdebugClientPort != 9003 {
+		t.Errorf("XdebugClientPort = %d, but the ini above pins 9003", config.XdebugClientPort)
+	}
+}


### PR DESCRIPTION
The port guard walks upward from a taken default and knew nothing about 9003, so a service whose own ports were busy could be published there. rustfs is the one that finds it: it wants 9000 and 9001, and an install where those were occupied lands on 9002 and 9003.

Nothing then reports a problem, because nothing fails. Xdebug connects back to the host exactly as configured, reaches the container that took the port instead of the IDE, and the session dies against a peer that does not speak DBGp. The IDE simply never sees a breakpoint.

The port the image is configured with is now the port every allocator reserves, so a shift cannot land on it again, and the ini is written from that same value so the two cannot drift apart. Only 9003 is reserved, the port lerd actually writes into the image; 9000 is the Xdebug 2 port and rustfs's own primary, so reserving it would move every rustfs install off its natural port for a port lerd never configures.

An install already published there keeps its port, since moving a service out from under whatever is pointed at it would be its own surprise. Doctor names the service holding it and the command that moves the right mapping, which is the part that was impossible to work out from the symptom:

```
⚠ xdebug port 9003  published by lerd-rustfs, so breakpoints never reach your IDE
                    (move it: lerd service port rustfs 9004 --container 9001)
```

It reads the quadlets rather than the running containers, so a stopped service that will claim the port at its next boot counts too.

Refs #1555