### PR TITLE
fix(share): name an Expose tunnel after the site, not the proxy port

### DIFF
--- a/docs/usage/sharing.md
+++ b/docs/usage/sharing.md
@@ -1,6 +1,6 @@
 # Sharing Sites
 
-`lerd share` exposes the current site via a public tunnel. Requires [ngrok](https://ngrok.com/download), [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/), or [Expose](https://expose.dev) to be installed, or an ngrok auth token so lerd can run ngrok as a container. A tool installed with Homebrew is found by the dashboard too, which does not inherit your shell's `PATH`.
+`lerd share` exposes the current site via a public tunnel. Requires [ngrok](https://ngrok.com/download), [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/), or [Expose](https://expose.dev) to be installed, or an ngrok auth token so lerd can run ngrok as a container. A tool installed with Homebrew, or dropped into lerd's own `bin` directory, is found by the dashboard too, which does not inherit your shell's `PATH`.
 
 For sharing on your local network instead of the public internet, see [LAN sharing](lan-sharing.md).
 
@@ -25,6 +25,8 @@ The three SSH tunnels need nothing installed beyond `ssh` itself and no account.
 Every tunnel is served through a small local proxy rather than pointed straight at nginx. The proxy sets the `Host` nginx routes on, dials a secured site over HTTPS without tripping on the local mkcert certificate, and rewrites the site's own `.test` domain out of redirects and asset URLs so the public hostname survives. Without it a secured site answers the first request with a redirect to its `.test` address, which means nothing to whoever opened the public URL.
 
 That rewrite covers more than the plain form of an address. JSON escapes its slashes, so the same URL reaches the browser as `https:\/\/site.test\/path` inside a payload embedded in the page or returned from an XHR, and it is matched in that form too. An external redirect does not always travel in a `Location` header either, since a framework can hand its own client one through a header of its own, so `Content-Location` and `X-Inertia-Location` are rewritten alongside it. Rewritten URLs always come back over `https`, because the tunnel is TLS and a plain-http one would be refused as mixed content.
+
+Expose names a tunnel after the host it is pointed at, and every lerd share goes through the local proxy on loopback, so lerd asks Expose for the site's own label instead: `payments.test` is shared as `payments`, and a worktree of it as `feature-payments`. Custom subdomains are an Expose Pro feature, so a free account is told the request was ignored and gets a random subdomain, which still beats a share that fails outright because the proxy's port number was already taken as a name.
 
 ## ngrok without installing it
 

--- a/internal/cli/share.go
+++ b/internal/cli/share.go
@@ -356,7 +356,13 @@ func buildTunnelCommand(tool *shareTool, tunnelName string, target shareTarget, 
 			return nil, nil, fmt.Errorf("starting local proxy: %w", err)
 		}
 		stop = stopProxy
-		cmd = exec.Command(hostbin.Path("expose"), "share", fmt.Sprintf("http://127.0.0.1:%d", proxyPort))
+		args := []string{"share", fmt.Sprintf("http://127.0.0.1:%d", proxyPort)}
+		// Expose derives the subdomain from the shared host, which here is the
+		// throwaway proxy port, so the site's own label has to be asked for.
+		if sub := shareHostLabel(target.domain, ""); isDNSLabel(sub) {
+			args = append(args, "--subdomain="+sub)
+		}
+		cmd = exec.Command(hostbin.Path("expose"), args...)
 	case shareModeCloudflare:
 		proxyPort, stopProxy, err := startHostProxy(target.domain, httpPort, httpsPort, target.secured)
 		if err != nil {

--- a/internal/cli/share_hostbin_test.go
+++ b/internal/cli/share_hostbin_test.go
@@ -82,3 +82,14 @@ func TestTunnelCommandUsesResolvedBinary(t *testing.T) {
 		t.Fatalf("command = %q %v; want it to run %s", cmd.Path, cmd.Args, want)
 	}
 }
+
+// share:tool has to accept the same install lerd share and the dashboard accept,
+// or a tool outside PATH can be used but never made the default.
+func TestShareToolSetAcceptsToolOutsidePATH(t *testing.T) {
+	withBrewOnlyTunnelTools(t, "expose")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if err := runShareTool(nil, []string{"expose"}); err != nil {
+		t.Fatalf("runShareTool() = %v; want the tool accepted", err)
+	}
+}

--- a/internal/cli/share_test.go
+++ b/internal/cli/share_test.go
@@ -1114,6 +1114,21 @@ func TestBuildTunnelCommand_exposeGoesThroughTheLocalProxy(t *testing.T) {
 	}
 }
 
+// Expose names the tunnel after the host it is pointed at, so without an
+// explicit subdomain a share claims the proxy's port number as its public name.
+func TestBuildTunnelCommand_exposeAsksForTheSiteSubdomain(t *testing.T) {
+	target := shareTarget{name: "rapids-feature", domain: "feature.rapids.test", secured: true}
+	cmd, stop, err := buildTunnelCommand(&shareTool{mode: shareModeExpose}, "", target, 80, 443, true)
+	if err != nil {
+		t.Fatalf("buildTunnelCommand: %v", err)
+	}
+	defer stop()
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "--subdomain=feature-rapids") {
+		t.Errorf("args = %v, want the site label asked for as the subdomain", cmd.Args)
+	}
+}
+
 // The two serveo-shaped providers predate the generalized SSH mode, so their
 // invocation is pinned: default port, nokey user, a fixed remote port of 80.
 func TestBuildTunnelCommand_serveoKeepsTheClassicSSHForm(t *testing.T) {

--- a/internal/cli/share_tool.go
+++ b/internal/cli/share_tool.go
@@ -2,11 +2,11 @@ package cli
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/feedback"
+	"github.com/geodro/lerd/internal/hostbin"
 	"github.com/spf13/cobra"
 )
 
@@ -91,8 +91,8 @@ func runShareTool(_ *cobra.Command, args []string) error {
 	if !ok {
 		return fmt.Errorf("unknown tool %q: use %s, or auto", tool, strings.Join(shareToolNames(), ", "))
 	}
-	if _, err := exec.LookPath(bin); err != nil {
-		return fmt.Errorf("%s requires %q which is not in PATH, install it first", tool, bin)
+	if _, ok := hostbin.Look(bin); !ok {
+		return fmt.Errorf("%s requires %q which is not installed", tool, bin)
 	}
 
 	cfg.Share.DefaultTool = tool

--- a/internal/cli/share_tool_test.go
+++ b/internal/cli/share_tool_test.go
@@ -76,7 +76,7 @@ func TestRunShareTool_rejectsToolWithoutItsBinary(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error, got nil")
 	}
-	if !strings.Contains(err.Error(), "not in PATH") {
+	if !strings.Contains(err.Error(), "not installed") {
 		t.Errorf("error = %v, want it to say the binary is missing", err)
 	}
 }

--- a/internal/hostbin/hostbin.go
+++ b/internal/hostbin/hostbin.go
@@ -11,17 +11,22 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+
+	"github.com/geodro/lerd/internal/config"
 )
 
-// ExtraDirs lists the install prefixes a daemon's PATH leaves out: both
-// Homebrew prefixes on macOS (Apple Silicon and Intel), and the equivalents on
-// Linux. Ordered the way a login shell would see them. A var so tests can point
+// ExtraDirs lists the install prefixes a daemon's PATH leaves out: lerd's own
+// bin dir, both Homebrew prefixes on macOS (Apple Silicon and Intel), and the
+// equivalents on Linux. Ordered the way a login shell would see them. A var so tests can point
 // it at a fixture instead of depending on what the host has installed.
 var ExtraDirs = func() []string {
+	// lerd's own bin dir comes first: a tool dropped in there is on the user's
+	// PATH only through `lerd path:enable`, which a daemon never inherits.
+	dirs := []string{config.BinDir()}
 	if runtime.GOOS == "darwin" {
-		return []string{"/opt/homebrew/bin", "/usr/local/bin"}
+		return append(dirs, "/opt/homebrew/bin", "/usr/local/bin")
 	}
-	return []string{"/usr/local/bin", "/snap/bin", "/home/linuxbrew/.linuxbrew/bin"}
+	return append(dirs, "/usr/local/bin", "/snap/bin", "/home/linuxbrew/.linuxbrew/bin")
 }
 
 // Look resolves name to an absolute path: PATH first, then the extra dirs.

--- a/internal/hostbin/hostbin_test.go
+++ b/internal/hostbin/hostbin_test.go
@@ -91,3 +91,21 @@ func writeExe(t *testing.T, path string) {
 		t.Fatal(err)
 	}
 }
+
+// A tunnel tool dropped into lerd's own bin dir is only on PATH through
+// `lerd path:enable`, which a daemon never inherits.
+func TestLookFindsLerdBinDir(t *testing.T) {
+	data := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", data)
+	binDir := filepath.Join(data, "lerd", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExe(t, filepath.Join(binDir, "expose"))
+	t.Setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+
+	got, ok := Look("expose")
+	if !ok || got != filepath.Join(binDir, "expose") {
+		t.Fatalf("Look() = %q, %v; want %s", got, ok, filepath.Join(binDir, "expose"))
+	}
+}


### PR DESCRIPTION
Expose derives a tunnel's subdomain from the host it is pointed at, and every lerd share is pointed at the local rewrite proxy on loopback, so a share asked for the proxy's ephemeral port number as its public name and died the moment another user held it. The site's own label is requested explicitly now, so a share is named after the site it serves and a worktree after its branch.

Custom subdomains are an Expose Pro feature. A free account is told the request was ignored and gets a random name instead, which still leaves it with a working tunnel rather than a collision on a number nobody chose.

The dashboard also missed a tunnel tool sitting in lerd's own bin directory. That directory reaches a shell through lerd path:enable and never reaches a daemon, so a tool installed there, which is where a composer global install of Expose lands, was invisible to lerd-ui while the CLI in a terminal ran it fine. It joins the Homebrew prefixes the daemons already search, and share:tool resolves a tool the same way instead of consulting PATH alone.

Refs #1551