### PR TITLE
feat(doctor): check that containers can resolve an internet name

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -168,6 +168,26 @@ hosts: mymachines mdns_minimal [NOTFOUND=return] files myhostname dns resolve
 This makes glibc consult the plain `dns` module before systemd-resolved's `nss-resolve`, which the VPN client no longer shadows.
 :::
 
+::: details composer or npm fails with "could not resolve host" inside a container
+Composer, npm and the framework store all run inside the container, not on the host, so they use the resolver the lerd network hands aardvark-dns rather than yours. Those two can differ: `.test` domains and container names are answered by aardvark-dns from its own records and keep working regardless, so a broken forwarder shows up only as downloads that fail with `could not resolve host` or `curl error 28 while downloading`, with nothing else complaining.
+
+`lerd doctor` checks this directly. In the DNS section, the `internet DNS from containers` line asks the running nginx container to resolve the framework store's hostname, which is an ordinary internet name and the same lookup composer makes:
+
+```
+[DNS]
+  ...
+  internet DNS from containers (raw.githubusercontent.com)   OK
+```
+
+If it fails, the forwarders on the lerd network are stale or unreachable from inside the container network namespace. `lerd stop && lerd start` re-points them at your current host resolvers, which fixes it in most cases. To see what they are set to:
+
+```bash
+podman network inspect lerd --format '{{.NetworkDNSServers}}'
+```
+
+An address that is valid on the host but not routable from a rootless network namespace is the usual cause. This is worth checking on WSL2 in particular, where the Windows-side resolver address the WSL VM is given is not always reachable from inside the namespace.
+:::
+
 ::: details "Secure Connection Failed" after the host wakes from suspend or hibernate
 After a long suspend or hibernate, rootless podman networking can come back in a bad state: the lerd-nginx container loses its host port forward (or stops), so nothing listens on 443 and the browser shows a generic "Secure Connection Failed" for your `.test` sites, or the lerd-dns container stops and names no longer resolve.
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
 	"github.com/geodro/lerd/internal/feedback"
+	"github.com/geodro/lerd/internal/origin"
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/services"
@@ -426,6 +427,26 @@ func runDoctorInto(w io.Writer, useColor bool) (DoctorReport, error) {
 		if !dnsRunning && PortInUse("5300") {
 			warn("DNS port 5300", "port in use by another process, lerd-dns may fail to start (find: "+FindListenerCmd("5300")+")")
 		}
+	}
+
+	// Everything above is about .test resolving on the host. aardvark-dns
+	// answers container names and .test from its own records, so those keep
+	// working while every other lookup goes to the forwarders the lerd network
+	// was given, and a stale or unroutable forwarder there is invisible until
+	// composer or npm times out mid-download (#1519). Probe the store's own
+	// host so a self-hosted store is tested rather than a name lerd never fetches.
+	storeHost := origin.StoreHost()
+	switch {
+	case storeHost == "":
+		// A store base with no hostname leaves nothing to look up.
+	case !podman.ContainerRunningQuiet("lerd-nginx"):
+		warn("internet DNS from containers", "skipped — lerd-nginx not running (start lerd first)")
+	case podman.ResolvesFromNginx(storeHost):
+		ok(fmt.Sprintf("internet DNS from containers (%s)", storeHost))
+	default:
+		fail("internet DNS from containers",
+			fmt.Sprintf("%s does not resolve inside a container, so composer, npm and the framework store will fail", storeHost),
+			"re-point the network at your current resolvers: lerd stop && lerd start (inspect them with: podman network inspect lerd --format '{{.NetworkDNSServers}}')")
 	}
 
 	// ── Ports ────────────────────────────────────────────────────────────────

--- a/internal/origin/origin.go
+++ b/internal/origin/origin.go
@@ -6,6 +6,7 @@
 package origin
 
 import (
+	"net/url"
 	"os"
 	"strings"
 )
@@ -24,6 +25,17 @@ func StoreBaseURLs() []string {
 		return list
 	}
 	return []string{"https://raw.githubusercontent.com/" + frameworksRepo + "/main/frameworks"}
+}
+
+// StoreHost returns the hostname of the framework store, or "" when the base
+// carries none. Probes that need a name the install actually fetches take it
+// from here so a self-hosted store is tested rather than one lerd never calls.
+func StoreHost() string {
+	u, err := url.Parse(StoreBaseURLs()[0])
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
 }
 
 // ServiceStoreBaseURLs returns the service-preset-store base, nested under a

--- a/internal/origin/origin_test.go
+++ b/internal/origin/origin_test.go
@@ -98,3 +98,24 @@ func TestChangelogURLsEmptyTagFallsBackToMain(t *testing.T) {
 		t.Errorf("got %q, want %q", got[0], want)
 	}
 }
+
+// The container DNS probe resolves the store's own host, so a self-hosted
+// store is probed instead of a name the install never fetches.
+func TestStoreHostFollowsTheStoreOverride(t *testing.T) {
+	if got := StoreHost(); got != "raw.githubusercontent.com" {
+		t.Errorf("default store host = %q, want raw.githubusercontent.com", got)
+	}
+	t.Setenv("LERD_STORE_BASE_URL", "https://store.example.test:8443/frameworks")
+	if got := StoreHost(); got != "store.example.test" {
+		t.Errorf("overridden store host = %q, want store.example.test", got)
+	}
+}
+
+// A store base that is not a URL leaves nothing to probe; the caller skips
+// rather than resolving an empty name.
+func TestStoreHostEmptyWhenBaseIsNotAURL(t *testing.T) {
+	t.Setenv("LERD_STORE_BASE_URL", "not a url")
+	if got := StoreHost(); got != "" {
+		t.Errorf("store host = %q, want empty", got)
+	}
+}

--- a/internal/podman/dnsprobe_test.go
+++ b/internal/podman/dnsprobe_test.go
@@ -1,0 +1,62 @@
+package podman
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// getent exits 0 only when the name actually resolved, so its status is the
+// whole answer: aardvark-dns forwarded the query and got a record back.
+func TestResolvesFromNginx_TrueOnlyWhenGetentSucceeds(t *testing.T) {
+	prev := execCommand
+	t.Cleanup(func() { execCommand = prev })
+
+	execCommand = fakeExec("140.82.121.4  example.test\n", "", 0)
+	if !ResolvesFromNginx("example.test") {
+		t.Error("a getent that exits 0 means the container resolved the name")
+	}
+
+	execCommand = fakeExec("", "", 2)
+	if ResolvesFromNginx("example.test") {
+		t.Error("a getent that exits non-zero means the lookup failed, not that it passed")
+	}
+}
+
+// An empty name would make getent list the whole hosts database and exit 0,
+// which would report a healthy resolver on a store base that carries no host.
+func TestResolvesFromNginx_EmptyNameNeverPasses(t *testing.T) {
+	prev := execCommand
+	t.Cleanup(func() { execCommand = prev })
+	execCommand = func(string, ...string) *exec.Cmd {
+		t.Error("an empty name must not reach podman exec")
+		return exec.Command("true")
+	}
+
+	if ResolvesFromNginx("") {
+		t.Error("ResolvesFromNginx(\"\") = true, want false")
+	}
+}
+
+// A broken forwarder is exactly the case where the lookup hangs instead of
+// failing, so doctor must come back on its own rather than sit there.
+func TestResolvesFromNginx_CapsWallClock(t *testing.T) {
+	prevExec, prevTimeout := execCommand, dnsProbeTimeout
+	t.Cleanup(func() { execCommand, dnsProbeTimeout = prevExec, prevTimeout })
+	dnsProbeTimeout = 50 * time.Millisecond
+	execCommand = func(string, ...string) *exec.Cmd {
+		return exec.Command("sleep", "30")
+	}
+
+	done := make(chan bool, 1)
+	go func() { done <- ResolvesFromNginx("example.test") }()
+
+	select {
+	case got := <-done:
+		if got {
+			t.Error("a probe killed on timeout must report failure, not success")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no wall-clock cap; a stalled resolver hangs lerd doctor forever")
+	}
+}

--- a/internal/podman/hosts.go
+++ b/internal/podman/hosts.go
@@ -277,19 +277,41 @@ func isInfraHostname(name string) bool {
 // probeHostFromNginx returns true if lerd-nginx can open a TCP connection to
 // ip:port within 2 seconds. Uses busybox nc (-z = scan only, -w = timeout).
 func probeHostFromNginx(ip, port string) bool {
-	cmd := execCommand(PodmanBin(), "exec", "lerd-nginx", "nc", "-z", "-w", "2", ip, port)
+	return runCapped(execCommand(PodmanBin(), "exec", "lerd-nginx", "nc", "-z", "-w", "2", ip, port), 3*time.Second)
+}
+
+// dnsProbeTimeout caps the container-side name lookup. A forwarder that is
+// unreachable from inside the netns times out rather than answering, which is
+// the failure this probe exists to catch, so it must not wait on it.
+var dnsProbeTimeout = 4 * time.Second
+
+// ResolvesFromNginx reports whether lerd-nginx can resolve name through the
+// forwarders the lerd network hands aardvark-dns. Container names and .test
+// domains keep working when those forwarders are stale, so nothing else
+// notices until composer or npm times out mid-download (#1519). Returns false
+// when the exec cannot run, so callers must check lerd-nginx is up first to
+// tell a broken resolver from an absent one.
+func ResolvesFromNginx(name string) bool {
+	if name == "" {
+		return false
+	}
+	return runCapped(execCommand(PodmanBin(), "exec", "lerd-nginx", "getent", "hosts", name), dnsProbeTimeout)
+}
+
+// runCapped runs cmd discarding its output and reports whether it exited 0
+// within d, killing it otherwise so a hung podman exec cannot block the caller.
+func runCapped(cmd *exec.Cmd, d time.Duration) bool {
 	cmd.Stdout = nil
 	cmd.Stderr = nil
-	// Cap total wall time so a hung exec doesn't block lerd start.
-	done := make(chan error, 1)
 	if err := cmd.Start(); err != nil {
 		return false
 	}
+	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
 	select {
 	case err := <-done:
 		return err == nil
-	case <-time.After(3 * time.Second):
+	case <-time.After(d):
 		_ = cmd.Process.Kill()
 		return false
 	}


### PR DESCRIPTION
Every DNS check lerd doctor ran was about .test resolving on the host. aardvark-dns answers container names and .test from its own records, so those keep working while every other lookup goes to the forwarders the lerd network was handed. A stale or unroutable forwarder there stayed invisible until composer or npm timed out mid-download, with doctor reporting a clean bill of health and the user having nothing to point at.

The DNS section now asks the running nginx container to resolve the framework store's own hostname. It comes from the store base URL rather than a hardcoded name, so a self-hosted store is probed instead of one the install never fetches. The check skips when nginx is not running, the same way the host reachability probe does, and the lookup is capped on wall clock because the failure it exists to catch hangs rather than answers.

When it fails, the hint points at re-pointing the network at the current host resolvers with a stop and start, and at the podman command that shows what they are currently set to. The troubleshooting docs gain an entry for the same case, including the WSL2 variant where the resolver address the VM is given is valid on the host but not routable from inside a rootless network namespace.

Closes #1522
Refs #1519