### PR TITLE
fix(nginx): let a worker proxy every path its server answers on

### DIFF
--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -272,6 +272,9 @@ workers:
       - other-worker
     proxy:                        # nginx proxy config (optional)
       path: /ws
+      paths:                      # several paths on one port (optional)
+        - /ws
+        - /ws-api
       port_env_key: WS_PORT
       default_port: 8080
     host: false                   # run on the host via fnm instead of in the FPM

--- a/docs/usage/framework-workers.md
+++ b/docs/usage/framework-workers.md
@@ -57,9 +57,14 @@ workers:
     command: php artisan reverb:start
     proxy:
       path: /app                    # URL path for the proxy location block
+      paths:                        # every path the server answers on (optional)
+        - /app
+        - /apps
       port_env_key: REVERB_SERVER_PORT  # env key holding the port
       default_port: 8080            # starting port for auto-assignment
 ```
+
+A server that answers on more than one path lists them all under `paths`, and each gets its own location block on the same port. Reverb is the case in point: the WebSocket connection lands on `/app` while the HTTP broadcasting API a server-side `ShouldBroadcast` event posts to lives on `/apps/{app_id}/events`, and a path left out falls through to PHP and answers 404. Where both are set, `paths` is the list that gets proxied and `path` is ignored, so a definition keeps `path` alongside it and still proxies on lerd versions released before `paths` existed.
 
 Port assignment scans all proxy port env keys across all sites to prevent collisions between different workers and frameworks.
 

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -255,9 +255,14 @@ func (w FrameworkWorker) IsPerWorktree() bool {
 // for this worker. When present, nginx adds a location block that proxies
 // requests to the worker inside the PHP-FPM container.
 type WorkerProxy struct {
-	Path        string `yaml:"path"`                   // URL path to proxy (e.g. "/app")
-	PortEnvKey  string `yaml:"port_env_key,omitempty"` // env key holding the port (e.g. "REVERB_SERVER_PORT")
-	DefaultPort int    `yaml:"default_port,omitempty"` // fallback port if env key is missing (default: 8080)
+	Path string `yaml:"path"` // URL path to proxy (e.g. "/app")
+	// Paths lists every path the worker's server answers on, one location each
+	// (Reverb takes its WebSocket on /app and its HTTP API on /apps). It wins
+	// over Path where both are set, so a definition can carry both and still
+	// proxy on binaries too old to read this field.
+	Paths       []string `yaml:"paths,omitempty"`
+	PortEnvKey  string   `yaml:"port_env_key,omitempty"` // env key holding the port (e.g. "REVERB_SERVER_PORT")
+	DefaultPort int      `yaml:"default_port,omitempty"` // fallback port if env key is missing (default: 8080)
 }
 
 // WorkerService is a running lerd service a worker depends on. WhenEnv is a
@@ -839,6 +844,7 @@ var laravelFramework = &Framework{
 			Check:   &FrameworkRule{Composer: "laravel/reverb"},
 			Proxy: &WorkerProxy{
 				Path:        "/app",
+				Paths:       []string{"/app", "/apps"},
 				PortEnvKey:  "REVERB_SERVER_PORT",
 				DefaultPort: 8080,
 			},

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -25,9 +25,14 @@ import (
 )
 
 // detectSiteProxy checks the site's framework definition for a worker with a
-// proxy configuration. Returns the proxy path and port if found. The path is
-// regexp.QuoteMeta-escaped: the vhost templates interpolate it into an nginx
-// regex location (`location ~ ^{{.ProxyPath}}(/|$)`) so the anchoring only
+// proxy configuration. Returns one location path per path the worker's server
+// answers on, plus the port. A worker can serve several: Reverb takes its
+// WebSocket on /app and the HTTP broadcasting API on /apps. The list form wins
+// over the single `path` when both are set, so a definition can carry both and
+// still proxy on binaries too old to read the list.
+//
+// Each path is regexp.QuoteMeta-escaped: the vhost templates interpolate it
+// into an nginx regex location (`location ~ ^{{.}}(/|$)`) so the anchoring only
 // matches that path and its subpaths, not an unrelated one sharing the same
 // prefix. A framework-declared path is realistically literal but can contain
 // regex metacharacters a template author never intended as regex — "/socket.io"
@@ -38,14 +43,14 @@ import (
 // under it) and a missing leading slash is added (`^app(/|$)` can never match a
 // URI, which always starts with "/"). A proxy declaring no path at all names
 // nothing to proxy, and is reported as no proxy rather than capturing the site.
-func detectSiteProxy(site config.Site) (path string, port int, ok bool) {
+func detectSiteProxy(site config.Site) (paths []string, port int, ok bool) {
 	fw, fwOK := config.GetFrameworkForDir(site.Framework, site.Path)
 	if !fwOK {
-		return "", 0, false
+		return nil, 0, false
 	}
 	proxy, _ := fw.DetectProxy(site.Path)
 	if proxy == nil {
-		return "", 0, false
+		return nil, 0, false
 	}
 	proxyPort := proxy.DefaultPort
 	if proxyPort == 0 {
@@ -58,17 +63,27 @@ func detectSiteProxy(site config.Site) (path string, port int, ok bool) {
 			}
 		}
 	}
-	if proxy.Path == "" {
-		return "", 0, false
+	declared := proxy.Paths
+	if len(declared) == 0 {
+		declared = []string{proxy.Path}
 	}
-	// "/" trims to empty, which renders `^(/|$)`: the root and everything under
-	// it, what a root-mounted worker means. Restoring it to "/" instead would
-	// render `^/(/|$)`, matching "/" and "//" and nothing else.
-	proxyPath := strings.TrimSuffix(proxy.Path, "/")
-	if proxyPath != "" && !strings.HasPrefix(proxyPath, "/") {
-		proxyPath = "/" + proxyPath
+	for _, raw := range declared {
+		if raw == "" {
+			continue
+		}
+		// "/" trims to empty, which renders `^(/|$)`: the root and everything
+		// under it, what a root-mounted worker means. Restoring it to "/"
+		// instead would render `^/(/|$)`, matching "/" and "//" and nothing else.
+		p := strings.TrimSuffix(raw, "/")
+		if p != "" && !strings.HasPrefix(p, "/") {
+			p = "/" + p
+		}
+		paths = append(paths, regexp.QuoteMeta(p))
 	}
-	return regexp.QuoteMeta(proxyPath), proxyPort, true
+	if len(paths) == 0 {
+		return nil, 0, false
+	}
+	return paths, proxyPort, true
 }
 
 // detectSiteDevServer returns the prefix and host port for a site whose
@@ -117,11 +132,12 @@ type VhostData struct {
 	PHPVersionShort string
 	// FPMContainer is the container nginx fastcgi's to: the shared
 	// lerd-php<ver>-fpm, or a per-site container for custom-FPM sites.
-	FPMContainer    string
-	CertDomain      string // domain whose cert files to use (defaults to Domain)
-	PublicDir       string // document root subdirectory, e.g. "public", "web", "."
-	Proxy           bool   // true when the site has a worker with WebSocket/HTTP proxy config
-	ProxyPath       string // URL path for the proxy (e.g. "/app")
+	FPMContainer string
+	CertDomain   string // domain whose cert files to use (defaults to Domain)
+	PublicDir    string // document root subdirectory, e.g. "public", "web", "."
+	// ProxyPaths are the URL paths a worker's server answers on (e.g. "/app",
+	// "/apps"), one location block each. Empty when the site has no proxy.
+	ProxyPaths      []string
 	ProxyPort       int    // port the worker listens on inside the PHP-FPM container
 	CustomContainer string // container name for custom container sites (e.g. "lerd-custom-nestapp")
 	CustomPort      int    // port the app listens on inside the custom container
@@ -247,7 +263,6 @@ func (d VhostData) validate() error {
 		"server names":     d.ServerNames,
 		"domain":           d.Domain,
 		"cert domain":      d.CertDomain,
-		"proxy path":       d.ProxyPath,
 		"PHP version":      d.PHPVersion,
 		"FPM container":    d.FPMContainer,
 		"custom container": d.CustomContainer,
@@ -257,6 +272,11 @@ func (d VhostData) validate() error {
 	} {
 		if i := strings.IndexAny(v, nginxValueForbidden); i >= 0 {
 			return fmt.Errorf("nginx %s %q contains %q, which would end the directive it lands in", name, v, string(v[i]))
+		}
+	}
+	for _, v := range d.ProxyPaths {
+		if i := strings.IndexAny(v, nginxValueForbidden); i >= 0 {
+			return fmt.Errorf("nginx proxy path %q contains %q, which would end the directive it lands in", v, string(v[i]))
 		}
 	}
 	// The paths reach the templates only through Root(), which quotes them, so
@@ -446,7 +466,7 @@ func renderFPMVhost(site config.Site, phpVersion string, ssl bool) ([]byte, erro
 	}
 
 	publicDir := resolvePublicDir(site)
-	proxyPath, proxyPort, hasProxy := detectSiteProxy(site)
+	proxyPaths, proxyPort, _ := detectSiteProxy(site)
 	devBase, devPort := detectSiteDevServer(site)
 	fpmContainer := podman.FPMContainerName(site, phpVersion)
 	data := VhostData{
@@ -457,8 +477,7 @@ func renderFPMVhost(site config.Site, phpVersion string, ssl bool) ([]byte, erro
 		PHPVersionShort: phpShort(phpVersion),
 		FPMContainer:    fpmContainer,
 		PublicDir:       publicDir,
-		Proxy:           hasProxy,
-		ProxyPath:       proxyPath,
+		ProxyPaths:      proxyPaths,
 		ProxyPort:       proxyPort,
 		UpstreamHost:    hostProxyUpstream(),
 		DevServerBase:   devBase,

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -351,6 +351,54 @@ func TestGenerateVhost_proxyWithoutPathIsNotProxied(t *testing.T) {
 	}
 }
 
+// A worker whose server answers on more than one path needs a location for
+// each: Reverb serves its WebSocket on /app and the HTTP broadcasting API on
+// /apps, and a path left unproxied falls through to PHP and 404s.
+func TestGenerateVhost_proxyPathsRendersEveryPath(t *testing.T) {
+	confD := setupConfD(t)
+	site := proxySite(t, "app", &config.WorkerProxy{Paths: []string{"/app", "/apps"}, DefaultPort: 6001})
+	if err := GenerateVhost(site, "8.4"); err != nil {
+		t.Fatalf("GenerateVhost: %v", err)
+	}
+	content := readConf(t, filepath.Join(confD, "app.test.conf"))
+	for _, want := range []string{`location ~ ^/app(/|$) {`, `location ~ ^/apps(/|$) {`} {
+		if !strings.Contains(content, want) {
+			t.Errorf("expected %s in:\n%s", want, content)
+		}
+	}
+	if strings.Count(content, "proxy_pass http://$proxybackend:6001;") != 2 {
+		t.Errorf("expected one proxy_pass per declared path, got:\n%s", content)
+	}
+}
+
+func TestGenerateSSLVhost_proxyPathsRendersEveryPath(t *testing.T) {
+	confD := setupConfD(t)
+	site := proxySite(t, "app", &config.WorkerProxy{Paths: []string{"/app", "/apps"}, DefaultPort: 6001})
+	if err := GenerateSSLVhost(site, "8.4"); err != nil {
+		t.Fatalf("GenerateSSLVhost: %v", err)
+	}
+	content := readConf(t, filepath.Join(confD, "app.test-ssl.conf"))
+	for _, want := range []string{`location ~ ^/app(/|$) {`, `location ~ ^/apps(/|$) {`} {
+		if !strings.Contains(content, want) {
+			t.Errorf("expected %s in:\n%s", want, content)
+		}
+	}
+}
+
+// The single-path form stays the fallback, not a path the list is added to:
+// a definition carries both so binaries too old to read paths keep proxying.
+func TestGenerateVhost_proxyPathsSupersedeSinglePath(t *testing.T) {
+	confD := setupConfD(t)
+	site := proxySite(t, "app", &config.WorkerProxy{Path: "/app", Paths: []string{"/app", "/apps"}, DefaultPort: 6001})
+	if err := GenerateVhost(site, "8.4"); err != nil {
+		t.Fatalf("GenerateVhost: %v", err)
+	}
+	content := readConf(t, filepath.Join(confD, "app.test.conf"))
+	if got := strings.Count(content, `location ~ ^/app(/|$) {`); got != 1 {
+		t.Errorf("expected /app proxied once, got %d:\n%s", got, content)
+	}
+}
+
 // ── GenerateHostProxyVhost ────────────────────────────────────────────────────
 
 func TestGenerateHostProxyVhost_proxiesToHostPort(t *testing.T) {

--- a/internal/nginx/templates/vhost-ssl.conf.tmpl
+++ b/internal/nginx/templates/vhost-ssl.conf.tmpl
@@ -16,10 +16,10 @@ server {
     ssl_certificate_key /etc/nginx/certs/{{.CertDomain}}.key;
 {{if .FrameworkNginx}}
 {{.FrameworkNginx}}
-{{end}}{{if .Proxy}}
-    location ~ ^{{.ProxyPath}}(/|$) {
-        set $proxybackend "{{.FPMContainer}}";
-        proxy_pass http://$proxybackend:{{.ProxyPort}};
+{{end}}{{range .ProxyPaths}}
+    location ~ ^{{.}}(/|$) {
+        set $proxybackend "{{$.FPMContainer}}";
+        proxy_pass http://$proxybackend:{{$.ProxyPort}};
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -27,8 +27,8 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout {{.RequestTimeout}}s;
-        proxy_send_timeout {{.RequestTimeout}}s;
+        proxy_read_timeout {{$.RequestTimeout}}s;
+        proxy_send_timeout {{$.RequestTimeout}}s;
     }
 {{end}}
 {{if .DevServerBase}}

--- a/internal/nginx/templates/vhost.conf.tmpl
+++ b/internal/nginx/templates/vhost.conf.tmpl
@@ -6,10 +6,10 @@ server {
     index index.php index.html;
 {{if .FrameworkNginx}}
 {{.FrameworkNginx}}
-{{end}}{{if .Proxy}}
-    location ~ ^{{.ProxyPath}}(/|$) {
-        set $proxybackend "{{.FPMContainer}}";
-        proxy_pass http://$proxybackend:{{.ProxyPort}};
+{{end}}{{range .ProxyPaths}}
+    location ~ ^{{.}}(/|$) {
+        set $proxybackend "{{$.FPMContainer}}";
+        proxy_pass http://$proxybackend:{{$.ProxyPort}};
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -17,8 +17,8 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout {{.RequestTimeout}}s;
-        proxy_send_timeout {{.RequestTimeout}}s;
+        proxy_read_timeout {{$.RequestTimeout}}s;
+        proxy_send_timeout {{$.RequestTimeout}}s;
     }
 {{end}}
 {{if .DevServerBase}}


### PR DESCRIPTION
A worker proxy named a single path, which is fine for a server that listens on one and wrong for every server that does not. Reverb is the case that surfaced it, its socket lives on /app and the HTTP broadcasting API on /apps, so a broadcast fired from the application fell through to PHP and returned a 404 while the socket itself worked.

The proxy definition now takes a paths list and the vhost renders one location per entry, on the same port and with the same normalising and escaping the single path always had. Where both are set the list wins, so a definition carries the old key too and still proxies on binaries released before this.

Refs #1571