### PR TITLE
fix(workers): stop reporting a worker unit that answers to nothing

### DIFF
--- a/docs/usage/framework-workers.md
+++ b/docs/usage/framework-workers.md
@@ -247,6 +247,19 @@ A worker becomes orphaned when its systemd unit is still running but its definit
 - **`lerd setup`**: offers orphaned workers as pre-selected stop steps before framework worker starts
 - **UI**: the stop button works for orphaned workers directly
 
+## Stale worker units
+
+A worker that leaves the definition entirely is a different case. A framework definition reaches every install within a day with no binary release, so a worker retired upstream is retired on every machine at once: it stops appearing in `lerd worker list`, and the dashboard stops drawing a toggle for it. Its unit file stays where it was written, though, still linked into `default.target.wants` and still armed for boot.
+
+Nothing used to reconcile the two, so a unit that answered to nothing kept being walked by [worker-heal](worker-heal.md) and reported as a worker that needed healing. Two things changed. Worker-heal now leaves a unit whose worker the site no longer declares alone, so it no longer counts towards the failing-worker banner. And `lerd site:doctor` reports it once, under **Worker Units**, with a fix that disables the unit, deletes it, and reloads the daemon:
+
+```bash
+lerd site:doctor           # names the units that answer to nothing
+lerd site:doctor --fix     # disables and removes them
+```
+
+The unit is never removed silently, because it may still be running something you want. A worker whose `check` rule simply stopped matching is not stale: the definition still names it, and the next branch checkout brings it back.
+
 ## Web UI (worker toggles)
 
 Framework workers appear as toggles in the Sites panel. Workers with a `check` rule only appear when the condition passes. Workers with `conflicts_with` suppress each other (e.g. when Horizon is available, the queue toggle is hidden).

--- a/docs/usage/worker-heal.md
+++ b/docs/usage/worker-heal.md
@@ -29,6 +29,8 @@ The probe is deliberately conservative about what it treats as a failure, becaus
 
 What the probe does catch is the case it exists for: a URL file written by the current run, pointing at a port that refuses a connection.
 
+A unit whose worker the site no longer declares is skipped as well. A framework definition that retires a worker reaches every install within a day, and the unit it wrote stays on disk, so a heal pass that looked only at systemd would keep reporting a worker the store had not named for hours. There is no start that would fix such a unit, so `lerd site:doctor` reports it once under **Worker Units** and offers to remove it; see [stale worker units](framework-workers.md#stale-worker-units).
+
 A worker with a `schedule` is not probed at all. It is a oneshot unit driven by a systemd timer, so it is inactive between ticks by design; its liveness is the timer's state, and a failing last run still surfaces from the service.
 
 ## CLI

--- a/internal/cli/site_doctor.go
+++ b/internal/cli/site_doctor.go
@@ -35,7 +35,7 @@ func NewSiteDoctorCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Output the report as JSON")
-	cmd.Flags().BoolVar(&fix, "fix", false, "Apply the findings lerd can resolve on its own (a drifted nginx vhost), then re-check")
+	cmd.Flags().BoolVar(&fix, "fix", false, "Apply the findings lerd can resolve on its own (a drifted nginx vhost, a stale worker unit), then re-check")
 	return cmd
 }
 
@@ -136,6 +136,21 @@ func applySiteDoctorFixes(path, fwName string, resp sitedoctor.Response, quiet b
 				feedback.Warn("%v", err)
 			}
 			if ready {
+				fixed = true
+			}
+		case sitedoctor.FixStaleWorkers:
+			site, err := config.FindSiteByPath(path)
+			if err != nil || site == nil {
+				continue
+			}
+			n, err := RemoveStaleWorkerUnits(*site)
+			if err != nil {
+				feedback.Warn("removing stale worker units: %v", err)
+			}
+			if n > 0 {
+				if !quiet {
+					fmt.Printf("  %s\n\n", feedback.Dim(fmt.Sprintf("removed %d stale worker unit(s)", n)))
+				}
 				fixed = true
 			}
 		case sitedoctor.FixCreateDatabase:

--- a/internal/cli/worker_stale.go
+++ b/internal/cli/worker_stale.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
+	lerdSystemd "github.com/geodro/lerd/internal/systemd"
+)
+
+// RemoveStaleWorkerUnits tears down every unit file left behind for a worker the
+// site no longer declares, and returns how many it removed. The doctor's fix for
+// the stale_workers finding, kept here rather than in sitedoctor so it goes
+// through the same teardown as `lerd worker stop`: disable, stop, drop the timer
+// sibling and the exec-mode artifacts, daemon-reload.
+//
+// Resolves the declared set again rather than trusting the report it came from,
+// because a store fetch between the check and the fix can put the worker back.
+func RemoveStaleWorkerUnits(site config.Site) (int, error) {
+	fw, _ := config.GetFrameworkForDir(site.Framework, site.Path)
+	declared, ok := config.DeclaredWorkerNames(site, fw)
+	if !ok {
+		return 0, nil
+	}
+	removed := 0
+	var firstErr error
+	for _, wu := range lerdSystemd.StaleWorkerUnits(site.Name, declared) {
+		if err := stopWorkerUnit(wu.Unit, wu.Worker, site.Name+"/"+wu.Worker); err != nil {
+			feedback.Warn("removing stale worker unit %s: %v", wu.Unit, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		removed++
+	}
+	return removed, firstErr
+}

--- a/internal/cli/worker_stale_test.go
+++ b/internal/cli/worker_stale_test.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// stageStaleUnits registers a site whose .lerd.yaml declares one custom worker,
+// and writes the given unit files into the sandboxed systemd user directory.
+func stageStaleUnits(t *testing.T, units ...string) config.Site {
+	t.Helper()
+	cfgHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+	projectDir := t.TempDir()
+	registerSite(t, "shop", projectDir)
+
+	yaml := "framework: \"\"\ncustom_workers:\n  mailer:\n    command: php mail\n"
+	if err := os.WriteFile(filepath.Join(projectDir, ".lerd.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	unitDir := config.SystemdUserDir()
+	if err := os.MkdirAll(unitDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	for _, u := range units {
+		if err := os.WriteFile(filepath.Join(unitDir, u), []byte("[Service]\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	site, err := config.FindSite("shop")
+	if err != nil {
+		t.Fatalf("FindSite: %v", err)
+	}
+	return *site
+}
+
+// The unit a retired worker left behind is the only one that goes; a worker the
+// project still declares keeps its unit, because removing that one takes a
+// running worker off a site that asked for it.
+func TestRemoveStaleWorkerUnits_removesOnlyTheUndeclared(t *testing.T) {
+	site := stageStaleUnits(t, "lerd-mailer-shop.service", "lerd-jump-shop.service")
+	fake := &stopTrackingMgr{}
+	swapMgr(t, fake)
+
+	n, err := RemoveStaleWorkerUnits(site)
+	if err != nil {
+		t.Fatalf("RemoveStaleWorkerUnits: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("removed = %d, want 1", n)
+	}
+	got := append([]string(nil), fake.removeServiceCalls...)
+	sort.Strings(got)
+	if len(got) != 1 || got[0] != "lerd-jump-shop" {
+		t.Errorf("removeServiceCalls = %v, want [lerd-jump-shop]", got)
+	}
+}
+
+// An install that cannot resolve what its site declares must delete nothing:
+// treating that silence as "nothing is declared" would take every worker unit
+// on the machine with it.
+func TestRemoveStaleWorkerUnits_removesNothingWithoutADefinition(t *testing.T) {
+	cfgHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+	projectDir := t.TempDir()
+	registerSite(t, "shop", projectDir)
+	unitDir := config.SystemdUserDir()
+	if err := os.MkdirAll(unitDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(unitDir, "lerd-queue-shop.service"), []byte("[Service]\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	site, err := config.FindSite("shop")
+	if err != nil {
+		t.Fatalf("FindSite: %v", err)
+	}
+	fake := &stopTrackingMgr{}
+	swapMgr(t, fake)
+
+	n, err := RemoveStaleWorkerUnits(*site)
+	if err != nil || n != 0 || len(fake.removeServiceCalls) != 0 {
+		t.Errorf("removed = %d (err=%v), removes=%v, want nothing touched", n, err, fake.removeServiceCalls)
+	}
+}

--- a/internal/config/declared_workers.go
+++ b/internal/config/declared_workers.go
@@ -1,0 +1,34 @@
+package config
+
+// DeclaredWorkerNames returns every worker name a site still answers for: the
+// ones its framework definition names, the custom workers in its .lerd.yaml,
+// and the lerd-managed builtins (the Stripe listener, the host-proxy dev
+// server). A gated worker counts as declared, because a check that stops
+// matching only hides the worker from the list while the definition still
+// names it.
+//
+// ok is false when nothing could be resolved to compare against, so a caller
+// that cannot tell declared from undeclared leaves every unit alone rather than
+// calling all of them stale.
+func DeclaredWorkerNames(s Site, fw *Framework) (names map[string]bool, ok bool) {
+	proj, _ := LoadProjectConfig(s.Path)
+	if fw == nil && (proj == nil || len(proj.CustomWorkers) == 0) {
+		return nil, false
+	}
+	names = map[string]bool{}
+	if fw != nil {
+		for n := range fw.Workers {
+			names[n] = true
+		}
+	}
+	if proj != nil {
+		for n := range proj.CustomWorkers {
+			names[n] = true
+		}
+	}
+	// The builtins are declared by lerd itself rather than by any definition, so
+	// they belong in the set that every caller compares against.
+	names[StripeWorkerName] = true
+	names[HostProxyWorkerName] = true
+	return names, true
+}

--- a/internal/config/declared_workers_test.go
+++ b/internal/config/declared_workers_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeProject(t *testing.T, dir, yaml string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatalf("writing .lerd.yaml: %v", err)
+	}
+}
+
+// A worker the framework definition names and a custom worker in .lerd.yaml are
+// both declared, and so are the builtins lerd runs outside any definition.
+func TestDeclaredWorkerNames_unionOfDefinitionAndProject(t *testing.T) {
+	dir := t.TempDir()
+	writeProject(t, dir, "framework: laravel\ncustom_workers:\n  mailer:\n    command: php mail\n")
+	fw := &Framework{Workers: map[string]FrameworkWorker{"queue": {}, "vite": {}}}
+
+	names, ok := DeclaredWorkerNames(Site{Name: "shop", Path: dir}, fw)
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	for _, want := range []string{"queue", "vite", "mailer", StripeWorkerName, HostProxyWorkerName} {
+		if !names[want] {
+			t.Errorf("names[%q] = false, want true", want)
+		}
+	}
+	if names["jump"] {
+		t.Error(`names["jump"] = true for a worker nothing declares`)
+	}
+}
+
+// A gate that stops matching hides a worker from the list without removing it
+// from the definition, so its unit must not be called stale: the next branch
+// checkout brings the worker back.
+func TestDeclaredWorkerNames_countsGatedWorkers(t *testing.T) {
+	dir := t.TempDir()
+	rule := FrameworkRule{File: "artisan"}
+	fw := &Framework{Workers: map[string]FrameworkWorker{"reverb": {Check: &rule}}}
+
+	names, ok := DeclaredWorkerNames(Site{Name: "shop", Path: dir}, fw)
+	if !ok || !names["reverb"] {
+		t.Fatalf("names[reverb] = %v (ok=%v), want true", names["reverb"], ok)
+	}
+}
+
+// With no framework resolved and no custom workers there is nothing to compare
+// against, and answering with an empty set would mark every unit on the machine
+// stale. The caller has to be told it cannot decide.
+func TestDeclaredWorkerNames_unresolvableFramework(t *testing.T) {
+	dir := t.TempDir()
+	if names, ok := DeclaredWorkerNames(Site{Name: "shop", Path: dir}, nil); ok || names != nil {
+		t.Errorf("DeclaredWorkerNames = (%v, %v), want (nil, false)", names, ok)
+	}
+}

--- a/internal/sitedoctor/sitedoctor.go
+++ b/internal/sitedoctor/sitedoctor.go
@@ -68,6 +68,10 @@ const (
 	// does not hold, a host action like the service fixes since a site cannot
 	// create its own schema from inside its container.
 	FixCreateDatabase = "database_create"
+	// FixStaleWorkers disables and deletes the unit files left behind for
+	// workers the site no longer declares, a host action for the same reason the
+	// vhost fix is one: the units live outside the container.
+	FixStaleWorkers = "stale_workers_remove"
 )
 
 // DoctorFixCommands maps each universal fix key to the shell command run in the
@@ -281,6 +285,9 @@ func RunWith(ctx context.Context, path string, fw *config.Framework, opts Option
 		resp.add(c)
 	}
 	if c, ok := checkVhost(path); ok {
+		resp.add(c)
+	}
+	if c, ok := checkStaleWorkers(path, fw); ok {
 		resp.add(c)
 	}
 	if !opts.Quick {
@@ -523,6 +530,7 @@ var universalLabels = map[string]string{
 	"php_version":       "PHP Version",
 	"vhost":             "Nginx Vhost",
 	"slow_routes":       "Response Time",
+	"stale_workers":     "Worker Units",
 }
 
 // humanize turns a snake_case check name into a Title Case fallback label.

--- a/internal/sitedoctor/stale_workers.go
+++ b/internal/sitedoctor/stale_workers.go
@@ -1,0 +1,47 @@
+package sitedoctor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/systemd"
+)
+
+// checkStaleWorkers reports unit files left behind for workers the site no
+// longer declares. A definition that retires a worker reaches every install
+// within a day, and nothing on the way in reconciles the units against it, so
+// the unit stays on disk, stays armed for boot, and stays something the
+// self-heal detector walks. Nothing else asks the opposite question of what a
+// unit still answers to, which is why it is asked here.
+//
+// Skipped when the framework cannot be resolved, since an install that cannot
+// read its store would otherwise call every worker stale.
+func checkStaleWorkers(path string, fw *config.Framework) (Check, bool) {
+	site, err := config.FindSiteByPath(path)
+	if err != nil || site == nil {
+		return Check{}, false
+	}
+	declared, ok := config.DeclaredWorkerNames(*site, fw)
+	if !ok {
+		return Check{}, false
+	}
+	stale := systemd.StaleWorkerUnits(site.Name, declared)
+	if len(stale) == 0 {
+		return Check{Name: "stale_workers", Status: StatusOK, Detail: "every worker unit answers to a definition"}, true
+	}
+	names := make([]string, 0, len(stale))
+	for _, wu := range stale {
+		names = append(names, wu.Worker)
+	}
+	noun := "a worker"
+	if len(names) > 1 {
+		noun = fmt.Sprintf("%d workers", len(names))
+	}
+	return Check{
+		Name:   "stale_workers",
+		Status: StatusWarn,
+		Detail: fmt.Sprintf("unit files are still installed for %s this site no longer declares (%s); remove them to stop them starting at boot", noun, strings.Join(names, ", ")),
+		Fix:    FixStaleWorkers,
+	}, true
+}

--- a/internal/sitedoctor/stale_workers_test.go
+++ b/internal/sitedoctor/stale_workers_test.go
@@ -1,0 +1,71 @@
+package sitedoctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func writeUnit(t *testing.T, name string) {
+	t.Helper()
+	dir := config.SystemdUserDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("[Service]\n"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+// A definition that retires a worker takes it out of the list and off the
+// dashboard, but nothing takes its unit off disk, where it stays armed for boot.
+// The doctor is the one surface that asks whether a unit still answers to
+// something, so it has to name the ones that do not.
+func TestCheckStaleWorkers_reportsARetiredWorker(t *testing.T) {
+	site := registerSite(t, config.Site{Name: "shop", Domains: []string{"shop.test"}})
+	writeUnit(t, "lerd-queue-shop.service")
+	writeUnit(t, "lerd-jump-shop.service")
+
+	fw := &config.Framework{Workers: map[string]config.FrameworkWorker{"queue": {}}}
+	c, ok := checkStaleWorkers(site.Path, fw)
+	if !ok {
+		t.Fatal("checkStaleWorkers did not run")
+	}
+	if c.Status != StatusWarn {
+		t.Fatalf("status = %q, want %q (detail: %s)", c.Status, StatusWarn, c.Detail)
+	}
+	if !strings.Contains(c.Detail, "jump") || strings.Contains(c.Detail, "queue") {
+		t.Errorf("detail = %q, want it to name jump and not queue", c.Detail)
+	}
+	if c.Fix != FixStaleWorkers {
+		t.Errorf("fix = %q, want %q", c.Fix, FixStaleWorkers)
+	}
+}
+
+// Every unit answering to a declared worker is the ordinary state of an install,
+// and a check that warns there would warn on every site forever.
+func TestCheckStaleWorkers_quietWhenEveryUnitIsDeclared(t *testing.T) {
+	site := registerSite(t, config.Site{Name: "shop", Domains: []string{"shop.test"}})
+	writeUnit(t, "lerd-queue-shop.service")
+	writeUnit(t, "lerd-nginx.service")
+
+	fw := &config.Framework{Workers: map[string]config.FrameworkWorker{"queue": {}}}
+	c, ok := checkStaleWorkers(site.Path, fw)
+	if !ok || c.Status != StatusOK {
+		t.Errorf("check = %+v (ok=%v), want an OK status", c, ok)
+	}
+}
+
+// With no framework resolved and no custom workers there is nothing to compare
+// against, so the check has to stand down rather than call every unit stale.
+func TestCheckStaleWorkers_skippedWithoutADefinition(t *testing.T) {
+	site := registerSite(t, config.Site{Name: "shop", Domains: []string{"shop.test"}})
+	writeUnit(t, "lerd-queue-shop.service")
+
+	if c, ok := checkStaleWorkers(site.Path, nil); ok {
+		t.Errorf("checkStaleWorkers ran and returned %+v, want it skipped", c)
+	}
+}

--- a/internal/systemd/stale_workers_test.go
+++ b/internal/systemd/stale_workers_test.go
@@ -1,0 +1,63 @@
+package systemd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func stageUnits(t *testing.T, names ...string) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	dir := config.SystemdUserDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, n := range names {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("[Service]\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", n, err)
+		}
+	}
+}
+
+func unitList(units []WorkerUnit) []string {
+	out := make([]string, len(units))
+	for i, u := range units {
+		out[i] = u.Unit
+	}
+	return out
+}
+
+// The unit a retired worker leaves behind is usually not running at all: it
+// failed, or it was never started this boot. FindOrphanedWorkers only answers
+// for the running ones, which is exactly why it never saw this case.
+func TestStaleWorkerUnits_includesUnitsThatAreNotRunning(t *testing.T) {
+	stageUnits(t, "lerd-jump-shop.service", "lerd-queue-shop.service", "lerd-nginx.service")
+
+	got := unitList(StaleWorkerUnits("shop", map[string]bool{"queue": true}))
+	if len(got) != 1 || got[0] != "lerd-jump-shop" {
+		t.Errorf("got %v, want [lerd-jump-shop]", got)
+	}
+}
+
+// lerd-queue-admin-shop is admin-shop's queue, not shop's "queue-admin", and
+// deleting it as shop's would take a worker off a site that still declares it.
+func TestStaleWorkerUnits_skipsALongerSiteCollision(t *testing.T) {
+	stageUnits(t, "lerd-queue-admin-shop.service")
+	for _, s := range []config.Site{
+		{Name: "shop", Path: "/p/shop", Domains: []string{"shop.test"}},
+		{Name: "admin-shop", Path: "/p/admin-shop", Domains: []string{"admin-shop.test"}},
+	} {
+		if err := config.AddSite(s); err != nil {
+			t.Fatalf("AddSite: %v", err)
+		}
+	}
+
+	if got := unitList(StaleWorkerUnits("shop", map[string]bool{})); len(got) != 0 {
+		t.Errorf("got %v, want nothing", got)
+	}
+}

--- a/internal/systemd/user.go
+++ b/internal/systemd/user.go
@@ -91,8 +91,6 @@ func IsServiceActiveOrRestarting(name string) bool {
 // IsTimerActive returns true if the worker's sibling .timer is active.
 func IsTimerActive(name string) bool { return DBusActiveState(name+".timer") == "active" }
 
-// FindOrphanedWorkers scans systemd unit files for worker units belonging to
-// the given site that are running but not present in the known workers set.
 // unitBelongsToLongerSite reports whether the unit file belongs to a registered
 // site whose name is longer than siteName and ends with "-<siteName>" worth of
 // collision (e.g. unit "...-admin-astrolov.service" belongs to "admin-astrolov",
@@ -107,7 +105,18 @@ func unitBelongsToLongerSite(unitFile, siteName string, sites []config.Site) boo
 	return false
 }
 
-func FindOrphanedWorkers(siteName string, known map[string]bool) []string {
+// WorkerUnit pairs a worker name with the unit file that carries it, so a
+// caller that needs to act on the unit does not have to rebuild its name.
+type WorkerUnit struct {
+	Worker string
+	Unit   string
+}
+
+// scanUndeclaredWorkerUnits walks the user unit directory for lerd-<worker>-<site>
+// units whose worker is not in known, filtering out the units that only look like
+// this site's: another site's worktree, a longer site name whose suffix collides,
+// and lerd's own per-site infrastructure.
+func scanUndeclaredWorkerUnits(siteName string, known map[string]bool) []WorkerUnit {
 	suffix := "-" + siteName + ".service"
 	prefix := "lerd-"
 	entries, err := os.ReadDir(config.SystemdUserDir())
@@ -122,7 +131,7 @@ func FindOrphanedWorkers(siteName string, known map[string]bool) []string {
 	}
 	// A host-proxy site's dev server (lerd-app-<site>) is the site's main
 	// process, never an orphan; recognised here so no caller has to special-case
-	// it around every FindOrphanedWorkers call.
+	// it around every scan.
 	hostProxySite := false
 	for _, s := range sites {
 		if s.Name == siteName && s.IsHostProxy() {
@@ -130,7 +139,7 @@ func FindOrphanedWorkers(siteName string, known map[string]bool) []string {
 			break
 		}
 	}
-	var orphans []string
+	var found []WorkerUnit
 	for _, e := range entries {
 		name := e.Name()
 		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, suffix) {
@@ -163,13 +172,32 @@ func FindOrphanedWorkers(siteName string, known map[string]bool) []string {
 		if unitBelongsToLongerSite(name, siteName, sites) {
 			continue
 		}
-		unitName := strings.TrimSuffix(name, ".service")
-		if IsServiceActiveOrRestarting(unitName) {
-			orphans = append(orphans, workerName)
+		found = append(found, WorkerUnit{Worker: workerName, Unit: strings.TrimSuffix(name, ".service")})
+	}
+	sort.Slice(found, func(i, j int) bool { return found[i].Unit < found[j].Unit })
+	return found
+}
+
+// FindOrphanedWorkers scans systemd unit files for worker units belonging to
+// the given site that are running but not present in the known workers set.
+func FindOrphanedWorkers(siteName string, known map[string]bool) []string {
+	var orphans []string
+	for _, wu := range scanUndeclaredWorkerUnits(siteName, known) {
+		if IsServiceActiveOrRestarting(wu.Unit) {
+			orphans = append(orphans, wu.Worker)
 		}
 	}
 	sort.Strings(orphans)
 	return orphans
+}
+
+// StaleWorkerUnits returns every unit file left behind for a worker the site no
+// longer declares, running or not. FindOrphanedWorkers answers the narrower
+// question of what to offer stopping right now; this one answers what is still
+// on disk, which is what a definition that dropped a worker leaves behind:
+// armed for boot, walked by the self-heal detector, and removable only by hand.
+func StaleWorkerUnits(siteName string, declared map[string]bool) []WorkerUnit {
+	return scanUndeclaredWorkerUnits(siteName, declared)
 }
 
 // UnitBelongsToOtherSiteWorktree reports whether the parsed candidate

--- a/internal/ui/site_doctor.go
+++ b/internal/ui/site_doctor.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	lerdcli "github.com/geodro/lerd/internal/cli"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/imagepull"
 	"github.com/geodro/lerd/internal/serviceops"
@@ -72,6 +73,13 @@ func handleDoctorFixRun(w http.ResponseWriter, r *http.Request, site *config.Sit
 	// than the request sitting silent until it finishes.
 	if key == sitedoctor.FixInstallServices || key == sitedoctor.FixStartServices {
 		handleDoctorServiceFix(w, r, site, key)
+		return
+	}
+	// Removing a stale worker unit touches the user's systemd units, which no
+	// container shell can reach, so it is a host action like the vhost one.
+	if key == sitedoctor.FixStaleWorkers {
+		n, err := lerdcli.RemoveStaleWorkerUnits(*site)
+		streamHostAction(w, fmt.Sprintf("removed %d stale worker unit(s) for %s", n, site.Name), err)
 		return
 	}
 	// Creating a schema runs in the engine's container, not the site's, so it is

--- a/internal/ui/web/src/tabs/sites/SiteDoctorModal.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteDoctorModal.svelte
@@ -138,7 +138,8 @@
     vhost_regenerate: 'Regenerate nginx vhost',
     services_install: 'Install the missing services',
     services_start: 'Start the stopped services',
-    database_create: 'Create the missing database'
+    database_create: 'Create the missing database',
+    stale_workers_remove: 'Remove the stale worker units'
   };
 
   async function runFix(check: DoctorCheck) {

--- a/internal/ui/web/src/tabs/sites/SiteDoctorModal.test.ts
+++ b/internal/ui/web/src/tabs/sites/SiteDoctorModal.test.ts
@@ -97,6 +97,27 @@ describe('SiteDoctorModal', () => {
     expect(launchCommand).not.toHaveBeenCalled();
   });
 
+  // A unit left behind by a worker the definition dropped is removed on the
+  // host, not in the site container, so it goes through the fix endpoint like
+  // the vhost one rather than looking for a framework command.
+  it('removes stale worker units through the fix endpoint', async () => {
+    loadDoctor.mockResolvedValue({
+      checks: [
+        { name: 'stale_workers', label: 'Worker Units', status: 'warn', detail: 'unit files are still installed for a worker this site no longer declares (jump)', fix: 'stale_workers_remove' }
+      ],
+      failures: 0,
+      warnings: 1
+    });
+    loadCommands.mockResolvedValue([]);
+
+    render(SiteDoctorModal, { props: { open: true, site: site(), branch: '', onclose: () => {} } });
+
+    await fireEvent.click(await screen.findByRole('button', { name: 'Fix' }));
+
+    expect(executeDoctorFix).toHaveBeenCalledWith('acme.test', 'stale_workers_remove', 'Remove the stale worker units', '');
+    expect(launchCommand).not.toHaveBeenCalled();
+  });
+
   it('omits the Fix button when no matching command is available', async () => {
     loadDoctor.mockResolvedValue({
       checks: [{ name: 'storage_link', status: 'warn', detail: 'symlink missing', fix: 'storage:link' }],

--- a/internal/workerheal/undeclared_test.go
+++ b/internal/workerheal/undeclared_test.go
@@ -1,0 +1,58 @@
+package workerheal
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func stubDeclared(t *testing.T, names map[string]bool, ok bool) {
+	t.Helper()
+	prev := declaredFn
+	declaredFn = func(config.Site, *config.Framework) (map[string]bool, bool) { return names, ok }
+	t.Cleanup(func() { declaredFn = prev })
+}
+
+// A worker retired upstream leaves its unit behind, failing on every tick. It
+// answers to nothing, so there is no start that would heal it, and reporting it
+// is what puts a banner on the dashboard for a worker the store stopped naming
+// hours ago.
+func TestDetect_undeclaredWorkerIsNotReported(t *testing.T) {
+	stubEnv(t,
+		[]string{"nativemob"}, nil,
+		map[string]string{
+			"lerd-jump-nativemob.service":  "failed",
+			"lerd-queue-nativemob.service": "failed",
+		},
+		nil,
+	)
+	stubDeclared(t, map[string]bool{"queue": true}, true)
+
+	got, err := Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if names := unitNames(got); len(names) != 1 || names[0] != "lerd-queue-nativemob" {
+		t.Errorf("got %v, want [lerd-queue-nativemob]", names)
+	}
+}
+
+// An install that cannot resolve its store knows nothing about what is declared,
+// and treating that silence as "nothing is declared" would drop every real
+// failure off the dashboard at once.
+func TestDetect_unresolvableDefinitionStillReports(t *testing.T) {
+	stubEnv(t,
+		[]string{"myapp"}, nil,
+		map[string]string{"lerd-queue-myapp.service": "failed"},
+		nil,
+	)
+	stubDeclared(t, nil, false)
+
+	got, err := Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if names := unitNames(got); len(names) != 1 || names[0] != "lerd-queue-myapp" {
+		t.Errorf("got %v, want [lerd-queue-myapp]", names)
+	}
+}

--- a/internal/workerheal/workerheal.go
+++ b/internal/workerheal/workerheal.go
@@ -77,6 +77,7 @@ var (
 	isStoppedFn       = config.IsStopped
 	workerReachableFn = defaultWorkerReachable
 	dirExistsFn       = defaultDirExists
+	declaredFn        = config.DeclaredWorkerNames
 )
 
 // defaultDirExists reports whether a worktree checkout is still on disk. Asked
@@ -268,9 +269,9 @@ func Detect() ([]UnhealthyWorker, error) {
 	// Every active site's checkout, so a unit's WorkingDirectory can be told apart
 	// from a worktree's.
 	sitePaths := make(map[string]string, len(reg.Sites))
-	// path + framework per site, for resolving a health-probed worker's block.
-	type siteMeta struct{ path, framework string }
-	meta := make(map[string]siteMeta, len(reg.Sites))
+	// The site record per name, for resolving a health-probed worker's block and
+	// the set of workers the site still declares.
+	meta := make(map[string]config.Site, len(reg.Sites))
 	// Workers a site has intentionally idle-suspended must never be reported as
 	// failing or drifted — they are asleep on purpose and resume on the next
 	// request, so flagging or healing them would be noise (and a heal would wake
@@ -281,7 +282,7 @@ func Detect() ([]UnhealthyWorker, error) {
 			continue
 		}
 		sitePaths[s.Name] = s.Path
-		meta[s.Name] = siteMeta{path: s.Path, framework: s.Framework}
+		meta[s.Name] = s
 		if len(s.IdleSuspendedWorkers) > 0 {
 			set := make(map[string]bool, len(s.IdleSuspendedWorkers))
 			for _, w := range s.IdleSuspendedWorkers {
@@ -299,11 +300,30 @@ func Detect() ([]UnhealthyWorker, error) {
 	// used to resolve worktree units (by WorkingDirectory) and to gate the dial
 	// (by ActiveEnter). Empty on darwin; callers fall back to the prior behaviour.
 	unitMeta := unitMetaFn()
-	// Framework resolved lazily, at most once per site with an active worker.
-	// GetFrameworkForDir is not a plain lookup (it can trigger an unthrottled
-	// store fetch), so it must never run per worker inside the loop.
+	// Framework resolved lazily, at most once per site. GetFrameworkForDir is not
+	// a plain lookup (it can trigger an unthrottled store fetch), so it must never
+	// run per worker inside the loop.
 	resolvedFw := make(map[string]*config.Framework)
 	resolvedSet := make(map[string]bool)
+	frameworkFor := func(site string) *config.Framework {
+		if !resolvedSet[site] {
+			m := meta[site]
+			resolvedFw[site], _ = config.GetFrameworkForDir(m.Framework, m.Path)
+			resolvedSet[site] = true
+		}
+		return resolvedFw[site]
+	}
+	// Memoised alongside the framework so a site with several stale units reads
+	// its .lerd.yaml once per tick rather than once per unit.
+	declared := make(map[string]map[string]bool)
+	declaredSet := make(map[string]bool)
+	declaredFor := func(site string) (map[string]bool, bool) {
+		if !declaredSet[site] {
+			declared[site], _ = declaredFn(meta[site], frameworkFor(site))
+			declaredSet[site] = true
+		}
+		return declared[site], declared[site] != nil
+	}
 	var out []UnhealthyWorker
 	for unit, state := range states {
 		// The unit-state cache aliases each .service unit under both
@@ -351,6 +371,15 @@ func Detect() ([]UnhealthyWorker, error) {
 			})
 			continue
 		}
+		// A unit for a worker the site no longer declares answers to nothing, so
+		// there is no start that would heal it: the definition it came from either
+		// dropped the worker or was replaced. Reporting it as a failing worker is
+		// what puts a banner on the dashboard for something the store has not named
+		// for hours. The site doctor reports it once instead, with a fix that takes
+		// the unit off disk.
+		if names, ok := declaredFor(site); ok && !names[worker] {
+			continue
+		}
 		// Anything still on its way up is not yet a problem; the orphan case above
 		// is the only reason this state is looked at at all.
 		if state == "activating" {
@@ -382,16 +411,11 @@ func Detect() ([]UnhealthyWorker, error) {
 			}
 			detected = "expected-but-stopped"
 		default: // "active": up, but a health-probed server may have died under it.
-			m := meta[site]
-			if !resolvedSet[site] {
-				resolvedFw[site], _ = config.GetFrameworkForDir(m.framework, m.path)
-				resolvedSet[site] = true
-			}
 			path := probePath // worktree checkout, or the site root for a parent
 			if path == "" {
-				path = m.path
+				path = meta[site].Path
 			}
-			reachable, probed := workerReachableFn(path, resolvedFw[site], worker, unitMeta[unit].ActiveEnter)
+			reachable, probed := workerReachableFn(path, frameworkFor(site), worker, unitMeta[unit].ActiveEnter)
 			if !probed || reachable {
 				continue // no health probe declared, or the server is serving
 			}


### PR DESCRIPTION
Removing a worker from a framework definition removed it from lerd but not from systemd. The unit file stayed on disk, stayed armed for boot, and stayed a unit the self-heal detector walked, so a worker nothing declared any more was reported as one that needed healing and the dashboard drew a banner for it.

Detection now asks whether a unit's worker is still declared before it classifies the unit's state. A worker counts as declared when the framework definition names it, when the project declares it as a custom worker, or when it is one of the builtins lerd runs outside any definition. A gated worker counts too, since a check that stops matching only hides it from the list while the definition still names it, and an install that can resolve none of this leaves every unit alone rather than calling all of them stale.

What the definition left behind is reported once rather than removed silently, the way an orphaned vhost is. The site doctor names the units that answer to nothing under Worker Units, and its fix disables them, deletes them and reloads the daemon through the same teardown a worker stop goes through. A unit may still be running something the user wants, so it only goes when the fix is asked for.

Closes #1577