### PR TITLE
Declare a composer package's workers once, not once per framework major

### DIFF
--- a/.claude/skills/lerd-add-framework/SKILL.md
+++ b/.claude/skills/lerd-add-framework/SKILL.md
@@ -34,7 +34,10 @@ and test against, but the pull request goes to **lerd-env/frameworks**.
    - `workers` — queue, schedule, and any framework-specific long-runners. Each
      has `command`, `restart`, optional `check`/`exclude_check` (composer package
      or file gating), `conflicts_with`, `proxy`, `per_worktree`, `host`. **New
-     workers go here, not in Go.**
+     workers go here, not in Go** — unless a composer package owns the worker
+     rather than the framework, in which case it goes in
+     `packages/<vendor>-<name>.yaml` and is declared once for every
+     major (see step 4).
    - `setup` — post-link steps (migrate, storage:link…) with sensible `default:`
    - `doctor.checks` — declarative health checks (`env_combo`, `symlink`,
      `command`) with a `fix:` command and a human `detail:` string
@@ -56,6 +59,18 @@ and test against, but the pull request goes to **lerd-env/frameworks**.
 4. **Update `frameworks/index.json`** if the store requires it (check how the
    existing entries are registered), and the README table in the
    lerd-env/frameworks `README.md`.
+
+   A worker, command, setup step or doctor check gated on a composer package
+   belongs to the package, so it is declared once in
+   `packages/<vendor>-<name>.yaml` (`package:`, an optional `version:`
+   for the package's own major, an optional `frameworks:` list of
+   `name`/`min`/`max` scopes, then `workers`, `commands`, `setup`, `doctor`, and a `removes:` block for what a new
+   major of the package took away) and
+   listed under `packages` in `frameworks/index.json` as `{"name": "vendor/pkg"}`,
+   with `versions`/`latest` only when the package publishes a file per major.
+   lerd merges it onto the resolved definition for a project that requires the
+   package, and the package wins a name collision with the version file. Copy
+   `packages/laravel-horizon.yaml`.
 
 5. **Validate end-to-end** against a real project:
    ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,11 @@ your change against all three before writing code.
    as versioned YAML. If a change adds a framework, a service, a worker, an env
    wiring, a doctor check, a custom command, or a proxy, it belongs in a store
    YAML file, **not** in Go. New workers go in the framework store YAML — never
-   in hardcoded Go, and never add a merger that backfills them. Copy the closest
-   existing YAML; those files are the schema of record.
+   in hardcoded Go, and never add a merger that backfills them. A worker,
+   command or doctor check a composer package owns rather than a framework goes
+   in `lerd-frameworks/packages/<vendor>-<name>.yaml` instead, where
+   it is declared once for every framework major. Copy the closest existing
+   YAML; those files are the schema of record.
 
 2. **Framework-agnostic.** No feature may know the name "Laravel" (or Symfony,
    WordPress…) in Go. Behaviour is driven by the YAML definition. If you find

--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -10,8 +10,9 @@ Lerd resolves framework definitions from multiple sources. Higher priority wins:
 |----------|--------|----------|---------|
 | 1 | User overlay | `~/.config/lerd/frameworks/<name>.yaml` | Manual overrides (merged on top) |
 | 2 | Project embedded | `.lerd.yaml` `framework_def` | Portability for user-defined frameworks |
-| 3 | Store-installed | `~/.local/share/lerd/frameworks/<name>@<version>.yaml` | Community definitions (auto-fetched) |
-| 4 | Built-in | Compiled into lerd binary | Laravel fallback only |
+| 3 | Store package layer | `~/.local/share/lerd/packages/<vendor>-<name>.yaml` | A composer package's own workers, commands and checks (merged on top, see below) |
+| 4 | Store-installed | `~/.local/share/lerd/frameworks/<name>@<version>.yaml` | Community definitions (auto-fetched) |
+| 5 | Built-in | Compiled into lerd binary | Laravel fallback only |
 
 Workers from the user overlay and project `.lerd.yaml` are merged on top of store or built-in definitions. See [Framework workers](framework-workers.md) for the worker lifecycle and how custom workers are added and managed.
 
@@ -22,6 +23,73 @@ A `.lerd.yaml` ships inside a project, so its embedded `framework_def` is treate
 
 A project's own host extensions still work, just with consent: a `host: true` entry in top-level `custom_workers`, and any top-level `commands:` you run via `lerd run` or the dashboard, prompt once showing the exact command before they run on your host, and the approval is remembered per site. Set `host_commands.skip_confirmation: true` (or `host_commands.disabled: true` to refuse them outright) in the global config to change that.
 :::
+
+## Package definitions
+
+Most of what a definition declares is not really the framework's. A Horizon worker belongs to `laravel/horizon`, a fixtures command to `doctrine/doctrine-fixtures-bundle`, and NativePHP's worker, commands and checks to `nativephp/electron` and `nativephp/mobile`. Written into the version files, each one has to be repeated in every major of every framework that can carry the package, and corrected in all of them at once.
+
+A package definition is that declaration written once, in the same store, as `packages/<vendor>-<name>.yaml`, a sibling of the `frameworks/` directory rather than something inside it, since a package is not a version of a framework. The composer name becomes the file name, the slash it carries being the only thing standing between it and a flat directory:
+
+```yaml
+package: nativephp/electron
+frameworks:                       # optional: which frameworks, and which majors
+  - name: laravel
+    min: "11"                     # inclusive; max: works the same way, either may be omitted
+workers:
+  native:
+    label: NativePHP
+    command: vendor/nativephp/electron/resources/js/resources/php/php artisan native:serve
+    host: true
+commands:
+  - name: native:build
+    label: Build desktop app
+    command: vendor/nativephp/electron/resources/js/resources/php/php artisan native:build
+setup:
+  - label: php artisan native:install
+    command: php artisan native:install
+    default: false
+doctor:
+  checks:
+    - name: nativephp_runtime
+      type: command
+      command: test -x vendor/nativephp/electron/resources/js/resources/php/php
+```
+
+Workers, commands, post-link setup steps and doctor checks are the whole schema, because that is what the duplication was made of. A `removes:` block takes entries away again, which is what a new major of the package needs (see below). Env wiring, detection and services stay with the framework, which is where they belong.
+
+The layer is merged onto the resolved definition when the project requires the package in its `composer.json`, and only for the frameworks the `frameworks:` list names. An empty list means every framework, which is right for a queue driver and wrong for `nativephp/electron`; `min` and `max` bound the framework majors it applies to, and are compared against the project's own major, so a Laravel 14 project still gets a package that declares `min: "11"`. The package wins any name collision: it is where the entry is maintained now, so a copy left behind in a version file is replaced rather than shadowing it, and the replacement keeps the position the definition listed it in. Your user overlay and a project's `.lerd.yaml` are merged after the package layer and still sit above it.
+
+### When a package major changes what lerd runs
+
+A package that has kept its interface is one file and says nothing about versions. When a major renames a command, moves a binary, or changes what a worker should run, that major gets a file of its own, `<vendor>-<name>@<major>.yaml`, and the index entry lists it:
+
+```json
+{"name": "drush/drush", "versions": ["13", "11"], "latest": "13"}
+```
+
+A versioned file serves its own major and every later one until the next versioned file, and the unversioned file serves everything below the first of them. So `drush-drush.yaml` keeps answering for Drush 10 and older, `@11` covers 11 and 12, `@13` covers 13 and up. Adding a major is adding one file: nothing that already worked has to be restated, and no project is moved onto a definition written for a version it does not have. A constraint no major can be read out of (`dev-main`, `*`) takes the latest, since a project tracking a branch is on the newest thing published.
+
+Publishing a major for a package that had one file asks every install for a file it has never fetched. Online that is one fetch, cached like any other. Offline, the newest cached file at or below that version answers instead, down to the unversioned one, so a worker a machine has been running for months does not disappear the day the store gains a version it cannot reach.
+
+Each file is the whole answer for the versions it serves, not a patch on the one before it, so a command that survived the major is repeated in the new file. What a new major *removes* has to be said out loud, because the copy the declaration was lifted out of is still sitting in the framework's own version files and silence there means keep it:
+
+```yaml
+package: laravel/horizon
+version: "6"
+removes:
+  commands:
+    - horizon:snapshot          # by name
+  workers:
+    - horizon-metrics
+  setup:
+    - Publish Horizon assets    # a setup step by its label, the only name it has
+  doctor:
+    - horizon_supervisor
+```
+
+Removals run after the merge, so a package can replace an entry and drop another in the same file.
+
+Only the packages listed under `packages` in the store index are ever looked up, so a project's dependency list never turns into a request for a file the store does not have. They are cached in `~/.local/share/lerd/packages/`, under the same file name the store serves, seeded by `lerd install`, refreshed by `lerd framework update` and on the same 24 hour window as a definition, so a package's worker resolves offline exactly like a framework's.
 
 ## Version resolution
 

--- a/docs/usage/framework-workers.md
+++ b/docs/usage/framework-workers.md
@@ -132,6 +132,10 @@ Some plugin middleware registers itself ahead of the tool's own base handling an
 
 When [idle-suspend](/usage/idle-suspend) is enabled it stops every one of a site's workers once the site has been idle, so workers carry no special configuration for it. A worker marked `per_worktree: true` (Vite is the only one by default) is suspended per worktree, on each worktree's own idle timer.
 
+## Workers a package brings
+
+A worker gated on a composer package belongs to the package, not to the framework major it happens to be written in, so the store lets it be declared once in `packages/<vendor>-<name>.yaml` and merges it onto whatever definition the project resolved. It behaves like any other framework worker from there: same commands, same tuning flags, same lifecycle. See [package definitions](framework-definitions.md#package-definitions) for the schema and how a package narrows itself to a framework and a range of its majors.
+
 ## Project-specific custom workers
 
 Add workers to `.lerd.yaml` for project-specific needs that don't belong in the framework definition:

--- a/internal/cli/framework.go
+++ b/internal/cli/framework.go
@@ -661,36 +661,57 @@ func updateAllFrameworks(client *store.Client, showDiff bool) error {
 		return err
 	}
 
-	local := config.ListFrameworksDetailed()
+	// Refresh the same version that's cached; previously this fetched
+	// entry.Latest for every entry, so users with multiple versions
+	// (laravel@10..@13) ended up only refreshing the latest file and the others
+	// stayed stale forever.
+	var installed []config.FrameworkInfo
+	for _, info := range config.ListFrameworksDetailed() {
+		if info.Source == config.SourceBuiltIn || !frameworkInIndex(idx, info.Name) {
+			continue
+		}
+		installed = append(installed, info)
+	}
+	packages := packageRefreshTargets(idx)
+	total := len(installed) + len(packages)
+	if total == 0 {
+		feedback.Line("no frameworks to update")
+		return nil
+	}
+
+	// A diff per definition is the point of --check, so that run keeps its lines
+	// and only the plain update collapses into one.
+	var bar *feedback.Progress
+	if !showDiff {
+		bar = feedback.StartProgress(fmt.Sprintf("updating %d definition%s", total, pluralS(total)), total)
+	}
 	updated := 0
-	for _, info := range local {
-		if info.Source == config.SourceBuiltIn {
-			continue
+	report := func(label string, err error) {
+		switch {
+		case bar != nil && err != nil:
+			bar.Failed(label, err.Error())
+		case bar != nil:
+			bar.Step(label)
+			updated++
+		case err != nil:
+			feedback.Warn("%s: %v", label, err)
+		default:
+			feedback.Note("updated " + label)
+			updated++
 		}
-		// Refresh the same version that's cached; previously this fetched
-		// entry.Latest for every entry, so users with multiple versions
-		// (laravel@10..@13) ended up only refreshing the latest file and
-		// the others stayed stale forever.
-		inIndex := false
-		for _, entry := range idx.Frameworks {
-			if entry.Name == info.Name {
-				inIndex = true
-				break
-			}
-		}
-		if !inIndex {
-			continue
-		}
+	}
+
+	for _, info := range installed {
+		label := info.Name + "@" + info.Version
 		remote, fetchErr := client.FetchFramework(info.Name, info.Version)
 		if fetchErr != nil {
-			feedback.Warn("%s@%s: %v", info.Name, info.Version, fetchErr)
+			report(label, fetchErr)
 			continue
 		}
-
 		if showDiff {
 			changed, diffErr := showFrameworkDiff(info.Name, info.Framework, remote)
 			if diffErr != nil {
-				feedback.Warn("%s@%s: %v", info.Name, info.Version, diffErr)
+				report(label, diffErr)
 				continue
 			}
 			if !changed {
@@ -698,21 +719,38 @@ func updateAllFrameworks(client *store.Client, showDiff bool) error {
 				continue
 			}
 		}
-
 		if saveErr := config.SaveStoreFramework(remote); saveErr != nil {
-			feedback.Warn("%s@%s: %v", info.Name, info.Version, saveErr)
+			report(label, saveErr)
 			continue
 		}
 		config.RemoveUserFramework(info.Name)
-		feedback.Note(fmt.Sprintf("updated %s@%s", remote.Name, versionOrLatest(remote)))
-		updated++
+		report(info.Name+"@"+versionOrLatest(remote), nil)
+	}
+
+	for _, t := range packages {
+		report(t.label, t.fetch(client))
+	}
+
+	if bar != nil {
+		bar.Done(storeRefreshTally(bar.Completed(), bar.Failures()))
+		return nil
 	}
 	if updated == 0 {
 		feedback.Line("no frameworks to update")
 	} else {
-		feedback.Done(fmt.Sprintf("updated %d framework(s)", updated))
+		feedback.Done(fmt.Sprintf("updated %d definition(s)", updated))
 	}
 	return nil
+}
+
+// frameworkInIndex reports whether the store still publishes a framework.
+func frameworkInIndex(idx *store.Index, name string) bool {
+	for _, entry := range idx.Frameworks {
+		if entry.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func versionOrLatest(fw *config.Framework) string {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -237,16 +237,9 @@ func installedStoreFrameworkTargets() []storeFrameworkTarget {
 // whole catalogue only arrives one definition at a time, as projects that need
 // each one turn up.
 func publishedStoreFrameworkTargets(idx *store.Index) []storeFrameworkTarget {
+	idx = resolveStoreIndex(idx)
 	if idx == nil {
-		var err error
-		if idx, err = store.CachedIndex(); err != nil {
-			// No cache to read: this is the fresh machine the seeding is for, or a
-			// run whose earlier index fetch failed. Ask the store, so a network that
-			// has come back since still fills the catalogue on this run.
-			if idx, err = store.NewClient().RefreshIndex(); err != nil {
-				return nil
-			}
-		}
+		return nil
 	}
 	var targets []storeFrameworkTarget
 	for _, e := range idx.Frameworks {
@@ -264,43 +257,122 @@ func publishedStoreFrameworkTargets(idx *store.Index) []storeFrameworkTarget {
 // catalogue an established one does rather than only the built-ins. idx is the
 // index the caller has already fetched; nil reads the cached copy.
 func refreshStoreFrameworks(idx *store.Index) {
+	idx = resolveStoreIndex(idx)
+	targets := append(frameworkRefreshTargets(idx), packageRefreshTargets(idx)...)
+	if len(targets) == 0 {
+		return
+	}
+	// One line for the whole catalogue: a machine holding every framework the
+	// store publishes plus the package layer is dozens of fetches, and a line
+	// each buries the rest of the install in a wall nobody reads.
+	client := store.NewClient()
+	bar := feedback.StartProgress(fmt.Sprintf("refreshing %d store definition%s", len(targets), pluralS(len(targets))), len(targets))
+	for _, t := range targets {
+		if err := t.fetch(client); err != nil {
+			bar.Failed(t.label, err.Error())
+			continue
+		}
+		bar.Step(t.label)
+	}
+	bar.Done(storeRefreshTally(bar.Completed(), bar.Failures()))
+}
+
+// storeRefreshTarget is one file to pull from the store, named for the progress
+// line and carrying the fetch that gets it.
+type storeRefreshTarget struct {
+	label string
+	fetch func(*store.Client) error
+}
+
+func storeRefreshTally(refreshed, failed int) string {
+	out := fmt.Sprintf("%d refreshed", refreshed)
+	if failed > 0 {
+		out += fmt.Sprintf(", %d failed", failed)
+	}
+	return out
+}
+
+// resolveStoreIndex returns the index the caller already fetched, or the cached
+// copy, or a fresh one. Nil only when nothing on disk and nothing upstream can
+// say what the store publishes.
+func resolveStoreIndex(idx *store.Index) *store.Index {
+	if idx != nil {
+		return idx
+	}
+	// No cache to read: this is the fresh machine the seeding is for, or a run
+	// whose earlier index fetch failed. Ask the store, so a network that has come
+	// back since still fills the catalogue on this run.
+	cached, err := store.CachedIndex()
+	if err == nil {
+		return cached
+	}
+	fetched, err := store.NewClient().RefreshIndex()
+	if err != nil {
+		return nil
+	}
+	return fetched
+}
+
+// packageRefreshTargets lists the package layer the store publishes, so a
+// machine that has just installed resolves a package's workers and commands
+// offline the same way it resolves a framework's.
+func packageRefreshTargets(idx *store.Index) []storeRefreshTarget {
+	if idx == nil {
+		return nil
+	}
+	var targets []storeRefreshTarget
+	for _, entry := range idx.Packages {
+		for _, version := range store.PackageVersions(entry) {
+			name, version := entry.Name, version
+			targets = append(targets, storeRefreshTarget{
+				label: store.PackageLabel(name, version),
+				fetch: func(c *store.Client) error {
+					_, err := c.FetchPackage(name, version)
+					return err
+				},
+			})
+		}
+	}
+	return targets
+}
+
+// frameworkRefreshTargets lists every definition the store publishes plus any
+// already cached here that it no longer does.
+func frameworkRefreshTargets(idx *store.Index) []storeRefreshTarget {
 	seen := map[storeFrameworkTarget]bool{}
-	var targets []storeFrameworkTarget
+	var defs []storeFrameworkTarget
 	for _, t := range append(publishedStoreFrameworkTargets(idx), installedStoreFrameworkTargets()...) {
 		if seen[t] {
 			continue
 		}
 		seen[t] = true
-		targets = append(targets, t)
+		defs = append(defs, t)
 	}
-	if len(targets) == 0 {
-		return
-	}
-	sort.Slice(targets, func(i, j int) bool {
-		if targets[i].name != targets[j].name {
-			return targets[i].name < targets[j].name
+	sort.Slice(defs, func(i, j int) bool {
+		if defs[i].name != defs[j].name {
+			return defs[i].name < defs[j].name
 		}
-		return frameworkVersionOrder(targets[i].version) < frameworkVersionOrder(targets[j].version)
+		return frameworkVersionOrder(defs[i].version) < frameworkVersionOrder(defs[j].version)
 	})
-	feedback.Header(fmt.Sprintf("Refreshing %d framework%s", len(targets), pluralS(len(targets))))
-	client := store.NewClient()
-	for _, t := range targets {
-		label := t.name
-		if t.version != "" {
-			label = t.name + "@" + t.version
+	targets := make([]storeRefreshTarget, 0, len(defs))
+	for _, d := range defs {
+		d := d
+		label := d.name
+		if d.version != "" {
+			label = d.name + "@" + d.version
 		}
-		step := feedback.Start(label)
-		fw, err := client.FetchFramework(t.name, t.version)
-		if err != nil {
-			step.Fail(err)
-			continue
-		}
-		if err := config.SaveStoreFramework(fw); err != nil {
-			step.Fail(err)
-			continue
-		}
-		step.OK("")
+		targets = append(targets, storeRefreshTarget{
+			label: label,
+			fetch: func(c *store.Client) error {
+				fw, err := c.FetchFramework(d.name, d.version)
+				if err != nil {
+					return err
+				}
+				return config.SaveStoreFramework(fw)
+			},
+		})
 	}
+	return targets
 }
 
 // frameworkVersionOrder sorts a definition's major version numerically, so the
@@ -362,15 +434,15 @@ func refreshStorePresets() {
 		return
 	}
 	sort.Strings(names)
-	feedback.Header(fmt.Sprintf("Refreshing %d service preset%s", len(names), pluralS(len(names))))
+	bar := feedback.StartProgress(fmt.Sprintf("refreshing %d service preset%s", len(names), pluralS(len(names))), len(names))
 	for _, name := range names {
-		step := feedback.Start(name)
 		if _, err := client.FetchServicePreset(name); err != nil {
-			step.Fail(err)
+			bar.Failed(name, err.Error())
 			continue
 		}
-		step.OK("")
+		bar.Step(name)
 	}
+	bar.Done(storeRefreshTally(bar.Completed(), bar.Failures()))
 }
 
 // publishedByStore narrows names to the presets the service store actually

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -1116,6 +1116,12 @@ func copyBuiltin(name string) *Framework {
 		workers[k] = v
 	}
 	fw.Workers = workers
+	fw.Commands = append([]FrameworkCommand(nil), src.Commands...)
+	if src.Doctor != nil {
+		doctor := *src.Doctor
+		doctor.Checks = append([]DoctorCheck(nil), src.Doctor.Checks...)
+		fw.Doctor = &doctor
+	}
 	return &fw
 }
 
@@ -1314,24 +1320,26 @@ func GetFrameworkForDir(name, projectDir string) (*Framework, bool) {
 		if version != "" && version != base.Version {
 			base.DetectedVersion = version
 		}
-		base = mergeUserOverlay(base)
 		base = mergeBuiltinFrankenPHP(base)
 		base = mergeBuiltinTinker(base)
 		base = mergeBuiltinDoctor(base)
+		// Packages before the overlay: a package replaces what a version file
+		// declares, and the overlay is the user's last word over both.
+		base = mergeStorePackages(base, projectDir)
+		base = mergeUserOverlay(base)
 		return mergeProjectWorkers(base, projectDir), true
 	}
 
 	// 4. For built-ins (Laravel, Symfony), fall back to the built-in definition.
-	if builtinFramework(name) != nil {
-		fw, ok := GetFramework(name)
-		if ok {
-			return mergeProjectWorkers(fw, projectDir), true
-		}
+	if base := copyBuiltin(name); base != nil {
+		base = mergeStorePackages(base, projectDir)
+		base = mergeBuiltinTinker(mergeBuiltinFrankenPHP(mergeUserOverlay(base)))
+		return mergeProjectWorkers(base, projectDir), true
 	}
 
 	// 5. No store definition — check user-only definition (custom framework).
 	if fw := loadFrameworkYAML(filepath.Join(FrameworksDir(), name+".yaml")); fw != nil {
-		return mergeProjectWorkers(fw, projectDir), true
+		return mergeProjectWorkers(mergeStorePackages(fw, projectDir), projectDir), true
 	}
 
 	return nil, false
@@ -1441,10 +1449,13 @@ func loadFrameworkYAML(path string) *Framework {
 }
 
 // cloneFrameworkMutable returns a copy where the maps and slices that
-// mergeUserOverlay/mergeProjectWorkers/mergeBuiltinFrankenPHP touch are freshly
-// allocated. Inner FrameworkWorker/Setup/Log values are copied by value;
-// pointer fields inside them aren't cloned because the merges only replace
-// whole entries, never mutate them in place.
+// mergeUserOverlay/mergeProjectWorkers/mergeBuiltinFrankenPHP/mergeStorePackages
+// touch are freshly allocated. Inner FrameworkWorker/Setup/Log values are copied
+// by value; pointer fields inside them aren't cloned because the merges only
+// replace whole entries, never mutate them in place. Commands and the doctor's
+// checks are cloned for the same reason the rest are: yaml decodes a sequence
+// into a slice with room to spare, so appending a package's command to the
+// value this hands back would otherwise write into the cache two callers share.
 func cloneFrameworkMutable(in *Framework) *Framework {
 	if in == nil {
 		return nil
@@ -1465,6 +1476,14 @@ func cloneFrameworkMutable(in *Framework) *Framework {
 	if in.FrankenPHP != nil {
 		cp := *in.FrankenPHP
 		out.FrankenPHP = &cp
+	}
+	if in.Commands != nil {
+		out.Commands = append([]FrameworkCommand(nil), in.Commands...)
+	}
+	if in.Doctor != nil {
+		cp := *in.Doctor
+		cp.Checks = append([]DoctorCheck(nil), in.Doctor.Checks...)
+		out.Doctor = &cp
 	}
 	return &out
 }

--- a/internal/config/framework_package.go
+++ b/internal/config/framework_package.go
@@ -1,0 +1,387 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PackageFetchFunc fetches a package definition from the store and caches it
+// locally. version is the package's own major, empty for a package that
+// publishes a single unversioned file. The store package registers it at
+// startup, the way it does for frameworks, to avoid a circular import.
+type PackageFetchFunc func(name, version string) (*FrameworkPackage, error)
+
+var packageFetchHook PackageFetchFunc
+
+// RegisterPackageFetchHook sets the callback used to fetch missing package
+// definitions from the store.
+func RegisterPackageFetchHook(fn PackageFetchFunc) {
+	packageFetchHook = fn
+}
+
+// FrameworkPackage is a declaration that belongs to a composer package rather
+// than to a framework major. A worker gated on laravel/horizon is horizon's, not
+// Laravel 11's, and writing it into every major is what made the same worker
+// exist sixteen times over. A project that requires the package gets these
+// merged onto whatever framework definition it resolved.
+type FrameworkPackage struct {
+	// Package is the composer package this file speaks for (vendor/name).
+	Package string `yaml:"package"`
+	// Version is the package's own major this file targets. A package whose
+	// declarations have not changed across its majors publishes one unversioned
+	// file and leaves this empty; one whose command moved in a major publishes a
+	// file per major, and a project is served the newest at or below the version
+	// it has installed.
+	Version string `yaml:"version,omitempty"`
+	// Frameworks narrows the package to the frameworks, and the ranges of their
+	// majors, it applies to. Empty means every framework: a queue driver needs no
+	// narrowing, while nativephp/electron is Laravel's alone.
+	Frameworks []FrameworkPackageScope    `yaml:"frameworks,omitempty"`
+	Workers    map[string]FrameworkWorker `yaml:"workers,omitempty"`
+	Commands   []FrameworkCommand         `yaml:"commands,omitempty"`
+	Setup      []FrameworkSetupCmd        `yaml:"setup,omitempty"`
+	Doctor     *FrameworkDoctor           `yaml:"doctor,omitempty"`
+	// Removes takes entries away from the resolved framework, for a major of the
+	// package that dropped a command or a worker. Declaring an entry is how a
+	// package replaces one, and this is how it deletes one, which it cannot do by
+	// staying silent: the copy a declaration was lifted out of is still in the
+	// framework's own version files, and silence there means keep it.
+	Removes *FrameworkPackageRemoves `yaml:"removes,omitempty"`
+}
+
+// FrameworkPackageRemoves names entries, by the name each is declared under,
+// that this version of the package no longer has.
+type FrameworkPackageRemoves struct {
+	Workers  []string `yaml:"workers,omitempty"`
+	Commands []string `yaml:"commands,omitempty"`
+	Setup    []string `yaml:"setup,omitempty"`
+	Doctor   []string `yaml:"doctor,omitempty"`
+}
+
+// FrameworkPackageScope binds a package to one framework, optionally to a range
+// of its majors. Min and Max are inclusive and either may be omitted for an
+// open end, the same shape a framework's PHP range uses.
+type FrameworkPackageScope struct {
+	Name string `yaml:"name"`
+	Min  string `yaml:"min,omitempty"`
+	Max  string `yaml:"max,omitempty"`
+}
+
+// AppliesTo reports whether the package's declarations belong on fw.
+func (p *FrameworkPackage) AppliesTo(fw *Framework) bool {
+	if p == nil || fw == nil {
+		return false
+	}
+	if len(p.Frameworks) == 0 {
+		return true
+	}
+	version := fw.Version
+	if fw.DetectedVersion != "" {
+		version = fw.DetectedVersion
+	}
+	for _, scope := range p.Frameworks {
+		if scope.Name != "" && scope.Name != fw.Name {
+			continue
+		}
+		if scope.covers(version) {
+			return true
+		}
+	}
+	return false
+}
+
+// covers reports whether a framework major falls inside the scope's range. A
+// range is stated against a major, so a version that is not one (a project whose
+// version never resolved) matches only an unbounded scope.
+func (s FrameworkPackageScope) covers(version string) bool {
+	if s.Min == "" && s.Max == "" {
+		return true
+	}
+	v, err := strconv.Atoi(version)
+	if err != nil {
+		return false
+	}
+	if lo, err := strconv.Atoi(s.Min); err == nil && v < lo {
+		return false
+	}
+	if hi, err := strconv.Atoi(s.Max); err == nil && v > hi {
+		return false
+	}
+	return true
+}
+
+// mergeStorePackages folds the store's package layer onto a resolved framework:
+// every package the store publishes that this project requires, and that claims
+// this framework, contributes its workers, commands and doctor checks.
+func mergeStorePackages(fw *Framework, projectDir string) *Framework {
+	if fw == nil || projectDir == "" {
+		return fw
+	}
+	for _, entry := range cachedStorePackages() {
+		if !ComposerHasPackage(projectDir, entry.Name) {
+			continue
+		}
+		pkg := resolveStorePackage(entry, projectDir)
+		if pkg == nil || !pkg.AppliesTo(fw) {
+			continue
+		}
+		applyPackage(fw, pkg)
+	}
+	return fw
+}
+
+// resolveStorePackage returns the definition serving this project, falling back
+// down the published versions when the one it should have cannot be had.
+//
+// The day the store starts publishing a major of its own for a package that had
+// one file, every install is asked for a file it has never fetched. Online that
+// is one fetch and it is cached. Offline it is nothing at all, and the worker
+// this machine has been running for months would disappear until the network
+// came back, so the newest cached file at or below the wanted version answers
+// instead: an older description of the package beats none.
+func resolveStorePackage(entry StorePackageEntry, projectDir string) *FrameworkPackage {
+	want := pickPackageVersion(projectDir, entry)
+	if pkg := loadStorePackage(entry.Name, want); pkg != nil {
+		return pkg
+	}
+	for _, v := range olderPublishedVersions(entry, want) {
+		if pkg := loadPackageYAML(StorePackageFile(entry.Name, v)); pkg != nil {
+			return pkg
+		}
+	}
+	return nil
+}
+
+// olderPublishedVersions lists the versions to try after want, newest first and
+// the unversioned file last. Only the cache is consulted for these, so a store
+// this machine cannot reach costs one failed fetch rather than one per version.
+func olderPublishedVersions(entry StorePackageEntry, want string) []string {
+	ceiling, err := strconv.Atoi(want)
+	if err != nil {
+		return nil // want is the unversioned file already, nothing below it
+	}
+	majors := sortedMajors(entry.Versions)
+	var out []string
+	for i := len(majors) - 1; i >= 0; i-- {
+		if majors[i] < ceiling {
+			out = append(out, strconv.Itoa(majors[i]))
+		}
+	}
+	return append(out, "")
+}
+
+// applyPackage merges one package's declarations onto fw. The package wins every
+// name collision: it is the newer statement about the entry and the one place it
+// is now maintained, so a copy left behind in a version file is replaced rather
+// than shadowing it. A collision is replaced in place, keeping the order the
+// definition listed its commands and checks in. The user's overlay and a
+// project's .lerd.yaml are merged after this and still sit above it.
+func applyPackage(fw *Framework, pkg *FrameworkPackage) {
+	if len(pkg.Workers) > 0 && fw.Workers == nil {
+		fw.Workers = make(map[string]FrameworkWorker, len(pkg.Workers))
+	}
+	for name, w := range pkg.Workers {
+		fw.Workers[name] = w
+	}
+	for _, cmd := range pkg.Commands {
+		fw.Commands = upsertCommand(fw.Commands, cmd)
+	}
+	// A setup step has no name to key on, so the command it runs is its identity:
+	// the framework files still carry the copies this package was lifted out of,
+	// and matching on the command is what keeps a project from being offered the
+	// same migration twice.
+	for _, step := range pkg.Setup {
+		if !hasSetupCommand(fw.Setup, step.Command) {
+			fw.Setup = append(fw.Setup, step)
+		}
+	}
+	if pkg.Doctor != nil && len(pkg.Doctor.Checks) > 0 {
+		if fw.Doctor == nil {
+			fw.Doctor = &FrameworkDoctor{}
+		}
+		for _, check := range pkg.Doctor.Checks {
+			fw.Doctor.Checks = upsertDoctorCheck(fw.Doctor.Checks, check)
+		}
+	}
+	applyPackageRemovals(fw, pkg.Removes)
+}
+
+// applyPackageRemovals drops the entries a version of the package says it no
+// longer has. A setup step is named by the label it is listed under, the only
+// name it has.
+func applyPackageRemovals(fw *Framework, rm *FrameworkPackageRemoves) {
+	if rm == nil {
+		return
+	}
+	for _, name := range rm.Workers {
+		delete(fw.Workers, name)
+	}
+	for _, name := range rm.Commands {
+		fw.Commands = slices.DeleteFunc(fw.Commands, func(c FrameworkCommand) bool { return c.Name == name })
+	}
+	for _, label := range rm.Setup {
+		fw.Setup = slices.DeleteFunc(fw.Setup, func(s FrameworkSetupCmd) bool { return s.Label == label })
+	}
+	if fw.Doctor == nil {
+		return
+	}
+	for _, name := range rm.Doctor {
+		fw.Doctor.Checks = slices.DeleteFunc(fw.Doctor.Checks, func(c DoctorCheck) bool { return c.Name == name })
+	}
+}
+
+func upsertCommand(cmds []FrameworkCommand, cmd FrameworkCommand) []FrameworkCommand {
+	for i := range cmds {
+		if cmds[i].Name == cmd.Name {
+			cmds[i] = cmd
+			return cmds
+		}
+	}
+	return append(cmds, cmd)
+}
+
+func hasSetupCommand(steps []FrameworkSetupCmd, command string) bool {
+	for _, s := range steps {
+		if s.Command == command {
+			return true
+		}
+	}
+	return false
+}
+
+func upsertDoctorCheck(checks []DoctorCheck, check DoctorCheck) []DoctorCheck {
+	for i := range checks {
+		if checks[i].Name == check.Name {
+			checks[i] = check
+			return checks
+		}
+	}
+	return append(checks, check)
+}
+
+// composerPackageName is what a path built from an index entry is allowed to
+// look like. The index is remote data and the name becomes a file path, so
+// anything with a second slash, a leading dot, or an upper-case letter is
+// refused rather than written outside the packages directory.
+var composerPackageName = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._-]*$`)
+
+// PackageSlug is a composer package as one file name, vendor and package joined
+// by the dash they are already made of. Empty when the name is not one composer
+// could publish, which is what keeps a name read out of the remote index from
+// naming a path of its own.
+func PackageSlug(name string) string {
+	if !composerPackageName.MatchString(name) {
+		return ""
+	}
+	return strings.ReplaceAll(name, "/", "-")
+}
+
+// StorePackageFile returns the local cache path for a package definition, or
+// empty when the name is not one composer could publish. version is the
+// package's own major; empty is the unversioned file.
+func StorePackageFile(name, version string) string {
+	slug := PackageSlug(name)
+	if slug == "" {
+		return ""
+	}
+	if version != "" {
+		slug += "@" + version
+	}
+	return filepath.Join(StorePackagesDir(), slug+".yaml")
+}
+
+// pickPackageVersion decides which published file serves the version of the
+// package a project has installed. Every package has one unversioned file, and a
+// major that changes what lerd runs adds a file of its own, which serves that
+// major and every later one until the next such file. So the answer is the
+// newest published version at or below what the project installed, and the
+// unversioned file below the first of them: a package that has never broken
+// anything stays one file, and one that has keeps serving older projects from
+// the file that was right for them.
+//
+// A constraint no major can be read out of (dev-main, *) takes the latest, since
+// a project tracking a branch is on the newest thing published.
+func pickPackageVersion(projectDir string, entry StorePackageEntry) string {
+	if len(entry.Versions) == 0 {
+		return ""
+	}
+	detected, err := strconv.Atoi(detectVersionFromComposer(projectDir, []FrameworkRule{{Composer: entry.Name}}))
+	if err != nil {
+		return entry.Latest
+	}
+	best := ""
+	for _, v := range sortedMajors(entry.Versions) {
+		if v <= detected {
+			best = strconv.Itoa(v)
+		}
+	}
+	return best
+}
+
+// sortedMajors returns the numeric versions in ascending order, dropping any
+// that is not a major.
+func sortedMajors(versions []string) []int {
+	var out []int
+	for _, v := range versions {
+		if n, err := strconv.Atoi(v); err == nil {
+			out = append(out, n)
+		}
+	}
+	sort.Ints(out)
+	return out
+}
+
+// loadStorePackage returns the cached definition for a package, fetching it when
+// the cache is missing or a day old, exactly like a framework definition.
+func loadStorePackage(name, version string) *FrameworkPackage {
+	path := StorePackageFile(name, version)
+	if path == "" {
+		return nil
+	}
+	pkg := loadPackageYAML(path)
+	if packageFetchHook == nil {
+		return pkg
+	}
+	if pkg != nil && !olderThan(path, storeRefreshWindow) {
+		return pkg
+	}
+	if fetched, err := packageFetchHook(name, version); err == nil && fetched != nil {
+		return fetched
+	}
+	return pkg
+}
+
+func loadPackageYAML(path string) *FrameworkPackage {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var pkg FrameworkPackage
+	if yaml.Unmarshal(data, &pkg) != nil || pkg.Package == "" {
+		return nil
+	}
+	return &pkg
+}
+
+// SaveStorePackage caches a fetched package definition.
+func SaveStorePackage(pkg *FrameworkPackage) error {
+	path := StorePackageFile(pkg.Package, pkg.Version)
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(StorePackagesDir(), 0755); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(pkg)
+	if err != nil {
+		return err
+	}
+	return publishStoreFile(path, data, 0644)
+}

--- a/internal/config/framework_package_test.go
+++ b/internal/config/framework_package_test.go
@@ -1,0 +1,393 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// packageSandbox lays out a store holding one acme@11 definition and an index
+// that publishes the package layer, plus a project requiring the framework and
+// whatever extra composer packages the caller names.
+// packages are index entries in their JSON form, so a test can publish a package
+// with versions of its own as easily as one without.
+func packageSandbox(t *testing.T, packages []string, require ...string) (store, project string) {
+	t.Helper()
+	store = storeSandbox(t)
+	write := func(path, body string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write(filepath.Join(store, "acme@11.yaml"), `name: acme
+label: Acme
+version: "11"
+public_dir: public
+detect:
+  - composer: acme/framework
+workers:
+  scheduler:
+    label: Scheduler
+    command: php acme schedule:work
+commands:
+  - name: migrate
+    label: Run migrations
+    command: php acme migrate
+`)
+
+	index := `{"frameworks":[{"name":"acme","label":"Acme","versions":["11"],"latest":"11","detect":[{"composer":"acme/framework"}]}]`
+	if len(packages) > 0 {
+		index += `,"packages":[` + strings.Join(packages, ",") + `]`
+	}
+	write(filepath.Join(store, "index.json"), index+"}")
+
+	project = t.TempDir()
+	deps := `"acme/framework": "^11.0"`
+	for _, r := range require {
+		deps += `, "` + r + `": "^1.0"`
+	}
+	write(filepath.Join(project, "composer.json"), `{"require": {`+deps+`}}`)
+	return store, project
+}
+
+// packageAtVersion is a one-worker definition pinned to a major of the package.
+func packageAtVersion(version, command string) string {
+	head := "package: acme/electron\n"
+	if version != "" {
+		head += "version: \"" + version + "\"\n"
+	}
+	return head + "workers:\n  native:\n    command: " + command + "\n"
+}
+
+const electronPackage = `package: acme/electron
+frameworks:
+  - name: acme
+    min: "11"
+workers:
+  native:
+    label: Native
+    command: php acme native:serve
+commands:
+  - name: native:build
+    label: Build desktop app
+    command: php acme native:build
+doctor:
+  checks:
+    - name: native_runtime
+      type: command
+      command: test -x vendor/acme/electron/php
+`
+
+// writePackage seeds the package cache, which is a sibling of the framework
+// store rather than a directory inside it.
+func writePackage(t *testing.T, slug, body string) {
+	t.Helper()
+	if err := os.MkdirAll(StorePackagesDir(), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(StorePackagesDir(), slug+".yaml"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetFrameworkForDir_packageDeclarationsMerge(t *testing.T) {
+	_, project := packageSandbox(t, []string{`{"name":"acme/electron"}`}, "acme/electron")
+	writePackage(t, "acme-electron", electronPackage)
+
+	fw, ok := GetFrameworkForDir("acme", project)
+	if !ok {
+		t.Fatal("framework did not resolve")
+	}
+	if _, has := fw.Workers["native"]; !has {
+		t.Error("package worker was not merged")
+	}
+	if !hasCommandNamed(fw.Commands, "native:build") {
+		t.Error("package command was not merged")
+	}
+	if fw.Doctor == nil || !hasCheckNamed(fw.Doctor.Checks, "native_runtime") {
+		t.Error("package doctor check was not merged")
+	}
+	if _, has := fw.Workers["scheduler"]; !has {
+		t.Error("framework's own worker was lost")
+	}
+}
+
+func TestGetFrameworkForDir_packageSkippedWithoutTheComposerPackage(t *testing.T) {
+	_, project := packageSandbox(t, []string{`{"name":"acme/electron"}`})
+	writePackage(t, "acme-electron", electronPackage)
+
+	fw, _ := GetFrameworkForDir("acme", project)
+	if _, has := fw.Workers["native"]; has {
+		t.Error("a project without the package must not get its worker")
+	}
+}
+
+// A package the index does not publish is never read, so a file left behind by
+// an earlier catalogue cannot keep injecting a worker.
+func TestGetFrameworkForDir_packageOutsideTheIndexIsIgnored(t *testing.T) {
+	_, project := packageSandbox(t, nil, "acme/electron")
+	writePackage(t, "acme-electron", electronPackage)
+
+	fw, _ := GetFrameworkForDir("acme", project)
+	if _, has := fw.Workers["native"]; has {
+		t.Error("package outside the index must not be merged")
+	}
+}
+
+func TestGetFrameworkForDir_packageRangeExcludesOlderMajors(t *testing.T) {
+	_, project := packageSandbox(t, []string{`{"name":"acme/electron"}`}, "acme/electron")
+	writePackage(t, "acme-electron", `package: acme/electron
+frameworks:
+  - name: acme
+    min: "12"
+workers:
+  native:
+    command: php acme native:serve
+`)
+
+	fw, _ := GetFrameworkForDir("acme", project)
+	if _, has := fw.Workers["native"]; has {
+		t.Error("acme 11 is below the package's range and must not get the worker")
+	}
+}
+
+func TestGetFrameworkForDir_packageNarrowedToAnotherFramework(t *testing.T) {
+	_, project := packageSandbox(t, []string{`{"name":"acme/electron"}`}, "acme/electron")
+	writePackage(t, "acme-electron", `package: acme/electron
+frameworks:
+  - name: other
+workers:
+  native:
+    command: php acme native:serve
+`)
+
+	fw, _ := GetFrameworkForDir("acme", project)
+	if _, has := fw.Workers["native"]; has {
+		t.Error("a package scoped to another framework must not be merged")
+	}
+}
+
+// The package is where the entry is maintained now, so a copy left behind in a
+// version file is replaced rather than shadowing it.
+func TestGetFrameworkForDir_packageWinsNameCollisions(t *testing.T) {
+	_, project := packageSandbox(t, []string{`{"name":"acme/electron"}`}, "acme/electron")
+	writePackage(t, "acme-electron", `package: acme/electron
+workers:
+  scheduler:
+    command: php acme package-scheduler
+commands:
+  - name: migrate
+    label: Package migrations
+    command: php acme package-migrate
+`)
+
+	fw, _ := GetFrameworkForDir("acme", project)
+	if got := fw.Workers["scheduler"].Command; got != "php acme package-scheduler" {
+		t.Errorf("worker command = %q, want the package's", got)
+	}
+	migrations := 0
+	for _, c := range fw.Commands {
+		if c.Name != "migrate" {
+			continue
+		}
+		migrations++
+		if c.Command != "php acme package-migrate" {
+			t.Errorf("command = %q, want the package's", c.Command)
+		}
+	}
+	if migrations != 1 {
+		t.Errorf("migrate appears %d times, want the package's entry in place of the framework's", migrations)
+	}
+}
+
+// The overlay is the user's own file, so it stays above the package layer the
+// way it is above every store definition.
+func TestGetFrameworkForDir_userOverlayWinsOverAPackage(t *testing.T) {
+	_, project := packageSandbox(t, []string{`{"name":"acme/electron"}`}, "acme/electron")
+	writePackage(t, "acme-electron", electronPackage)
+	overlay := filepath.Join(FrameworksDir(), "acme.yaml")
+	if err := os.MkdirAll(filepath.Dir(overlay), 0755); err != nil {
+		t.Fatal(err)
+	}
+	body := "name: acme\nworkers:\n  native:\n    command: php acme mine\n"
+	if err := os.WriteFile(overlay, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fw, _ := GetFrameworkForDir("acme", project)
+	if got := fw.Workers["native"].Command; got != "php acme mine" {
+		t.Errorf("worker command = %q, want the overlay's", got)
+	}
+}
+
+func hasCommandNamed(cmds []FrameworkCommand, name string) bool {
+	for _, c := range cmds {
+		if c.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasCheckNamed(checks []DoctorCheck, name string) bool {
+	for _, c := range checks {
+		if c.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// Resolving twice must not accumulate: the parsed definition is cached and
+// shared, so a merge that appended into it would grow the list every call.
+func TestGetFrameworkForDir_packageMergeDoesNotAccumulate(t *testing.T) {
+	_, project := packageSandbox(t, []string{`{"name":"acme/electron"}`}, "acme/electron")
+	writePackage(t, "acme-electron", electronPackage)
+
+	first, _ := GetFrameworkForDir("acme", project)
+	second, _ := GetFrameworkForDir("acme", project)
+	if len(first.Commands) != len(second.Commands) {
+		t.Errorf("commands grew between resolutions: %d then %d", len(first.Commands), len(second.Commands))
+	}
+	if len(first.Doctor.Checks) != len(second.Doctor.Checks) {
+		t.Errorf("doctor checks grew between resolutions: %d then %d", len(first.Doctor.Checks), len(second.Doctor.Checks))
+	}
+}
+
+func TestStorePackageFile_rejectsNamesThatEscapeTheStore(t *testing.T) {
+	storeSandbox(t)
+	for _, name := range []string{"../../etc/passwd", "acme/../../x", "acme", "acme/sub/dir", "/abs/path", "Acme/Electron", ""} {
+		if got := StorePackageFile(name, ""); got != "" {
+			t.Errorf("%q must be refused, got %q", name, got)
+		}
+	}
+	if got := StorePackageFile("acme/electron", ""); filepath.Base(got) != "acme-electron.yaml" {
+		t.Errorf("unversioned path = %q, want the slug file", got)
+	}
+	if got := StorePackageFile("acme/electron", "5"); filepath.Base(got) != "acme-electron@5.yaml" {
+		t.Errorf("versioned path = %q, want the slug@major file", got)
+	}
+}
+
+// A package whose declarations moved in one of its own majors publishes a file
+// per major, and a project is served the newest at or below what it installed.
+func TestGetFrameworkForDir_packageVersionFollowsTheInstalledPackage(t *testing.T) {
+	cases := []struct {
+		installed string
+		want      string
+	}{
+		{"^5.0", "php acme five"},
+		{"^6.2", "php acme six"},
+		{"^9.0", "php acme six"},
+		{"^3.0", "php acme base"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.installed, func(t *testing.T) {
+			_, project := packageSandbox(t, []string{`{"name":"acme/electron","versions":["5","6"],"latest":"6"}`})
+			if err := os.WriteFile(filepath.Join(project, "composer.json"),
+				[]byte(`{"require": {"acme/framework": "^11.0", "acme/electron": "`+tc.installed+`"}}`), 0644); err != nil {
+				t.Fatal(err)
+			}
+			writePackage(t, "acme-electron", packageAtVersion("", "php acme base"))
+			writePackage(t, "acme-electron@5", packageAtVersion("5", "php acme five"))
+			writePackage(t, "acme-electron@6", packageAtVersion("6", "php acme six"))
+
+			fw, _ := GetFrameworkForDir("acme", project)
+			if got := fw.Workers["native"].Command; got != tc.want {
+				t.Errorf("worker command = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Below the first major that needed a file of its own, the unversioned file is
+// what serves the project, so a package that breaks something adds one file
+// instead of restating everything it did before.
+func TestGetFrameworkForDir_packageBelowEveryVersionUsesTheBaseFile(t *testing.T) {
+	_, project := packageSandbox(t, []string{`{"name":"acme/electron","versions":["6"],"latest":"6"}`})
+	if err := os.WriteFile(filepath.Join(project, "composer.json"),
+		[]byte(`{"require": {"acme/framework": "^11.0", "acme/electron": "^4.0"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writePackage(t, "acme-electron", packageAtVersion("", "php acme base"))
+	writePackage(t, "acme-electron@6", packageAtVersion("6", "php acme six"))
+
+	fw, _ := GetFrameworkForDir("acme", project)
+	if got := fw.Workers["native"].Command; got != "php acme base" {
+		t.Errorf("worker command = %q, want the unversioned file's", got)
+	}
+}
+
+// The day the store starts publishing a major of its own, an install that cannot
+// reach it is asked for a file it has never fetched. The newest cached file at
+// or below that version answers instead of nothing.
+func TestGetFrameworkForDir_packageFallsBackWhenTheWantedVersionIsNotCached(t *testing.T) {
+	_, project := packageSandbox(t, []string{`{"name":"acme/electron","versions":["5","7"],"latest":"7"}`})
+	if err := os.WriteFile(filepath.Join(project, "composer.json"),
+		[]byte(`{"require": {"acme/framework": "^11.0", "acme/electron": "^7.0"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writePackage(t, "acme-electron", packageAtVersion("", "php acme base"))
+	writePackage(t, "acme-electron@5", packageAtVersion("5", "php acme five"))
+
+	fw, _ := GetFrameworkForDir("acme", project)
+	if got := fw.Workers["native"].Command; got != "php acme five" {
+		t.Errorf("worker command = %q, want the newest cached file below the wanted version", got)
+	}
+}
+
+// A major that drops a command has to say so: the copy the declaration was
+// lifted out of is still in the framework's version file.
+func TestGetFrameworkForDir_packageRemovesEntries(t *testing.T) {
+	_, project := packageSandbox(t, []string{`{"name":"acme/electron"}`}, "acme/electron")
+	writePackage(t, "acme-electron", `package: acme/electron
+removes:
+  workers:
+    - scheduler
+  commands:
+    - migrate
+`)
+
+	fw, _ := GetFrameworkForDir("acme", project)
+	if _, has := fw.Workers["scheduler"]; has {
+		t.Error("worker the package removed is still there")
+	}
+	if hasCommandNamed(fw.Commands, "migrate") {
+		t.Error("command the package removed is still there")
+	}
+}
+
+func TestPackageAppliesTo_scopes(t *testing.T) {
+	cases := []struct {
+		name  string
+		scope []FrameworkPackageScope
+		fw    Framework
+		want  bool
+	}{
+		{"no scope applies everywhere", nil, Framework{Name: "acme", Version: "11"}, true},
+		{"inclusive min", []FrameworkPackageScope{{Name: "acme", Min: "11"}}, Framework{Name: "acme", Version: "11"}, true},
+		{"inclusive max", []FrameworkPackageScope{{Name: "acme", Max: "11"}}, Framework{Name: "acme", Version: "11"}, true},
+		{"above max", []FrameworkPackageScope{{Name: "acme", Max: "11"}}, Framework{Name: "acme", Version: "12"}, false},
+		{"detected version wins over the borrowed definition",
+			[]FrameworkPackageScope{{Name: "acme", Min: "12"}},
+			Framework{Name: "acme", Version: "11", DetectedVersion: "14"}, true},
+		{"range needs a major to compare",
+			[]FrameworkPackageScope{{Name: "acme", Min: "11"}}, Framework{Name: "acme"}, false},
+		{"unbounded scope needs none",
+			[]FrameworkPackageScope{{Name: "acme"}}, Framework{Name: "acme"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pkg := &FrameworkPackage{Package: "acme/electron", Frameworks: tc.scope}
+			if got := pkg.AppliesTo(&tc.fw); got != tc.want {
+				t.Errorf("AppliesTo = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -444,6 +444,16 @@ func StoreFrameworksDir() string {
 	return filepath.Join(DataDir(), "frameworks")
 }
 
+// StorePackagesDir returns the directory for store-installed package
+// definitions, the layer that attaches workers, commands, setup steps and
+// doctor checks to a composer package instead of to one framework major. It is
+// a sibling of the framework store rather than a directory inside it, the way
+// the store itself publishes the two, since a package is not a version of a
+// framework. One file per package, named for the package.
+func StorePackagesDir() string {
+	return filepath.Join(DataDir(), "packages")
+}
+
 // StoreIndexFile returns the path to the locally cached framework store index.
 // The store package refreshes it in the background; offline detection and
 // listing read it so a fresh machine can resolve any framework without a

--- a/internal/config/store_index.go
+++ b/internal/config/store_index.go
@@ -17,21 +17,55 @@ type cachedStoreEntry struct {
 	Detect   []FrameworkRule `json:"detect"`
 }
 
-// loadCachedStoreEntries reads the locally cached framework store index. Returns
+// StorePackageEntry is one composer package the store publishes declarations
+// for. Versions lists the package's own majors that have a file of their own;
+// a package whose declarations hold across every major publishes none and is
+// served by a single unversioned file.
+type StorePackageEntry struct {
+	Name     string   `json:"name"`
+	Versions []string `json:"versions,omitempty"`
+	Latest   string   `json:"latest,omitempty"`
+}
+
+// cachedStoreIndex mirrors the store index fields the config package reads.
+type cachedStoreIndex struct {
+	Frameworks []cachedStoreEntry  `json:"frameworks"`
+	Packages   []StorePackageEntry `json:"packages"`
+}
+
+// loadCachedStoreIndex reads the locally cached framework store index. Returns
 // nil when the cache is absent or unreadable (e.g. a fresh machine that has not
 // reached the store yet), so callers fall back to the built-in adapters.
-func loadCachedStoreEntries() []cachedStoreEntry {
+func loadCachedStoreIndex() *cachedStoreIndex {
 	data, err := os.ReadFile(StoreIndexFile())
 	if err != nil {
 		return nil
 	}
-	var idx struct {
-		Frameworks []cachedStoreEntry `json:"frameworks"`
-	}
+	var idx cachedStoreIndex
 	if json.Unmarshal(data, &idx) != nil {
 		return nil
 	}
+	return &idx
+}
+
+func loadCachedStoreEntries() []cachedStoreEntry {
+	idx := loadCachedStoreIndex()
+	if idx == nil {
+		return nil
+	}
 	return idx.Frameworks
+}
+
+// cachedStorePackages returns the composer packages the store publishes a
+// definition for. Only these are ever looked up for a project, so a project's
+// own dependency list is never turned into a fetch for a file the store does
+// not have.
+func cachedStorePackages() []StorePackageEntry {
+	idx := loadCachedStoreIndex()
+	if idx == nil {
+		return nil
+	}
+	return idx.Packages
 }
 
 // projectOwnsFramework reports whether a framework name belongs to the projects

--- a/internal/store/package_store.go
+++ b/internal/store/package_store.go
@@ -1,0 +1,91 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+func init() {
+	config.RegisterPackageFetchHook(autoFetchPackage)
+}
+
+// autoFetchPackage downloads a package definition and caches it locally. Called
+// by the framework resolver when a project requires a package the store index
+// lists and the local copy is missing or a day old.
+func autoFetchPackage(name, version string) (*config.FrameworkPackage, error) {
+	return NewClient().FetchPackage(name, version)
+}
+
+// packageBases returns the store locations the package layer is served from.
+// Packages sit beside the framework definitions rather than under them, since
+// they are not versions of a framework and were never fetched by a binary that
+// predates them, so the definitions directory in each base is swapped for the
+// packages one.
+func (c *Client) packageBases() []string {
+	bases := append([]string{c.BaseURL}, c.Fallbacks...)
+	out := make([]string, 0, len(bases))
+	for _, base := range bases {
+		trimmed := strings.TrimSuffix(base, "/")
+		if cut, ok := strings.CutSuffix(trimmed, "/frameworks"); ok {
+			trimmed = cut
+		}
+		out = append(out, trimmed+"/packages")
+	}
+	return out
+}
+
+// PackageVersions returns the versions of a package to fetch. Every package has
+// its unversioned file, the one that serves a project below the first major that
+// needed a file of its own, so that file is always in the list.
+func PackageVersions(entry config.StorePackageEntry) []string {
+	return append([]string{""}, entry.Versions...)
+}
+
+// PackageLabel spells a package and version the way the framework store spells
+// one of its definitions.
+func PackageLabel(name, version string) string {
+	if version == "" {
+		return name
+	}
+	return name + "@" + version
+}
+
+// FetchPackage downloads one package definition from the store, the layer that
+// declares a composer package's workers, commands and doctor checks once
+// instead of once per framework major.
+func (c *Client) FetchPackage(name, version string) (*config.FrameworkPackage, error) {
+	slug := config.PackageSlug(name)
+	if slug == "" {
+		return nil, fmt.Errorf("invalid package name %q", name)
+	}
+	if version != "" {
+		slug += "@" + version
+	}
+	data, err := c.fetchFrom(c.packageBases(), slug+".yaml")
+	if err != nil {
+		return nil, fmt.Errorf("fetching package %s: %w", name, err)
+	}
+	var pkg config.FrameworkPackage
+	if err := yaml.Unmarshal(data, &pkg); err != nil {
+		return nil, fmt.Errorf("parsing package %s: %w", name, err)
+	}
+	// The name the store answered with decides where this is cached, and the
+	// request already proved it is a name we asked for; a file claiming another
+	// package would otherwise overwrite that package's cache.
+	if pkg.Package != name {
+		return nil, fmt.Errorf("package %s declares itself as %q", name, pkg.Package)
+	}
+	if pkg.Version != version {
+		return nil, fmt.Errorf("package %s@%s declares itself as version %q", name, version, pkg.Version)
+	}
+	if err := config.SaveStorePackage(&pkg); err != nil {
+		return nil, err
+	}
+	// Marks stay with the definitions: a package's worker draws the same
+	// workers/<icon>.svg a framework's does.
+	c.fetchWorkerIcons(pkg.Workers)
+	return &pkg, nil
+}

--- a/internal/store/package_store_test.go
+++ b/internal/store/package_store_test.go
@@ -1,0 +1,83 @@
+package store
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+const testPackageYAML = `package: acme/electron
+frameworks:
+  - name: acme
+    min: "11"
+workers:
+  native:
+    label: Native
+    command: php acme native:serve
+    icon: nativemark
+`
+
+func packageServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/packages/acme-electron.yaml", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(testPackageYAML)) //nolint:errcheck
+	})
+	mux.HandleFunc("/packages/acme-impostor.yaml", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("package: acme/electron\n")) //nolint:errcheck
+	})
+	mux.HandleFunc("/workers/nativemark.svg", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M4 4h16v16H4z"/></svg>`)) //nolint:errcheck
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { http.NotFound(w, r) })
+	return httptest.NewServer(mux)
+}
+
+func TestFetchPackage_cachesTheDefinitionAndItsWorkerIcons(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	srv := packageServer(t)
+	defer srv.Close()
+
+	pkg, err := testClient(t, srv).FetchPackage("acme/electron", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, has := pkg.Workers["native"]; !has {
+		t.Error("worker missing from the parsed package")
+	}
+	if _, err := os.Stat(config.StorePackageFile("acme/electron", "")); err != nil {
+		t.Errorf("definition was not cached: %v", err)
+	}
+	if _, ok := config.WorkerIcon("nativemark"); !ok {
+		t.Error("worker mark was not cached alongside the definition")
+	}
+}
+
+// The path a package is cached at comes from the name we asked for, so a file
+// answering with another package's name is refused rather than written over it.
+func TestFetchPackage_refusesADefinitionNamingAnotherPackage(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	srv := packageServer(t)
+	defer srv.Close()
+
+	if _, err := testClient(t, srv).FetchPackage("acme/impostor", ""); err == nil {
+		t.Fatal("expected a mismatched package name to fail")
+	}
+	if _, err := os.Stat(config.StorePackageFile("acme/electron", "")); err == nil {
+		t.Error("the impostor must not have been cached as acme/electron")
+	}
+}
+
+func TestFetchPackage_rejectsANameThatIsNotAComposerPackage(t *testing.T) {
+	srv := packageServer(t)
+	defer srv.Close()
+
+	if _, err := testClient(t, srv).FetchPackage("../../etc/passwd", ""); err == nil {
+		t.Fatal("expected an invalid package name to fail")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -33,9 +33,11 @@ type Client struct {
 	Fallbacks []string
 }
 
-// Index is the top-level store index listing all available frameworks.
+// Index is the top-level store index listing all available frameworks, and the
+// composer packages that ship declarations of their own.
 type Index struct {
-	Frameworks []IndexEntry `json:"frameworks"`
+	Frameworks []IndexEntry               `json:"frameworks"`
+	Packages   []config.StorePackageEntry `json:"packages,omitempty"`
 }
 
 // IndexEntry describes a single framework available in the store.
@@ -315,9 +317,16 @@ func (c *Client) findEntry(idx *Index, name string) (*IndexEntry, bool) {
 }
 
 func (c *Client) fetch(path string) ([]byte, error) {
+	return c.fetchFrom(append([]string{c.BaseURL}, c.Fallbacks...), path)
+}
+
+// fetchFrom tries each base in order and returns the first body one serves, so
+// a caller reading a part of the store that lives outside the definitions
+// directory passes its own bases rather than a path full of parent segments.
+func (c *Client) fetchFrom(bases []string, path string) ([]byte, error) {
 	client := &http.Client{Timeout: httpTimeout}
 	var errs []string
-	for _, base := range append([]string{c.BaseURL}, c.Fallbacks...) {
+	for _, base := range bases {
 		body, err := fetchWithRetry(client, base+"/"+path)
 		if err == nil {
 			return body, nil


### PR DESCRIPTION
Almost every worker and command lerd ships is gated on a composer package rather than on the framework it sits in, and it has to be written again in every major of that framework. laravel/horizon is written into eight Laravel files, drush/drush into four Drupal ones, and adding NativePHP meant putting the same worker, two commands and three checks into three files, then correcting all three twice in one afternoon.

The framework store gains a package layer: one file per composer package, beside the definitions rather than inside them, declaring the workers, commands, setup steps and doctor checks that belong to the package rather than to whatever framework happens to carry it. A project that requires the package gets them merged onto the definition it resolved, narrowed by an optional list of frameworks and the range of their majors, so a queue driver can stay unscoped while nativephp/electron says it is Laravel's alone. The package wins a name collision with a version file, which is what lets a declaration move without being shadowed by the copy it leaves behind, and the user's overlay and a project's own .lerd.yaml still sit above both.

A package carries its own versions the way a framework does. One that has kept its interface is a single file; a major that changes what lerd runs adds a file of its own, which serves that major and every later one until the next such file, with the unversioned file serving everything below the first of them. What a major removes it has to say out loud, since the copy the declaration was lifted out of is still in the framework's version files and silence there means keep it. An install that cannot reach a version it has never fetched falls back to the newest cached file below it, so a store that gains a version while a machine is offline never costs that machine the worker it has been running for months.

Only the packages the store index lists are ever looked up, so a project's dependency list never turns into a request for a file the store does not have. They are seeded by lerd install, refreshed by lerd framework update and on the same daily window a definition uses, and cached beside the framework store so a package's worker resolves offline exactly like a framework's.

The refresh that pulls them shares one progress line with the definitions instead of printing a line each, which on a machine holding the whole catalogue was fifty lines of output nobody reads; the service presets refreshed two steps later now do the same.

The store side is lerd-env/frameworks#57, which declares sixteen packages. It does not have to wait for this: the declarations it lifts stay in the version files an older binary reads, so nothing changes for one. NativePHP is the exception, and a small one, since most of what its entries need is unreleased anyway. A site on v1.33.1 loses the native worker toggle when that store change lands, and its unit, if it is running, is reported as needing healing until the install catches up.

Closes #1574
