### PR TITLE
docs(new): say that a scaffold installs the major that was picked

### DIFF
--- a/.claude/skills/lerd-add-framework/SKILL.md
+++ b/.claude/skills/lerd-add-framework/SKILL.md
@@ -23,7 +23,9 @@ and test against, but the pull request goes to **lerd-env/frameworks**.
    adjust. The existing YAML is the schema of record — do not invent fields.
 
 2. **Fill the sections that apply** (all keyed by real examples in the store):
-   - `name`, `version`, `label`, `public_dir`, `create` (scaffold command)
+   - `name`, `version`, `label`, `public_dir`, `create` (scaffold command,
+     which must constrain its package to the file's own major, e.g.
+     `composer create-project laravel/laravel:^12.0`)
    - `php.min` / `php.max` — the versions the framework supports
    - `detect` — marker file, lockfile, or `composer:` package that identifies it,
      including the major version

--- a/docs/getting-started/cakephp.md
+++ b/docs/getting-started/cakephp.md
@@ -19,7 +19,7 @@ Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Cursor, Ju
 ```bash [lerd new]
 cd ~/Lerd
 lerd new mysite --framework=cakephp
-# runs: composer create-project cakephp/app ./mysite
+# runs: composer create-project cakephp/app:^5.0 ./mysite
 ```
 
 ```bash [composer]

--- a/docs/getting-started/codeigniter.md
+++ b/docs/getting-started/codeigniter.md
@@ -19,7 +19,7 @@ Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Cursor, Ju
 ```bash [lerd new]
 cd ~/Lerd
 lerd new mysite --framework=codeigniter
-# runs: composer create-project codeigniter4/appstarter ./mysite
+# runs: composer create-project codeigniter4/appstarter:^4.0 ./mysite
 ```
 
 ```bash [composer]

--- a/docs/getting-started/drupal.md
+++ b/docs/getting-started/drupal.md
@@ -19,7 +19,7 @@ Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Cursor, Ju
 ```bash [lerd new]
 cd ~/Lerd
 lerd new mysite --framework=drupal
-# runs: composer create-project drupal/recommended-project ./mysite
+# runs: composer create-project drupal/recommended-project:^11.0 ./mysite
 ```
 
 ```bash [composer]

--- a/docs/getting-started/laravel.md
+++ b/docs/getting-started/laravel.md
@@ -26,7 +26,7 @@ laravel new myapp
 ```bash [lerd new]
 cd ~/Lerd
 lerd new myapp
-# runs: composer create-project laravel/laravel ./myapp
+# runs: composer create-project laravel/laravel:^13.0 ./myapp
 ```
 
 ```bash [existing repo]

--- a/docs/getting-started/magento.md
+++ b/docs/getting-started/magento.md
@@ -32,7 +32,7 @@ Worth knowing before you start, because each one changes a step below:
 cd ~/Lerd
 lerd new mysite --framework=magento
 # runs: composer create-project --repository-url=https://mirror.mage-os.org/ \
-#         magento/project-community-edition ./mysite
+#         magento/project-community-edition:^2.0 ./mysite
 ```
 
 ```bash [composer]

--- a/docs/getting-started/nixos.md
+++ b/docs/getting-started/nixos.md
@@ -181,7 +181,7 @@ Firefox/Chromium use their own certificate stores. Many pick up the mkcert CA au
 ## Create a Laravel project
 
 ```bash
-lerd new myapp        # composer create-project laravel/laravel ./myapp
+lerd new myapp        # composer create-project laravel/laravel:^13.0 ./myapp
 cd myapp
 lerd isolate 8.4      # pin PHP version for this project (optional; 8.5 also available)
 lerd link             # register ./myapp → myapp.test

--- a/docs/getting-started/statamic.md
+++ b/docs/getting-started/statamic.md
@@ -19,7 +19,7 @@ Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Cursor, Ju
 ```bash [lerd new]
 cd ~/Lerd
 lerd new mysite --framework=statamic
-# runs: composer create-project statamic/statamic ./mysite
+# runs: composer create-project statamic/statamic:^6.0 ./mysite
 ```
 
 ```bash [composer]

--- a/docs/getting-started/symfony.md
+++ b/docs/getting-started/symfony.md
@@ -19,7 +19,7 @@ Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Cursor, Ju
 ```bash [lerd new]
 cd ~/Lerd
 lerd new myapp --framework=symfony
-# runs: composer create-project symfony/skeleton ./myapp
+# runs: composer create-project symfony/skeleton:^8.0 ./myapp
 ```
 
 ```bash [composer]

--- a/docs/getting-started/tempest.md
+++ b/docs/getting-started/tempest.md
@@ -19,7 +19,7 @@ Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Cursor, Ju
 ```bash [lerd new]
 cd ~/Lerd
 lerd new mysite --framework=tempest
-# runs: composer create-project tempest/app ./mysite
+# runs: composer create-project tempest/app:^3.0 ./mysite
 ```
 
 ```bash [composer]

--- a/docs/getting-started/typo3.md
+++ b/docs/getting-started/typo3.md
@@ -19,7 +19,7 @@ Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Cursor, Ju
 ```bash [lerd new]
 cd ~/Lerd
 lerd new mysite --framework=typo3
-# runs: composer create-project typo3/cms-base-distribution ./mysite
+# runs: composer create-project typo3/cms-base-distribution:^14.0 ./mysite
 ```
 
 ```bash [composer]

--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -153,6 +153,12 @@ never start blocking on a prompt. `--framework-version` answers the version
 question the same way, which is how the dashboard's site wizard scaffolds a
 chosen major; it needs a `--framework` to apply to.
 
+The major you pick reaches composer as well as lerd. Each definition's create
+command names its own major, `composer create-project laravel/laravel:^11.0`, so
+the release that lands on disk is the one you asked for rather than whatever is
+newest, and the PHP range, workers and env wiring the definition brings match the
+code beside them.
+
 The command then carries the project the rest of the way: it links the new
 directory, which routes a project with no `.lerd.yaml` through the
 [init wizard](/usage/sites) for PHP version, HTTPS and services, and offers setup

--- a/internal/cli/store_create_version_test.go
+++ b/internal/cli/store_create_version_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+// createPackage returns the composer package a create command scaffolds from,
+// the last argument naming a vendor/package rather than a flag.
+func createPackage(create string) string {
+	pkg := ""
+	for _, arg := range strings.Fields(create) {
+		if strings.HasPrefix(arg, "-") || !strings.Contains(arg, "/") {
+			continue
+		}
+		pkg = arg
+	}
+	return pkg
+}
+
+// lerd new asks which major to scaffold and resolves that major's definition, so
+// a create command that leaves its package unconstrained hands composer the
+// newest release whatever the answer was and the project on disk ends up a major
+// the definition was never written for.
+func TestStoreFrameworks_CreateNamesItsMajor(t *testing.T) {
+	root := filepath.Join("..", "..", "lerd-frameworks", "frameworks")
+	dirs, err := os.ReadDir(root)
+	if err != nil {
+		t.Skipf("frameworks store checkout not present: %v", err)
+	}
+	checked := 0
+	for _, d := range dirs {
+		if !d.IsDir() {
+			continue
+		}
+		files, err := os.ReadDir(filepath.Join(root, d.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", d.Name(), err)
+		}
+		for _, f := range files {
+			if f.IsDir() || filepath.Ext(f.Name()) != ".yaml" {
+				continue
+			}
+			name := filepath.Join(d.Name(), f.Name())
+			b, err := os.ReadFile(filepath.Join(root, name))
+			if err != nil {
+				t.Fatalf("read %s: %v", name, err)
+			}
+			var fw config.Framework
+			if err := yaml.Unmarshal(b, &fw); err != nil {
+				t.Fatalf("unmarshal %s: %v", name, err)
+			}
+			if fw.Create == "" {
+				continue
+			}
+			checked++
+
+			pkg := createPackage(fw.Create)
+			vendor, constraint, ok := strings.Cut(pkg, ":")
+			if !ok {
+				t.Errorf("%s: create scaffolds %s unconstrained, want :^%s.0", name, pkg, fw.Version)
+				continue
+			}
+			major, _, _ := strings.Cut(strings.TrimLeft(constraint, "^~>=v "), ".")
+			if major != fw.Version {
+				t.Errorf("%s: create scaffolds %s:%s, want major %s", name, vendor, constraint, fw.Version)
+			}
+			if _, err := strconv.Atoi(fw.Version); err != nil {
+				t.Errorf("%s: version %q is not a major", name, fw.Version)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Skip("no framework definitions in the store checkout")
+	}
+}


### PR DESCRIPTION
The store definitions now constrain their create command to the major they are for, lerd-env/frameworks#59, so the release composer installs is the one the version question was answered with. The walkthroughs still showed the unconstrained command they used to run, and the scaffolding section never said the answer reached composer at all, only that lerd pulled the matching definition.

A check over the local store checkout keeps a definition from publishing a create command that scaffolds some other major. That is the shape the bug had, and the shape a new version file copied from an older one would take again.

Refs lerd-env/frameworks#41