### PR TITLE
fix(install): retry the dnsmasq build with the host resolvers

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -168,6 +168,14 @@ hosts: mymachines mdns_minimal [NOTFOUND=return] files myhostname dns resolve
 This makes glibc consult the plain `dns` module before systemd-resolved's `nss-resolve`, which the VPN client no longer shadows.
 :::
 
+::: details `lerd install` fails at "Building dnsmasq" with "unable to select packages"
+The dnsmasq image is the one thing lerd builds rather than pulls, and the `apk add` inside that build resolves names from the build's own network namespace, not through the host resolver that just pulled the base image. When that namespace has no working resolver, the build fails with `WARNING: fetching https://dl-cdn.alpinelinux.org/...: DNS: transient error` followed by `ERROR: unable to select packages`, even though every pull before it succeeded.
+
+lerd retries the build once with your host's real upstream nameservers pinned, which covers the common case of a stub resolver (`127.0.0.53`) that podman's default handling does not translate correctly on your setup. A rootless build cannot join the lerd network, so pinning the servers is the only lever available.
+
+If both attempts fail, lerd says so at the end of the install rather than reporting a clean finish: without the image, lerd-dns cannot start and no `.test` name resolves. Check what the container network can reach with `lerd doctor`, in particular the `internet DNS from containers` line, fix it, then run `lerd install` again.
+:::
+
 ::: details composer or npm fails with "could not resolve host" inside a container
 Composer, npm and the framework store all run inside the container, not on the host, so they use the resolver the lerd network hands aardvark-dns rather than yours. Those two can differ: `.test` domains and container names are answered by aardvark-dns from its own records and keep working regardless, so a broken forwarder shows up only as downloads that fail with `could not resolve host` or `curl error 28 while downloading`, with nothing else complaining.
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -1107,6 +1107,14 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	// package manager swaps underneath it is recognised on the next command.
 	writeInstalledVersion(version.Version)
 
+	// Every other step still reports success when this one build fails, so the
+	// install reads as complete while lerd-dns crash-loops on a missing image
+	// and no .test name ever resolves (#1537). Say so instead.
+	if wantDNS && isDNSContainerUnit() && !podman.ImageExists(podman.DNSMasqImage) {
+		feedback.Begin()
+		feedback.Warn("the dnsmasq image did not build, so lerd-dns cannot start and .test names will not resolve. Check the container's network access with `lerd doctor`, then run `lerd install` again")
+	}
+
 	feedback.Begin()
 	feedback.Done("lerd installation complete")
 	feedback.Begin()

--- a/internal/cli/install_dns_linux.go
+++ b/internal/cli/install_dns_linux.go
@@ -4,7 +4,6 @@ package cli
 
 import (
 	"io"
-	"strings"
 
 	"github.com/geodro/lerd/internal/dns"
 	"github.com/geodro/lerd/internal/feedback"
@@ -23,13 +22,9 @@ func writeDNSUnit(_ io.Writer) error {
 
 // ensureDNSImageForStart ensures the lerd-dnsmasq container image exists on Linux.
 func ensureDNSImageForStart() {
-	// Build the dnsmasq image if it doesn't exist. Ignore errors — the image
-	// will be pulled/built during RunParallel if missing.
-	containerfile := "FROM docker.io/library/alpine:latest\nRUN apk add --no-cache dnsmasq\n"
-	if !podman.ImageExists("lerd-dnsmasq:local") {
-		cmd := podman.Cmd("build", "-t", "lerd-dnsmasq:local", "-")
-		cmd.Stdin = strings.NewReader(containerfile)
-		cmd.Run() //nolint:errcheck
+	// Ignore errors — the image will be built again during RunParallel if missing.
+	if !podman.ImageExists(podman.DNSMasqImage) {
+		_ = podman.BuildDNSMasqImage(io.Discard, dns.ReadUpstreamDNS())
 	}
 }
 
@@ -48,12 +43,7 @@ func pullDNSImages() []BuildJob {
 		{
 			Label: "Building dnsmasq image",
 			Run: func(w io.Writer) error {
-				containerfile := "FROM docker.io/library/alpine:latest\nRUN apk add --no-cache dnsmasq\n"
-				cmd := podman.Cmd("build", "-t", "lerd-dnsmasq:local", "-")
-				cmd.Stdin = strings.NewReader(containerfile)
-				cmd.Stdout = w
-				cmd.Stderr = w
-				return cmd.Run()
+				return podman.BuildDNSMasqImage(w, dns.ReadUpstreamDNS())
 			},
 		},
 	}

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -75,16 +75,11 @@ func ensureImages() {
 
 		img := image
 		switch {
-		case img == "lerd-dnsmasq:local":
+		case img == podman.DNSMasqImage:
 			jobs = append(jobs, BuildJob{
 				Label: "Building dnsmasq",
 				Run: func(w io.Writer) error {
-					containerfile := "FROM docker.io/library/alpine:latest\nRUN apk add --no-cache dnsmasq\n"
-					cmd := podman.Cmd("build", "-t", "lerd-dnsmasq:local", "-")
-					cmd.Stdin = strings.NewReader(containerfile)
-					cmd.Stdout = w
-					cmd.Stderr = w
-					return cmd.Run()
+					return podman.BuildDNSMasqImage(w, dns.ReadUpstreamDNS())
 				},
 			})
 

--- a/internal/podman/dnsmasq.go
+++ b/internal/podman/dnsmasq.go
@@ -1,0 +1,39 @@
+package podman
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// DNSMasqImage is the local tag of the dnsmasq image lerd-dns runs.
+const DNSMasqImage = "lerd-dnsmasq:local"
+
+const dnsmasqContainerfile = "FROM docker.io/library/alpine:latest\nRUN apk add --no-cache dnsmasq\n"
+
+// BuildDNSMasqImage builds the dnsmasq image, retrying once with nameservers
+// pinned via --dns when the plain build fails. apk resolves from inside the
+// build's own network namespace rather than through the host resolver that
+// just pulled the base image, and podman's handling of a stub resolver there
+// does not hold on every rootless host (#1537). Joining the lerd network is
+// not an alternative: a rootless build cannot attach to a named network.
+func BuildDNSMasqImage(w io.Writer, nameservers []string) error {
+	err := buildDNSMasq(w, nil)
+	if err == nil || len(nameservers) == 0 {
+		return err
+	}
+	fmt.Fprintf(w, "\nretrying with the host resolvers (%s)\n", strings.Join(nameservers, ", "))
+	return buildDNSMasq(w, nameservers)
+}
+
+func buildDNSMasq(w io.Writer, nameservers []string) error {
+	args := []string{"build", "-t", DNSMasqImage}
+	for _, ns := range nameservers {
+		args = append(args, "--dns", ns)
+	}
+	cmd := Cmd(append(args, "-")...)
+	cmd.Stdin = strings.NewReader(dnsmasqContainerfile)
+	cmd.Stdout = w
+	cmd.Stderr = w
+	return cmd.Run()
+}

--- a/internal/podman/dnsmasq_test.go
+++ b/internal/podman/dnsmasq_test.go
@@ -1,0 +1,111 @@
+package podman
+
+import (
+	"errors"
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// recordExec returns an execCommand stub that appends every invocation's args
+// and answers with the given per-call exit codes.
+func recordExec(calls *[][]string, exits ...int) func(string, ...string) *exec.Cmd {
+	n := 0
+	return func(name string, args ...string) *exec.Cmd {
+		*calls = append(*calls, args)
+		exit := 0
+		if n < len(exits) {
+			exit = exits[n]
+		}
+		n++
+		return fakeExec("", "", exit)(name, args...)
+	}
+}
+
+func hasDNSFlag(args []string, server string) bool {
+	for i, a := range args {
+		if a == "--dns" && i+1 < len(args) && args[i+1] == server {
+			return true
+		}
+	}
+	return false
+}
+
+// The plain build is what works on a healthy host, so a passing one must not
+// drag the host's resolvers into the image build.
+func TestBuildDNSMasqImage_NoRetryWhenTheFirstBuildPasses(t *testing.T) {
+	prev := execCommand
+	t.Cleanup(func() { execCommand = prev })
+	var calls [][]string
+	execCommand = recordExec(&calls, 0)
+
+	if err := BuildDNSMasqImage(io.Discard, []string{"192.0.2.1"}); err != nil {
+		t.Fatalf("BuildDNSMasqImage() = %v, want nil", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("ran %d builds, want 1", len(calls))
+	}
+	if hasDNSFlag(calls[0], "192.0.2.1") {
+		t.Error("the first build must run with podman's own resolver handling, not pinned servers")
+	}
+}
+
+// apk resolves from inside the build's network namespace, where the host's
+// stub resolver is not reachable. Pinning the real upstreams is the retry.
+func TestBuildDNSMasqImage_RetriesWithTheHostResolvers(t *testing.T) {
+	prev := execCommand
+	t.Cleanup(func() { execCommand = prev })
+	var calls [][]string
+	execCommand = recordExec(&calls, 1, 0)
+
+	if err := BuildDNSMasqImage(io.Discard, []string{"192.0.2.1", "192.0.2.2"}); err != nil {
+		t.Fatalf("BuildDNSMasqImage() = %v, want nil once the retry succeeds", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("ran %d builds, want 2", len(calls))
+	}
+	for _, server := range []string{"192.0.2.1", "192.0.2.2"} {
+		if !hasDNSFlag(calls[1], server) {
+			t.Errorf("retry args %v carry no --dns %s", calls[1], server)
+		}
+	}
+	if calls[1][len(calls[1])-1] != "-" {
+		t.Errorf("retry args %v must still read the Containerfile from stdin", calls[1])
+	}
+}
+
+// With nothing to pin, a second identical build would only double the wait
+// before the same failure.
+func TestBuildDNSMasqImage_NoRetryWithoutNameservers(t *testing.T) {
+	prev := execCommand
+	t.Cleanup(func() { execCommand = prev })
+	var calls [][]string
+	execCommand = recordExec(&calls, 1, 1)
+
+	err := BuildDNSMasqImage(io.Discard, nil)
+	if err == nil {
+		t.Fatal("BuildDNSMasqImage() = nil, want the build error")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Errorf("err = %v, want the underlying build failure", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("ran %d builds, want 1", len(calls))
+	}
+}
+
+// Every build path must produce the same image, or `lerd start` rebuilds what
+// `lerd install` just built.
+func TestBuildDNSMasqImage_TagsTheImageLerdDnsmasq(t *testing.T) {
+	prev := execCommand
+	t.Cleanup(func() { execCommand = prev })
+	var calls [][]string
+	execCommand = recordExec(&calls, 0)
+
+	_ = BuildDNSMasqImage(io.Discard, nil)
+	if !strings.Contains(strings.Join(calls[0], " "), "-t "+DNSMasqImage) {
+		t.Errorf("build args %v do not tag %s", calls[0], DNSMasqImage)
+	}
+}


### PR DESCRIPTION
The dnsmasq image is the one thing lerd builds rather than pulls, and the apk add inside it resolves names from the build's own network namespace rather than through the host resolver that pulled the base image a second earlier. On a host where podman does not translate the stub resolver into something reachable from that namespace, every pull succeeds and the build alone fails with a DNS transient error and no package to select.

The build now retries once with the host's real upstream nameservers pinned. That is the only lever available here: a rootless build cannot attach to a named network, so the working forwarders lerd already maintains on the lerd network are out of reach, and pinning the servers directly is what is left. The plain build still runs first, so a healthy host keeps podman's own resolver handling and never sees the retry.

The same build existed in three copies across install and start, which had already drifted in their labels and error handling. They are now one helper in the podman package.

When both attempts fail the install says so at the end instead of reporting a clean finish. Without the image lerd-dns cannot start at all, so the previous behaviour left the reporter with a completed install, a unit restarting in a loop over a thousand times, and nothing on screen connecting the two.

Stacked on #1578 because the troubleshooting docs touch the same section and the new entry points at the container DNS check that PR adds. Merge that one first.

Refs #1537