### PR TITLE
Show the package layer in framework list

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -306,7 +306,7 @@ Activity-driven worker suspension: lerd gracefully stops each site's suspendable
 
 | Command | Description |
 |---|---|
-| `lerd framework list` | List all available framework definitions and their workers |
+| `lerd framework list` | List all available framework definitions and their workers, and the packages the store declares |
 | `lerd framework add <name>` | Install a published framework from the store, or author a custom one (flags or `--from-file`) |
 | `lerd framework remove <name>` | Remove a framework definition (confirms if a site still uses it) |
 | `lerd framework prune` | Remove installed definitions no site uses |

--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -89,6 +89,8 @@ removes:
 
 Removals run after the merge, so a package can replace an entry and drop another in the same file.
 
+`lerd framework list` prints the layer under the definitions table: every package the store publishes, what each one declares, which file answers for the project you are standing in, and whether that project requires it. Everything a package contributes surfaces as an ordinary worker or command, so this is the only place that says where a declaration came from. It reads the cache and never fetches.
+
 Only the packages listed under `packages` in the store index are ever looked up, so a project's dependency list never turns into a request for a file the store does not have. They are cached in `~/.local/share/lerd/packages/`, under the same file name the store serves, seeded by `lerd install`, refreshed by `lerd framework update` and on the same 24 hour window as a definition, so a package's worker resolves offline exactly like a framework's.
 
 ## Version resolution

--- a/internal/cli/framework.go
+++ b/internal/cli/framework.go
@@ -99,7 +99,74 @@ func runFrameworkList(check bool) error {
 		}
 	}
 	feedback.Table(headers, rows)
+	listStorePackages(cwd)
 	return nil
+}
+
+// listStorePackages prints the package layer under the definitions: what the
+// store publishes, what each package contributes, and which of them this
+// project requires. The layer is otherwise invisible, since everything it
+// declares surfaces as an ordinary worker or command, so this is the only place
+// that says where a declaration came from.
+func listStorePackages(cwd string) {
+	pkgs := config.ListStorePackages(cwd)
+	if len(pkgs) == 0 {
+		return
+	}
+	rows := make([][]string, 0, len(pkgs))
+	for _, p := range pkgs {
+		rows = append(rows, []string{p.Name, packageDeclares(p), packageFileLabel(p), packageUse(p, cwd)})
+	}
+	feedback.Header("Packages")
+	feedback.Table([]string{"Package", "Declares", "File", "This project"}, rows)
+}
+
+// packageDeclares summarises a package's contributions: workers and commands by
+// name, since those are what a user recognises, and the rest by count.
+func packageDeclares(p config.StorePackageInfo) string {
+	if !p.Cached {
+		return "—"
+	}
+	var parts []string
+	for _, w := range p.Workers {
+		parts = append(parts, w+" worker")
+	}
+	if len(p.Commands) > 0 {
+		parts = append(parts, strings.Join(p.Commands, ", "))
+	}
+	if p.Setup > 0 {
+		parts = append(parts, fmt.Sprintf("%d setup", p.Setup))
+	}
+	if p.Doctor > 0 {
+		parts = append(parts, fmt.Sprintf("%d check%s", p.Doctor, pluralS(p.Doctor)))
+	}
+	if len(parts) == 0 {
+		return "—"
+	}
+	return strings.Join(parts, ", ")
+}
+
+// packageFileLabel names the file serving this project, or says the store
+// publishes one this machine has not pulled yet.
+func packageFileLabel(p config.StorePackageInfo) string {
+	if !p.Cached {
+		return "not installed"
+	}
+	if p.Version == "" {
+		return "any version"
+	}
+	return "@" + p.Version
+}
+
+func packageUse(p config.StorePackageInfo, cwd string) string {
+	switch {
+	case p.Required:
+		return "yes"
+	case cwd == "":
+		return "—"
+	default:
+		return "no"
+	}
 }
 
 func storeStatus(info config.FrameworkInfo, idx *store.Index) (latest, status string) {

--- a/internal/cli/framework_packages_list_test.go
+++ b/internal/cli/framework_packages_list_test.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestPackageDeclares(t *testing.T) {
+	cases := []struct {
+		name string
+		in   config.StorePackageInfo
+		want string
+	}{
+		{"workers and commands by name", config.StorePackageInfo{
+			Cached: true, Workers: []string{"cron"}, Commands: []string{"cr", "uli"}, Setup: 3,
+		}, "cron worker, cr, uli, 3 setup"},
+		{"checks counted", config.StorePackageInfo{
+			Cached: true, Workers: []string{"native"}, Doctor: 1,
+		}, "native worker, 1 check"},
+		{"nothing cached to describe", config.StorePackageInfo{}, "—"},
+		{"cached but empty", config.StorePackageInfo{Cached: true}, "—"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := packageDeclares(tc.in); got != tc.want {
+				t.Errorf("packageDeclares = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The file column says which definition answers, and admits when the store
+// publishes one this machine has never pulled.
+func TestPackageFileLabel(t *testing.T) {
+	if got := packageFileLabel(config.StorePackageInfo{Cached: true}); got != "any version" {
+		t.Errorf("unversioned = %q, want \"any version\"", got)
+	}
+	if got := packageFileLabel(config.StorePackageInfo{Cached: true, Version: "13"}); got != "@13" {
+		t.Errorf("versioned = %q, want @13", got)
+	}
+	if got := packageFileLabel(config.StorePackageInfo{Version: "13"}); got != "not installed" {
+		t.Errorf("uncached = %q, want \"not installed\"", got)
+	}
+}
+
+// Run outside a project there is nothing to require, which is a different
+// answer from a project that does not use the package.
+func TestPackageUse(t *testing.T) {
+	if got := packageUse(config.StorePackageInfo{Required: true}, "/tmp/site"); got != "yes" {
+		t.Errorf("required = %q, want yes", got)
+	}
+	if got := packageUse(config.StorePackageInfo{}, "/tmp/site"); got != "no" {
+		t.Errorf("not required = %q, want no", got)
+	}
+	if got := packageUse(config.StorePackageInfo{}, ""); got != "—" {
+		t.Errorf("outside a project = %q, want an em dash", got)
+	}
+}

--- a/internal/config/framework_package.go
+++ b/internal/config/framework_package.go
@@ -385,3 +385,57 @@ func SaveStorePackage(pkg *FrameworkPackage) error {
 	}
 	return publishStoreFile(path, data, 0644)
 }
+
+// StorePackageInfo is one published package as a lister sees it: what the
+// cached file declares, which file serves this project, and whether the project
+// requires the package at all.
+type StorePackageInfo struct {
+	Name string
+	// Version is the file that would serve this project, empty for the
+	// unversioned one. Cached reports whether that file is on disk.
+	Version  string
+	Cached   bool
+	Required bool
+	Workers  []string
+	Commands []string
+	Setup    int
+	Doctor   int
+}
+
+// ListStorePackages describes the package layer for projectDir, which may be
+// empty for a listing outside a project. It reads the cache and never fetches:
+// a listing that pulled sixteen files from the network would be a different
+// command than the one people run to see what they already have.
+func ListStorePackages(projectDir string) []StorePackageInfo {
+	entries := cachedStorePackages()
+	out := make([]StorePackageInfo, 0, len(entries))
+	for _, entry := range entries {
+		info := StorePackageInfo{Name: entry.Name}
+		if projectDir != "" {
+			info.Required = ComposerHasPackage(projectDir, entry.Name)
+		}
+		info.Version = pickPackageVersion(projectDir, entry)
+		if pkg := loadPackageYAML(StorePackageFile(entry.Name, info.Version)); pkg != nil {
+			info.Cached = true
+			for name := range pkg.Workers {
+				info.Workers = append(info.Workers, name)
+			}
+			sort.Strings(info.Workers)
+			for _, c := range pkg.Commands {
+				info.Commands = append(info.Commands, c.Name)
+			}
+			info.Setup = len(pkg.Setup)
+			if pkg.Doctor != nil {
+				info.Doctor = len(pkg.Doctor.Checks)
+			}
+		}
+		out = append(out, info)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Required != out[j].Required {
+			return out[i].Required
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}

--- a/internal/config/store_packages_list_test.go
+++ b/internal/config/store_packages_list_test.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A listing describes the layer from the cache alone: what each package
+// declares, which file would serve this project, and whether the project
+// requires it at all.
+func TestListStorePackages_describesTheLayerForAProject(t *testing.T) {
+	_, project := packageSandbox(t, []string{
+		`{"name":"acme/electron"}`,
+		`{"name":"acme/queue"}`,
+	}, "acme/electron")
+	writePackage(t, "acme-electron", electronPackage)
+
+	got := ListStorePackages(project)
+	if len(got) != 2 {
+		t.Fatalf("listed %d packages, want 2", len(got))
+	}
+	// The one this project requires sorts first.
+	first := got[0]
+	if first.Name != "acme/electron" || !first.Required {
+		t.Fatalf("first entry = %+v, want the required acme/electron", first)
+	}
+	if !first.Cached {
+		t.Error("a package with a file on disk must read as cached")
+	}
+	if len(first.Workers) != 1 || first.Workers[0] != "native" {
+		t.Errorf("workers = %v, want [native]", first.Workers)
+	}
+	if len(first.Commands) != 1 || first.Commands[0] != "native:build" {
+		t.Errorf("commands = %v, want [native:build]", first.Commands)
+	}
+	if first.Doctor != 1 {
+		t.Errorf("doctor checks = %d, want 1", first.Doctor)
+	}
+	// The store publishes the second one, but nothing pulled it and this
+	// project does not use it.
+	if second := got[1]; second.Cached || second.Required {
+		t.Errorf("second entry = %+v, want neither cached nor required", second)
+	}
+}
+
+// Outside a project nothing is required, and the listing still names what the
+// store publishes.
+func TestListStorePackages_outsideAProject(t *testing.T) {
+	packageSandbox(t, []string{`{"name":"acme/electron"}`})
+	writePackage(t, "acme-electron", electronPackage)
+
+	got := ListStorePackages("")
+	if len(got) != 1 {
+		t.Fatalf("listed %d packages, want 1", len(got))
+	}
+	if got[0].Required {
+		t.Error("no project means nothing is required")
+	}
+	if !got[0].Cached {
+		t.Error("the cached file should still be read")
+	}
+}
+
+// The file named is the one that would serve the project, not simply the newest
+// the store publishes.
+func TestListStorePackages_namesTheVersionServingTheProject(t *testing.T) {
+	_, project := packageSandbox(t, []string{`{"name":"acme/electron","versions":["5","7"],"latest":"7"}`})
+	if err := os.WriteFile(filepath.Join(project, "composer.json"),
+		[]byte(`{"require": {"acme/framework": "^11.0", "acme/electron": "^6.0"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writePackage(t, "acme-electron@5", packageAtVersion("5", "php acme five"))
+
+	got := ListStorePackages(project)
+	if len(got) != 1 || got[0].Version != "5" {
+		t.Fatalf("version = %q, want the 5 file that serves a 6 install", got[0].Version)
+	}
+}


### PR DESCRIPTION
Everything a package declares surfaces as an ordinary worker, command, setup step or doctor check, which is the point, but it also means nothing says where a declaration came from. A site running a horizon worker looks the same whether the framework file or the package declared it, and a package the store has just started publishing is invisible until something it declares turns up.

lerd framework list now prints the layer under the definitions: every package the store publishes, what each one declares, which file answers for the project you are standing in, and whether that project requires it. The ones in use sort first. It reads the cache and never fetches, since a listing that pulled sixteen files over the network would be a different command than the one people run to see what they already have.

```
 ▸ Packages

Package             Declares                                              File         This project
nativephp/electron  native worker, native:install, native:build, 1 check  any version  yes
laravel/horizon     horizon worker                                        any version  no
drush/drush         cron worker, site:install, cr, uli, updb, cex, cim…   any version  no
```