### PR TITLE
fix(ui): probe the PHP patch after an install, not just a rebuild

### DIFF
--- a/internal/ui/php_build_refresh_test.go
+++ b/internal/ui/php_build_refresh_test.go
@@ -1,0 +1,47 @@
+package ui
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Both PHP build handlers leave the same things stale: the container states,
+// the patch probed out of the image that was just replaced, and the status
+// snapshot built from both. Install used to poll only the container cache, so
+// a freshly built version reported no patch until an unrelated background
+// probe happened to fill it in. Guarding the source keeps the two paths
+// together, since neither handler can be driven from a test without building
+// a real image.
+func TestPHPBuildHandlersRefreshThroughOneHelper(t *testing.T) {
+	src, err := os.ReadFile("server.go")
+	if err != nil {
+		t.Fatalf("reading server.go: %v", err)
+	}
+	for _, handler := range []string{"func handlePHPInstall(", "func handlePHPRebuild("} {
+		body := funcBody(string(src), handler)
+		if body == "" {
+			t.Fatalf("%s not found in server.go", handler)
+		}
+		if !strings.Contains(body, "refreshAfterPHPBuild(version)") {
+			t.Errorf("%s does not refresh through refreshAfterPHPBuild", handler)
+		}
+		if strings.Contains(body, "podman.Cache.PollNow()") {
+			t.Errorf("%s polls containers on its own instead of using refreshAfterPHPBuild", handler)
+		}
+	}
+}
+
+// funcBody returns the source between a function's opening line and the next
+// top-level closing brace.
+func funcBody(src, decl string) string {
+	i := strings.Index(src, decl)
+	if i < 0 {
+		return ""
+	}
+	rest := src[i:]
+	if end := strings.Index(rest, "\n}\n"); end >= 0 {
+		return rest[:end]
+	}
+	return rest
+}

--- a/internal/ui/php_rebuild_test.go
+++ b/internal/ui/php_rebuild_test.go
@@ -5,10 +5,10 @@ import (
 	"time"
 )
 
-// A finished rebuild must re-probe the patch and drop the status snapshot
+// A finished build must re-probe the patch and drop the status snapshot
 // before the client is told it is done, or the card keeps the old number until
 // the snapshot's TTL expires.
-func TestRefreshAfterPHPRebuild(t *testing.T) {
+func TestRefreshAfterPHPBuild(t *testing.T) {
 	origPoll, origPatch := pollContainersFn, refreshPHPPatchFn
 	t.Cleanup(func() {
 		pollContainersFn, refreshPHPPatchFn = origPoll, origPatch
@@ -26,7 +26,7 @@ func TestRefreshAfterPHPRebuild(t *testing.T) {
 	snapshots.status.data, snapshots.status.at = []byte(`{"php":[]}`), time.Now()
 	snapshots.status.mu.Unlock()
 
-	refreshAfterPHPRebuild("8.5")
+	refreshAfterPHPBuild("8.5")
 
 	if !polled {
 		t.Error("container cache was not polled")

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -4991,10 +4991,10 @@ func handlePHPInstall(w http.ResponseWriter, r *http.Request) {
 		done(map[string]any{"ok": false, "error": err.Error(), "version": version})
 		return
 	}
-	// Refresh the container cache before signalling done so the client's
-	// follow-up status load (and the publishAfter broadcast) report the
-	// freshly-started FPM as running instead of a stale not-running snapshot.
-	podman.Cache.PollNow()
+	// Refresh before signalling done so the client's follow-up status load
+	// (and the publishAfter broadcast) report the freshly-started FPM as
+	// running, with the patch read out of the image it just built.
+	refreshAfterPHPBuild(version)
 	done(map[string]any{"ok": true, "version": version})
 }
 
@@ -5003,12 +5003,12 @@ var (
 	refreshPHPPatchFn = podman.RefreshFPMPHPVersion
 )
 
-// refreshAfterPHPRebuild brings back what a finished rebuild made stale: the
-// container states, the PHP patch probed out of the old image, and the cached
-// status snapshot built from both. It runs before the done event because the
-// client loads status the moment the modal closes, ahead of publishAfter's own
-// invalidation.
-func refreshAfterPHPRebuild(version string) {
+// refreshAfterPHPBuild brings back what a finished install or rebuild made
+// stale: the container states, the PHP patch probed out of the image that was
+// replaced, and the cached status snapshot built from both. It runs before the
+// done event because the client loads status the moment the modal closes,
+// ahead of publishAfter's own invalidation.
+func refreshAfterPHPBuild(version string) {
 	pollContainersFn()
 	refreshPHPPatchFn(version)
 	snapshots.Invalidate(eventbus.KindStatus)
@@ -5047,7 +5047,7 @@ func handlePHPRebuild(w http.ResponseWriter, r *http.Request, version string) {
 		done(map[string]any{"ok": false, "error": err.Error(), "version": version})
 		return
 	}
-	refreshAfterPHPRebuild(version)
+	refreshAfterPHPBuild(version)
 	done(map[string]any{"ok": true, "version": version})
 }
 


### PR DESCRIPTION
Installing a PHP version from the dashboard left the card showing the bare minor version, 8.2 rather than 8.2.33, until the page was reloaded.

The patch number is probed out of the image with a throwaway container and cached per version. The rebuild handler re-probed it synchronously before reporting the build done, so the status load the client makes the moment the modal closes carried the new number. The install handler only polled the container cache, so that first status read found nothing cached for a version that had never been probed and returned the row with no patch at all. It filled in later, whenever an unrelated background probe happened to run, which is what made a reload look like the cure.

Both handlers now share one refresh that polls the container states, probes the patch out of the image just built, and drops the status snapshot, all before the done event.

Driving the real endpoints against a cold probe cache, the old binary answered `{"version":"8.2","running":true}` right after the install finished and the new one answers `{"version":"8.2","patch":"8.2.33","running":true}`.

Closes #1587
