### PR TITLE
fix(php): build ext-ftp with OpenSSL so ftp_ssl_connect exists

### DIFF
--- a/.github/workflows/base-images.yml
+++ b/.github/workflows/base-images.yml
@@ -125,6 +125,13 @@ jobs:
           fi
           docker run --rm "$IMG" php -r 'exit(count(PDO::getAvailableDrivers()) >= 3 ? 0 : 1);'
           docker run --rm "$IMG" composer --version >/dev/null
+          # ext-ftp loads happily without FTPS, so `php -m` cannot see #1576.
+          # Only a built-feature probe can: ftp_ssl_connect is the whole point
+          # of building ftp against OpenSSL.
+          if ! docker run --rm "$IMG" php -r 'exit(function_exists("ftp_ssl_connect") ? 0 : 1);'; then
+            echo "::error::PHP ${{ matrix.php }} built ext-ftp without OpenSSL (ftp_ssl_connect missing)"
+            exit 1
+          fi
 
       - name: Set up Go
         if: steps.check.outputs.exists != 'true'

--- a/internal/podman/build_test.go
+++ b/internal/podman/build_test.go
@@ -310,6 +310,29 @@ func TestPhpFpmContainerfile_RuntimeIncludesGit(t *testing.T) {
 	}
 }
 
+// ext/ftp compiles FTPS in only when OpenSSL was configured; a phpize build
+// leaves PHP_OPENSSL unset and silently ships an ftp without ftp_ssl_connect
+// (#1576). The configure flag was renamed in 8.4, so both branches matter.
+func TestPhpFpmContainerfile_BuildsFTPWithSSL(t *testing.T) {
+	tmpl, err := GetQuadletTemplate("lerd-php-fpm.Containerfile")
+	if err != nil {
+		t.Fatalf("read containerfile: %v", err)
+	}
+	builder, _, ok := strings.Cut(tmpl, "# ── Runtime stage")
+	if !ok {
+		t.Fatal("runtime stage marker missing from Containerfile")
+	}
+	for _, want := range []string{
+		"openssl-dev",
+		"docker-php-ext-configure ftp --with-openssl-dir=/usr",
+		"docker-php-ext-configure ftp --with-ftp-ssl",
+	} {
+		if !strings.Contains(builder, want) {
+			t.Errorf("builder stage must contain %q or ext-ftp loses FTPS support", want)
+		}
+	}
+}
+
 func TestPhpExtensionLoaded(t *testing.T) {
 	out := "Core\ndate\nimap\nPDO\nZend OPcache\n"
 	cases := map[string]bool{

--- a/internal/podman/quadlets/lerd-php-fpm.Containerfile
+++ b/internal/podman/quadlets/lerd-php-fpm.Containerfile
@@ -25,6 +25,7 @@ RUN apk update && apk add --no-cache \
         gmp-dev \
         bzip2-dev \
         openldap-dev \
+        openssl-dev \
         sqlite-dev \
         libxslt-dev \
         zlib-dev \
@@ -33,6 +34,14 @@ RUN apk update && apk add --no-cache \
            docker-php-ext-configure gd --with-freetype-dir=/usr --with-jpeg-dir=/usr --with-png-dir=/usr --with-webp-dir=/usr; \
        else \
            docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
+       fi \
+    # ext/ftp drops FTPS unless OpenSSL is configured, and a phpize build never
+    # sets PHP_OPENSSL, so ftp_ssl_connect goes missing (#1576). 8.4 renamed the
+    # opt-in flag from --with-openssl-dir to --with-ftp-ssl.
+    && if [ "$PHP_ID" -lt 80400 ]; then \
+           docker-php-ext-configure ftp --with-openssl-dir=/usr; \
+       else \
+           docker-php-ext-configure ftp --with-ftp-ssl; \
        fi \
     && docker-php-ext-install -j$(nproc) \
         curl \


### PR DESCRIPTION
ext-ftp loaded fine in every published image but had been compiled without its SSL half, so ftp_ssl_connect simply did not exist and anything doing FTPS, Flysystem's FTP adapter with ssl on being the common one, died on an undefined function. The cause is that ext/ftp enables FTPS only when OpenSSL is configured in the same php-src configure run, and installing the extension through phpize against an already built PHP never is that run, so the SSL branch was silently skipped no matter what packages were present.

The builder now configures ftp explicitly before installing it, picking the flag the PHP version expects, since 8.4 renamed the opt-in from --with-openssl-dir to --with-ftp-ssl, and openssl-dev joins the builder packages so the pkg-config probe finds the headers. Nothing changes in the runtime stage, the extension resolves the SSL symbols from the PHP binary as it always did.

The guard added for the earlier missing-extension bug compares php -m against the advertised set, and no comparison of module names could ever have caught this one, the module was there. So the base image workflow now probes ftp_ssl_connect on the image it just built. Only the current build job does that, the historic rebuild job replays Containerfiles from old tags that legitimately predate the fix.

Refs #1576
