### PR TITLE
feat(nginx): add a location-scope custom.d override per site

### DIFF
--- a/docs/usage/nginx-overrides.md
+++ b/docs/usage/nginx-overrides.md
@@ -12,17 +12,23 @@ Each worktree is served on its own subdomain (`{branch}.{primary}.test`) with it
 
 ## From the CLI and MCP
 
-The same override is reachable without the web UI, which is handy for scripting or from an agent. `lerd nginx show [site]` prints the current override (`--path` prints just the file path), `lerd nginx edit [site]` opens it in `$EDITOR` and then validates with `nginx -t` and reloads on save, and `lerd nginx reset [site]` deletes it and falls back to the bundled defaults. Add `--branch <name>` to any of them to target a worktree's override instead of the main branch's. The MCP `site_nginx` tool mirrors this with `action: read | write | reset`, an optional `site`, an optional `branch`, and `content` for writes; writes run the same `nginx -t` validation, backup, and reload as the web editor. All three surfaces go through one shared edit service, so validation, backups, and reload behave identically whichever one you use.
+The same override is reachable without the web UI, which is handy for scripting or from an agent. `lerd nginx show [site]` prints the current override (`--path` prints just the file path), `lerd nginx edit [site]` opens it in `$EDITOR` and then validates with `nginx -t` and reloads on save, and `lerd nginx reset [site]` deletes it and falls back to the bundled defaults. Add `--branch <name>` to any of them to target a worktree's override instead of the main branch's, and `--location` to target the location-scope file described below instead of the server-block one. The MCP `site_nginx` tool mirrors this with `action: read | write | reset`, an optional `site`, an optional `branch`, an optional `scope` (`server` or `location`), and `content` for writes; writes run the same `nginx -t` validation, backup, and reload as the web editor. All three surfaces go through one shared edit service, so validation, backups, and reload behave identically whichever one you use.
 
 ## How it works
 
-Every generated site vhost ends with:
+Every generated site vhost carries two includes. One at the end of the `server { }` block:
 
 ```nginx
 include /etc/nginx/custom.d/{your-domain}.conf*;
 ```
 
-The trailing `*` makes the include a glob, so nginx treats a missing override file as empty (no 500). The directory is bind-mounted read-only into the `lerd-nginx` container and is never touched by lerd after creation.
+and one at the end of the block that actually serves the site, `location ~ \.php$` on an FPM site and `location /` on a proxied one:
+
+```nginx
+include /etc/nginx/custom.d/{your-domain}.location.conf*;
+```
+
+The trailing `*` makes each include a glob, so nginx treats a missing override file as empty (no 500). The directory is bind-mounted read-only into the `lerd-nginx` container and is never touched by lerd after creation.
 
 ## Request timeouts
 
@@ -65,6 +71,8 @@ That's it. The snippet is merged into the generated server block for `bigapp.tes
 
 Lines you put in `custom.d/{domain}.conf` land inside the site's `server { ... }` block, so you can use anything nginx allows at server level: `client_max_body_size`, `add_header`, extra `location` blocks, `proxy_pass` overrides, `rewrite`, and so on.
 
+`fastcgi_param` and `proxy_set_header` are the exception, and they are why there is a second file. Nginx resolves both per location, and the moment a location declares one of its own it ignores the entire inherited set, so a `fastcgi_param SERVER_NAME $host;` written at server level never reaches PHP. Put those in `custom.d/{domain}.location.conf` instead: it is included at the very end of the block that serves the site, after everything lerd sets, so a repeated directive wins. In the web UI it is the **Location** tab of the same editor; from the CLI it is `lerd nginx show|edit|reset --location`. Save, backup, `nginx -t` validation, restore, and reset all work exactly the same on both files, and both survive vhost regeneration, worktree seeding, and a domain rename.
+
 Two things there cannot be redeclared, because the generated vhost already carries them and nginx rejects the repeat rather than overriding it. Setting `root` fails with `"root" directive is duplicate`; lerd derives the docroot from the linked site, so change it with `lerd link` rather than from a snippet. Repeating a `location` lerd emits (`/`, `~ \.php$`, `~ /\.ht`) fails with `duplicate location`; add a differently scoped location such as `/media` instead of restating one of those. Both failures surface in the editor before anything is committed, so the site keeps serving on its previous config.
 
 If you need directives at `http {}` level (gzip, proxy buffers, a global `client_max_body_size`, a new `map`), edit the **global override** from the web UI: open **System → Nginx** and pick the **Config** tab. It edits `~/.local/share/lerd/nginx/http.d/zz-lerd-user.conf`, which the generated `nginx.conf` includes last inside its `http {}` block, after lerd's own settings. The editor is the same surface as the per-site one: Save runs `nginx -t` before the new bytes are committed, there is an optional backup-first checkbox with a **Restore** button, and **Reset** drops the file back to empty. The `http.d` directory is bind-mounted read-only into the `lerd-nginx` container and lerd never writes into it itself.
@@ -93,3 +101,12 @@ The generated vhosts already set the `X-Forwarded-*` family for you so tools lik
 | `HTTP_X_REAL_IP`, `HTTP_X_FORWARDED_FOR` | `$remote_addr` |
 
 The fallbacks are declared once in `conf.d/_forwarded.conf` (generated by lerd at install time) via two `map` blocks that produce `$real_forwarded_host` and `$real_forwarded_proto`. Direct browser requests without `X-Forwarded-*` headers keep seeing the real host and scheme; tunneled requests see the public hostname the tunnel received. PHP apps that call `url()` or read `$_SERVER['HTTP_HOST']` get correct absolute URLs in both paths without any app-side changes.
+
+Some codebases want the opposite: the local hostname even when the request arrived through a tunnel, because they compare `SERVER_NAME` against their own configuration. Opt one site out in its location-scope override, `custom.d/{domain}.location.conf`:
+
+```nginx
+fastcgi_param SERVER_NAME $host;
+fastcgi_param HTTP_HOST $host;
+```
+
+The `map` blocks in `_forwarded.conf` stay as they are; they only define variables, and this simply stops using them for those two parameters. `HTTP_X_FORWARDED_HOST` still carries the tunnel hostname, so nothing that needs the public name loses it.

--- a/internal/cli/aidocs/lerd-reference.md
+++ b/internal/cli/aidocs/lerd-reference.md
@@ -40,7 +40,7 @@ Actions: `list` (discover sites — CALL FIRST), `link`, `unlink`, `domain_add`,
 - certificates renew themselves before they expire; `tls_renew` forces it by hand for one site
 - `php`/`node` take `version`; pass `branch` to pin the override on a worktree's checkout
 - `runtime` switches `fpm` ↔ `frankenphp` (`worker: true` enables frankenphp worker mode)
-- `nginx_write` saves a custom override (runs `nginx -t`, backs up, reloads); `branch` targets a worktree
+- `nginx_write` saves a custom override (runs `nginx -t`, backs up, reloads); `branch` targets a worktree, `scope` picks the file: `server` (default) sits at the end of the server block, `location` inside the block serving the site, the only place a `fastcgi_param` or `proxy_set_header` override takes effect
 - `park` registers a parent dir and auto-registers every PHP project under it; `unpark` reverses it (project files kept)
 
 #### `service` — built-in & custom services

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -600,9 +600,11 @@ func TestIsLerdBuiltImage_matchers(t *testing.T) {
 // 33200 for the env contract, which is what stops an assistant hand-editing a
 // settings.php or reading Laravel's key names on a project that declares none,
 // plus sqlite as a wiring rather than a service, and the doctor fixes that run
-// on the host rather than in the container.
+// on the host rather than in the container, then 33200 → 33450 for the nginx
+// `scope`: a site has two override files and an assistant that does not know
+// the location one writes fastcgi_param into the file nginx ignores.
 func TestLerdReference_underSizeCeiling(t *testing.T) {
-	const ceiling = 33200
+	const ceiling = 33450
 	if got := len(lerdReference); got > ceiling {
 		t.Errorf("lerd-reference.md is %d bytes, ceiling is %d — trim before raising", got, ceiling)
 	}

--- a/internal/cli/nginx.go
+++ b/internal/cli/nginx.go
@@ -29,6 +29,22 @@ func resolveNginxDomain(args []string, branch string) (*config.Site, string, err
 	return site, domain, nil
 }
 
+// nginxScope maps the --location flag onto the scope. The two override files
+// differ only in where the generated vhost includes them, so one boolean beats
+// a --scope string with exactly two legal values.
+func nginxScope(location bool) siteops.NginxScope {
+	if location {
+		return siteops.NginxLocationScope
+	}
+	return siteops.NginxServerScope
+}
+
+// addNginxFlags registers the flags every `lerd nginx` subcommand shares.
+func addNginxFlags(cmd *cobra.Command, branch *string, location *bool) {
+	cmd.Flags().StringVar(branch, "branch", "", "Worktree branch to target instead of the main branch")
+	cmd.Flags().BoolVar(location, "location", false, "Target the override included inside the site's request-handling location, where fastcgi_param and proxy_set_header overrides take effect")
+}
+
 // NewNginxCmd returns the `lerd nginx` command group for the per-site custom
 // nginx override. Saving goes through the same edit service as the web UI, so
 // `nginx -t` validation, backups, and the reload all behave identically.
@@ -37,8 +53,10 @@ func NewNginxCmd() *cobra.Command {
 		Use:   "nginx",
 		Short: "Show, edit, or reset a site's custom nginx override",
 		Long: "Manage the per-site nginx override included at the end of a site's\n" +
-			"server block (custom.d/{domain}.conf). Pass --branch to target a\n" +
-			"worktree's override instead of the main branch's.",
+			"server block (custom.d/{domain}.conf). Pass --location for the one\n" +
+			"included inside the block that serves the site, the only place a\n" +
+			"fastcgi_param or proxy_set_header override takes effect, and\n" +
+			"--branch to target a worktree's override instead of the main branch's.",
 	}
 	cmd.AddCommand(newNginxShowCmd(), newNginxEditCmd(), newNginxResetCmd())
 	return cmd
@@ -46,6 +64,7 @@ func NewNginxCmd() *cobra.Command {
 
 func newNginxShowCmd() *cobra.Command {
 	var branch string
+	var location bool
 	var pathOnly bool
 	cmd := &cobra.Command{
 		Use:   "show [site]",
@@ -57,10 +76,10 @@ func newNginxShowCmd() *cobra.Command {
 				return err
 			}
 			if pathOnly {
-				fmt.Fprintln(cmd.OutOrStdout(), siteops.CustomNginxPath(domain))
+				fmt.Fprintln(cmd.OutOrStdout(), siteops.CustomNginxPath(domain, nginxScope(location)))
 				return nil
 			}
-			got, err := siteops.ReadCustomNginx(domain)
+			got, err := siteops.ReadCustomNginx(domain, nginxScope(location))
 			if err != nil {
 				return err
 			}
@@ -71,13 +90,14 @@ func newNginxShowCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&branch, "branch", "", "Worktree branch to target instead of the main branch")
+	addNginxFlags(cmd, &branch, &location)
 	cmd.Flags().BoolVar(&pathOnly, "path", false, "Print the override file path and exit")
 	return cmd
 }
 
 func newNginxEditCmd() *cobra.Command {
 	var branch string
+	var location bool
 	cmd := &cobra.Command{
 		Use:   "edit [site]",
 		Short: "Open the custom nginx override in $EDITOR, then validate and reload",
@@ -87,7 +107,7 @@ func newNginxEditCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			got, err := siteops.ReadCustomNginx(domain)
+			got, err := siteops.ReadCustomNginx(domain, nginxScope(location))
 			if err != nil {
 				return err
 			}
@@ -111,7 +131,7 @@ func newNginxEditCmd() *cobra.Command {
 				return err
 			}
 			if !launched {
-				fmt.Printf("Override file: %s\n", siteops.CustomNginxPath(domain))
+				fmt.Printf("Override file: %s\n", siteops.CustomNginxPath(domain, nginxScope(location)))
 				fmt.Println("Set $EDITOR to edit it automatically.")
 				return nil
 			}
@@ -123,7 +143,7 @@ func newNginxEditCmd() *cobra.Command {
 				fmt.Fprintln(cmd.OutOrStdout(), "No changes.")
 				return nil
 			}
-			res, err := siteops.SaveCustomNginx(domain, string(edited), got.Exists)
+			res, err := siteops.SaveCustomNginx(domain, nginxScope(location), string(edited), got.Exists)
 			if err != nil {
 				return err
 			}
@@ -137,12 +157,13 @@ func newNginxEditCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&branch, "branch", "", "Worktree branch to target instead of the main branch")
+	addNginxFlags(cmd, &branch, &location)
 	return cmd
 }
 
 func newNginxResetCmd() *cobra.Command {
 	var branch string
+	var location bool
 	cmd := &cobra.Command{
 		Use:   "reset [site]",
 		Short: "Delete the custom nginx override and reload nginx (backups are kept)",
@@ -152,13 +173,13 @@ func newNginxResetCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := siteops.ResetCustomNginx(domain); err != nil {
+			if err := siteops.ResetCustomNginx(domain, nginxScope(location)); err != nil {
 				return err
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Reset %s to bundled defaults.\n", domain)
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&branch, "branch", "", "Worktree branch to target instead of the main branch")
+	addNginxFlags(cmd, &branch, &location)
 	return cmd
 }

--- a/internal/cli/nginx_test.go
+++ b/internal/cli/nginx_test.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
@@ -22,7 +24,7 @@ func TestNginxShow_printsSavedOverride(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := siteops.ReadCustomNginx(resolveNginxTestDomain(t, "acme", ""))
+	got, err := siteops.ReadCustomNginx(resolveNginxTestDomain(t, "acme", ""), siteops.NginxServerScope)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,4 +75,46 @@ func resolveNginxTestDomain(t *testing.T, name, branch string) string {
 		t.Fatal(err)
 	}
 	return domain
+}
+
+func TestNginxShow_locationFlagTargetsTheLocationOverride(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := config.AddSite(config.Site{Name: "acme", Path: t.TempDir(), Domains: []string{"acme.test"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(config.NginxCustomD(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(config.NginxCustomD(), "acme.test.location.conf"), []byte("# only-in-location\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runNginxCmd(t, "show", "acme", "--location")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "# only-in-location\n" {
+		t.Fatalf("got %q, want the location override", out)
+	}
+	out, err = runNginxCmd(t, "show", "acme")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "only-in-location") {
+		t.Fatalf("server scope must not read the location file, got %q", out)
+	}
+}
+
+// runNginxCmd drives the real cobra command so the --location flag wiring is
+// exercised, not just the siteops call underneath it.
+func runNginxCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := NewNginxCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
 }

--- a/internal/mcp/groups.go
+++ b/internal/mcp/groups.go
@@ -324,6 +324,7 @@ func siteTool() mcpTool {
 				"version":  {Type: "string", Description: "php/node: target version."},
 				"branch":   {Type: "string", Description: "Optional worktree branch (php/node/nginx_*)."},
 				"content":  {Type: "string", Description: "nginx_write: full nginx config."},
+				"scope":    {Type: "string", Enum: []string{"server", "location"}, Description: "nginx_*: server (default) or location. Only a location override can change fastcgi_param or proxy_set_header."},
 				"runtime":  {Type: "string", Enum: []string{"fpm", "frankenphp"}, Description: "runtime: target runtime."},
 				"worker":   {Type: "boolean", Description: "runtime: frankenphp worker mode."},
 			},

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -510,7 +510,11 @@ func execSiteNginxRead(args map[string]any) (any, *rpcError) {
 	if err != nil {
 		return toolErr(err.Error()), nil
 	}
-	got, err := siteops.ReadCustomNginx(domain)
+	scope, err := siteops.ParseNginxScope(strArg(args, "scope"))
+	if err != nil {
+		return toolErr(err.Error()), nil
+	}
+	got, err := siteops.ReadCustomNginx(domain, scope)
 	if err != nil {
 		return toolErr(err.Error()), nil
 	}
@@ -518,7 +522,7 @@ func execSiteNginxRead(args map[string]any) (any, *rpcError) {
 	if !got.Exists {
 		state = "no override yet — showing the template"
 	}
-	return toolOK(fmt.Sprintf("# %s (%s)\n%s", domain, state, got.Body)), nil
+	return toolOK(fmt.Sprintf("# %s (%s scope, %s)\n%s", domain, scope, state, got.Body)), nil
 }
 
 func execSiteNginxWrite(args map[string]any) (any, *rpcError) {
@@ -526,7 +530,11 @@ func execSiteNginxWrite(args map[string]any) (any, *rpcError) {
 	if err != nil {
 		return toolErr(err.Error()), nil
 	}
-	res, err := siteops.SaveCustomNginx(domain, strArg(args, "content"), true)
+	scope, err := siteops.ParseNginxScope(strArg(args, "scope"))
+	if err != nil {
+		return toolErr(err.Error()), nil
+	}
+	res, err := siteops.SaveCustomNginx(domain, scope, strArg(args, "content"), true)
 	if err != nil {
 		return toolErr(err.Error()), nil
 	}
@@ -545,10 +553,14 @@ func execSiteNginxReset(args map[string]any) (any, *rpcError) {
 	if err != nil {
 		return toolErr(err.Error()), nil
 	}
-	if err := siteops.ResetCustomNginx(domain); err != nil {
+	scope, err := siteops.ParseNginxScope(strArg(args, "scope"))
+	if err != nil {
 		return toolErr(err.Error()), nil
 	}
-	return toolOK(fmt.Sprintf("Reset %s to the bundled nginx defaults.", domain)), nil
+	if err := siteops.ResetCustomNginx(domain, scope); err != nil {
+		return toolErr(err.Error()), nil
+	}
+	return toolOK(fmt.Sprintf("Reset the %s scope override for %s to the bundled nginx defaults.", scope, domain)), nil
 }
 
 // QueueStartFn and QueueStopFn are injected by the cli package (which owns the

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -267,8 +267,11 @@ func TestToolList_underSizeCeiling(t *testing.T) {
 	// (required by the MCP spec), then 22900 → 23050 for the `no_snapshot`
 	// property: a data wipe now snapshots the databases first and refuses when
 	// it cannot, so an assistant that does not know the flag reads a blocked
-	// remove as a broken service.
-	const ceiling = 23050
+	// remove as a broken service, then 23050 → 23250 for the site `scope`
+	// property: a site now has two nginx override files and the location one is
+	// the only place a fastcgi_param or proxy_set_header override takes effect,
+	// so an assistant without the property writes into the file nginx ignores.
+	const ceiling = 23250
 	got, err := json.Marshal(toolList())
 	if err != nil {
 		t.Fatalf("marshal tool list: %v", err)

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -1738,3 +1738,56 @@ func TestRepairVhosts_stillRemovesAVhostNoSiteOwns(t *testing.T) {
 		t.Error("an unowned SSL vhost with no certificate should be removed")
 	}
 }
+
+// includedInsideLocation reports whether the location-scope include sits inside
+// the block opened by the given header line rather than merely somewhere in the
+// file. Nginx drops the server-level fastcgi_param and proxy_set_header sets as
+// soon as a location declares one, so an include placed at server scope cannot
+// override them and the position is the whole point of the hook.
+func includedInsideLocation(content, header, include string) bool {
+	start := strings.Index(content, header)
+	if start < 0 {
+		return false
+	}
+	end := strings.Index(content[start:], "\n    }")
+	if end < 0 {
+		return false
+	}
+	return strings.Contains(content[start:start+end], include)
+}
+
+func TestGenerateVhost_includesLocationScopedCustomD(t *testing.T) {
+	confD := setupConfD(t)
+	site := config.Site{Name: "fwd", Domains: []string{"fwd.test"}, Path: "/srv/fwd"}
+	if err := GenerateVhost(site, "8.3"); err != nil {
+		t.Fatal(err)
+	}
+	content := readConf(t, filepath.Join(confD, "fwd.test.conf"))
+	if !includedInsideLocation(content, "location ~ \\.php$ {", "include /etc/nginx/custom.d/fwd.test.location.conf*;") {
+		t.Errorf("expected the location-scope include inside the php location, got:\n%s", content)
+	}
+}
+
+func TestGenerateSSLVhost_includesLocationScopedCustomD(t *testing.T) {
+	confD := setupConfD(t)
+	site := config.Site{Name: "fwd", Domains: []string{"fwd.test"}, Path: "/srv/fwd"}
+	if err := GenerateSSLVhost(site, "8.3"); err != nil {
+		t.Fatal(err)
+	}
+	content := readConf(t, filepath.Join(confD, "fwd.test-ssl.conf"))
+	if !includedInsideLocation(content, "location ~ \\.php$ {", "include /etc/nginx/custom.d/fwd.test.location.conf*;") {
+		t.Errorf("expected the location-scope include inside the php location, got:\n%s", content)
+	}
+}
+
+func TestGenerateCustomVhost_includesLocationScopedCustomD(t *testing.T) {
+	confD := setupConfD(t)
+	site := config.Site{Name: "nestapp", Domains: []string{"nestapp.test"}, ContainerPort: 3000}
+	if err := GenerateCustomVhost(site); err != nil {
+		t.Fatal(err)
+	}
+	content := readConf(t, filepath.Join(confD, "nestapp.test.conf"))
+	if !includedInsideLocation(content, "location / {", "include /etc/nginx/custom.d/nestapp.test.location.conf*;") {
+		t.Errorf("expected the location-scope include inside location /, got:\n%s", content)
+	}
+}

--- a/internal/nginx/templates/vhost-custom-ssl.conf.tmpl
+++ b/internal/nginx/templates/vhost-custom-ssl.conf.tmpl
@@ -30,6 +30,7 @@ server {
         {{- if .BackendSSL}}
         proxy_ssl_verify off;
         {{- end}}
+        include /etc/nginx/custom.d/{{.Domain}}.location.conf*;
     }
 
     include /etc/nginx/custom.d/{{.Domain}}.conf*;

--- a/internal/nginx/templates/vhost-custom.conf.tmpl
+++ b/internal/nginx/templates/vhost-custom.conf.tmpl
@@ -20,6 +20,7 @@ server {
         {{- if .BackendSSL}}
         proxy_ssl_verify off;
         {{- end}}
+        include /etc/nginx/custom.d/{{.Domain}}.location.conf*;
     }
 
     include /etc/nginx/custom.d/{{.Domain}}.conf*;

--- a/internal/nginx/templates/vhost-hostproxy-ssl.conf.tmpl
+++ b/internal/nginx/templates/vhost-hostproxy-ssl.conf.tmpl
@@ -29,6 +29,7 @@ server {
         {{- if .BackendSSL}}
         proxy_ssl_verify off;
         {{- end}}
+        include /etc/nginx/custom.d/{{.Domain}}.location.conf*;
     }
 
     include /etc/nginx/custom.d/{{.Domain}}.conf*;

--- a/internal/nginx/templates/vhost-hostproxy.conf.tmpl
+++ b/internal/nginx/templates/vhost-hostproxy.conf.tmpl
@@ -19,6 +19,7 @@ server {
         {{- if .BackendSSL}}
         proxy_ssl_verify off;
         {{- end}}
+        include /etc/nginx/custom.d/{{.Domain}}.location.conf*;
     }
 
     include /etc/nginx/custom.d/{{.Domain}}.conf*;

--- a/internal/nginx/templates/vhost-ssl.conf.tmpl
+++ b/internal/nginx/templates/vhost-ssl.conf.tmpl
@@ -79,7 +79,8 @@ server {
         fastcgi_param HTTP_COOKIE "$http_cookie; SPX_KEY=$spx_key{{if .Profiling}}; SPX_ENABLED=1{{end}}";
 {{if .LerdSite}}        fastcgi_param LERD_SITE {{.LerdSite}};
 {{end}}{{if .LerdBranch}}        fastcgi_param LERD_BRANCH {{.LerdBranch}};
-{{end}}    }
+{{end}}        include /etc/nginx/custom.d/{{.Domain}}.location.conf*;
+    }
 
     location ~ /\.ht {
         deny all;

--- a/internal/nginx/templates/vhost.conf.tmpl
+++ b/internal/nginx/templates/vhost.conf.tmpl
@@ -68,7 +68,8 @@ server {
         fastcgi_param HTTP_COOKIE "$http_cookie; SPX_KEY=$spx_key{{if .Profiling}}; SPX_ENABLED=1{{end}}";
 {{if .LerdSite}}        fastcgi_param LERD_SITE {{.LerdSite}};
 {{end}}{{if .LerdBranch}}        fastcgi_param LERD_BRANCH {{.LerdBranch}};
-{{end}}    }
+{{end}}        include /etc/nginx/custom.d/{{.Domain}}.location.conf*;
+    }
 
     location ~ /\.ht {
         deny all;

--- a/internal/siteops/nginxoverride.go
+++ b/internal/siteops/nginxoverride.go
@@ -1,6 +1,7 @@
 package siteops
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -24,26 +25,86 @@ const nginxSiteTemplate = `# Lerd per-site nginx overrides.
 # Included at the end of this site's server { } block. Lerd never overwrites
 # this file, so edits survive vhost regeneration and ` + "`lerd update`" + `. Add
 # directives valid inside a server block, then save to reload nginx.
+#
+# fastcgi_param and proxy_set_header do not belong here: nginx ignores the
+# server-level set as soon as a location declares one of its own. Use the
+# location-scope override for those.
 
 # client_max_body_size 100m;
 # location /ws { proxy_pass http://127.0.0.1:6001; proxy_http_version 1.1; }
 `
 
+// nginxLocationTemplate seeds the location-scope editor. Same never-overwritten
+// contract; the examples are the directives that only work at this level.
+const nginxLocationTemplate = `# Lerd per-site nginx overrides, location scope.
+#
+# Included at the end of the block that actually serves this site: the PHP
+# location on an FPM site, location / on a proxied one. Directives nginx
+# resolves per location land here, above all fastcgi_param and
+# proxy_set_header, which a server-scope override cannot reach.
+
+# Keep SERVER_NAME as the requested host instead of X-Forwarded-Host:
+# fastcgi_param SERVER_NAME $host;
+# fastcgi_param HTTP_HOST $host;
+`
+
+// NginxScope names which of a site's two override files to act on. Both are
+// per site and never overwritten; they differ only in where the generated
+// vhost includes them.
+type NginxScope string
+
+const (
+	NginxServerScope   NginxScope = "server"
+	NginxLocationScope NginxScope = "location"
+)
+
+// ParseNginxScope maps the wire value onto a scope, treating the empty string
+// as the server scope so existing callers and stored URLs keep working.
+func ParseNginxScope(s string) (NginxScope, error) {
+	switch NginxScope(s) {
+	case "", NginxServerScope:
+		return NginxServerScope, nil
+	case NginxLocationScope:
+		return NginxLocationScope, nil
+	}
+	return "", fmt.Errorf("unknown nginx override scope %q", s)
+}
+
+// suffix is the custom.d filename tail for the scope. The location file must
+// not match the server include's {domain}.conf* glob, hence the infix.
+func (s NginxScope) suffix() string {
+	if s == NginxLocationScope {
+		return ".location.conf"
+	}
+	return ".conf"
+}
+
+func (s NginxScope) template() string {
+	if s == NginxLocationScope {
+		return nginxLocationTemplate
+	}
+	return nginxSiteTemplate
+}
+
 // CustomNginxPath is the on-disk path of a domain's custom override.
-func CustomNginxPath(domain string) string {
-	return filepath.Join(config.NginxCustomD(), domain+".conf")
+func CustomNginxPath(domain string, scope NginxScope) string {
+	return filepath.Join(config.NginxCustomD(), domain+scope.suffix())
 }
 
 // nginxFile builds the cfgedit.File for a domain's custom override. Backups and
 // write-staging live in custom.d.bkp/, kept off the custom.d/*.conf* glob.
-func nginxFile(domain string) cfgedit.File {
+func nginxFile(domain string, scope NginxScope) cfgedit.File {
 	return cfgedit.File{
-		Path:     CustomNginxPath(domain),
+		Path:     CustomNginxPath(domain, scope),
 		BkpDir:   config.NginxCustomDBkp(),
-		BkpName:  domain + ".conf",
-		Template: nginxSiteTemplate,
+		BkpName:  domain + scope.suffix(),
+		Template: scope.template(),
 	}
 }
+
+// nginxScopes is every scope, for the whole-site operations (rename, inherit,
+// remove) that have to carry both files.
+var nginxScopes = []NginxScope{NginxServerScope, NginxLocationScope}
 
 // nginxValidate runs `nginx -t` (via the stubbable indirection) so cfgedit can
 // pre-flight a save without importing nginx itself.
@@ -51,14 +112,14 @@ func nginxValidate(string) (string, error) { return NginxTestFn() }
 
 // ReadCustomNginx returns the saved override, or the seeded template
 // (Exists=false) when nothing is on disk yet.
-func ReadCustomNginx(domain string) (cfgedit.Content, error) {
-	return nginxFile(domain).Read()
+func ReadCustomNginx(domain string, scope NginxScope) (cfgedit.Content, error) {
+	return nginxFile(domain, scope).Read()
 }
 
 // SaveCustomNginx writes, validates with `nginx -t`, rolls back on a failure
 // that names our file, and reloads nginx.
-func SaveCustomNginx(domain, content string, backup bool) (cfgedit.SaveResult, error) {
-	return nginxFile(domain).Save(content, cfgedit.SaveOpts{
+func SaveCustomNginx(domain string, scope NginxScope, content string, backup bool) (cfgedit.SaveResult, error) {
+	return nginxFile(domain, scope).Save(content, cfgedit.SaveOpts{
 		Backup:   backup,
 		Validate: nginxValidate,
 		Owns:     cfgedit.MentionsFile,
@@ -67,47 +128,56 @@ func SaveCustomNginx(domain, content string, backup bool) (cfgedit.SaveResult, e
 }
 
 // ResetCustomNginx deletes the override and reloads nginx. Backups are kept.
-func ResetCustomNginx(domain string) error {
-	return nginxFile(domain).Reset(func() error { return NginxReloadFn() })
+func ResetCustomNginx(domain string, scope NginxScope) error {
+	return nginxFile(domain, scope).Reset(func() error { return NginxReloadFn() })
 }
 
 // ListCustomNginxBackups returns a domain's override backups, newest first.
-func ListCustomNginxBackups(domain string) ([]cfgedit.Backup, error) {
-	return nginxFile(domain).ListBackups()
+func ListCustomNginxBackups(domain string, scope NginxScope) ([]cfgedit.Backup, error) {
+	return nginxFile(domain, scope).ListBackups()
 }
 
 // ReadCustomNginxBackup returns the raw bytes of one backup (os.ErrNotExist
 // when the name is invalid or the file is gone).
-func ReadCustomNginxBackup(domain, name string) ([]byte, error) {
-	return nginxFile(domain).ReadBackup(name)
+func ReadCustomNginxBackup(domain string, scope NginxScope, name string) ([]byte, error) {
+	return nginxFile(domain, scope).ReadBackup(name)
 }
 
 // RestoreCustomNginx swaps a backup over the live override and reloads nginx.
-func RestoreCustomNginx(domain, name string) (cfgedit.RestoreResult, error) {
-	return nginxFile(domain).Restore(name, func() error { return NginxReloadFn() })
+func RestoreCustomNginx(domain string, scope NginxScope, name string) (cfgedit.RestoreResult, error) {
+	return nginxFile(domain, scope).Restore(name, func() error { return NginxReloadFn() })
 }
 
 // ValidNginxBackupName reports whether name is a well-formed backup for domain.
-func ValidNginxBackupName(domain, name string) bool {
-	return nginxFile(domain).ValidBackupName(name)
+func ValidNginxBackupName(domain string, scope NginxScope, name string) bool {
+	return nginxFile(domain, scope).ValidBackupName(name)
 }
 
-// InheritCustomNginxConfig seeds a new worktree's override from its parent's:
-// it copies custom.d/{parent}.conf to custom.d/{worktree}.conf only when the
-// parent exists and the worktree override does not. Callers must invoke it only
-// on genuine worktree creation — running it on every resync would resurrect an
-// override the user deliberately reset (it can't tell "new" from "reset").
+// InheritCustomNginxConfig seeds a new worktree's overrides from its parent's:
+// it copies each scope's file only when the parent has one and the worktree
+// does not. Callers must invoke it only on genuine worktree creation — running
+// it on every resync would resurrect an override the user deliberately reset
+// (it can't tell "new" from "reset").
 func InheritCustomNginxConfig(parentDomain, worktreeDomain string) error {
 	if parentDomain == worktreeDomain {
 		return nil
 	}
-	dst := CustomNginxPath(worktreeDomain)
+	for _, scope := range nginxScopes {
+		if err := inheritOneNginxScope(parentDomain, worktreeDomain, scope); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func inheritOneNginxScope(parentDomain, worktreeDomain string, scope NginxScope) error {
+	dst := CustomNginxPath(worktreeDomain, scope)
 	if _, err := os.Stat(dst); err == nil {
 		return nil
 	} else if !os.IsNotExist(err) {
 		return err
 	}
-	data, err := os.ReadFile(CustomNginxPath(parentDomain))
+	data, err := os.ReadFile(CustomNginxPath(parentDomain, scope))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -120,21 +190,23 @@ func InheritCustomNginxConfig(parentDomain, worktreeDomain string) error {
 	return nginx.WriteFileAtomic(dst, data, 0o644)
 }
 
-// RemoveCustomNginxConfig deletes a worktree's live override and every
+// RemoveCustomNginxConfig deletes a worktree's live overrides and every
 // timestamped backup for that domain. Used when a worktree is removed.
 func RemoveCustomNginxConfig(domain string) error {
-	if err := os.Remove(CustomNginxPath(domain)); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	f := nginxFile(domain)
-	backups, err := f.ListBackups()
-	if err != nil {
-		return err
-	}
 	var firstErr error
-	for _, b := range backups {
-		if err := os.Remove(filepath.Join(f.BkpDir, b.Name)); err != nil && firstErr == nil {
-			firstErr = err
+	for _, scope := range nginxScopes {
+		if err := os.Remove(CustomNginxPath(domain, scope)); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		f := nginxFile(domain, scope)
+		backups, err := f.ListBackups()
+		if err != nil {
+			return err
+		}
+		for _, b := range backups {
+			if err := os.Remove(filepath.Join(f.BkpDir, b.Name)); err != nil && firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
 	return firstErr

--- a/internal/siteops/nginxoverride_test.go
+++ b/internal/siteops/nginxoverride_test.go
@@ -36,7 +36,7 @@ func writeOverride(t *testing.T, domain, content string) string {
 
 func TestReadCustomNginx_seedsTemplateWhenMissing(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
-	got, err := ReadCustomNginx("acme.test")
+	got, err := ReadCustomNginx("acme.test", NginxServerScope)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,14 +51,14 @@ func TestReadCustomNginx_seedsTemplateWhenMissing(t *testing.T) {
 func TestSaveCustomNginx_writesAndReloads(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	reloads := stubReloadTest(t, "test is successful", nil)
-	res, err := SaveCustomNginx("acme.test", "# v1\n", false)
+	res, err := SaveCustomNginx("acme.test", NginxServerScope, "# v1\n", false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !res.OK || *reloads != 1 {
 		t.Fatalf("res=%+v reloads=%d", res, *reloads)
 	}
-	b, _ := os.ReadFile(CustomNginxPath("acme.test"))
+	b, _ := os.ReadFile(CustomNginxPath("acme.test", NginxServerScope))
 	if string(b) != "# v1\n" {
 		t.Fatalf("on-disk content = %q", string(b))
 	}
@@ -68,14 +68,14 @@ func TestSaveCustomNginx_rollsBackWhenValidationNamesOurFile(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	stubReloadTest(t, "nginx: [emerg] invalid in /etc/nginx/custom.d/acme.test.conf:2", os.ErrInvalid)
 	writeOverride(t, "acme.test", "# good\n")
-	res, err := SaveCustomNginx("acme.test", "bogus;\n", false)
+	res, err := SaveCustomNginx("acme.test", NginxServerScope, "bogus;\n", false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if res.OK {
 		t.Fatal("expected validation failure")
 	}
-	b, _ := os.ReadFile(CustomNginxPath("acme.test"))
+	b, _ := os.ReadFile(CustomNginxPath("acme.test", NginxServerScope))
 	if string(b) != "# good\n" {
 		t.Fatalf("expected rollback, got %q", string(b))
 	}
@@ -85,7 +85,7 @@ func TestResetCustomNginx_removesFile(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	stubReloadTest(t, "ok", nil)
 	p := writeOverride(t, "acme.test", "# x\n")
-	if err := ResetCustomNginx("acme.test"); err != nil {
+	if err := ResetCustomNginx("acme.test", NginxServerScope); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(p); !os.IsNotExist(err) {
@@ -97,14 +97,14 @@ func TestListAndRestoreBackup_roundTrip(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	stubReloadTest(t, "ok", nil)
 	writeOverride(t, "acme.test", "# v1\n")
-	if _, err := SaveCustomNginx("acme.test", "# v2\n", true); err != nil {
+	if _, err := SaveCustomNginx("acme.test", NginxServerScope, "# v2\n", true); err != nil {
 		t.Fatal(err)
 	}
-	list, err := ListCustomNginxBackups("acme.test")
+	list, err := ListCustomNginxBackups("acme.test", NginxServerScope)
 	if err != nil || len(list) != 1 {
 		t.Fatalf("expected 1 backup, got %v err=%v", list, err)
 	}
-	res, err := RestoreCustomNginx("acme.test", list[0].Name)
+	res, err := RestoreCustomNginx("acme.test", NginxServerScope, list[0].Name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestInheritCustomNginxConfig_copiesOnce(t *testing.T) {
 	if err := InheritCustomNginxConfig("acme.test", "feat.acme.test"); err != nil {
 		t.Fatal(err)
 	}
-	b, err := os.ReadFile(CustomNginxPath("feat.acme.test"))
+	b, err := os.ReadFile(CustomNginxPath("feat.acme.test", NginxServerScope))
 	if err != nil || string(b) != "# parent\n" {
 		t.Fatalf("expected inherited copy, got %q err=%v", string(b), err)
 	}
@@ -132,7 +132,7 @@ func TestInheritCustomNginxConfig_doesNotClobberWorktreeEdits(t *testing.T) {
 	if err := InheritCustomNginxConfig("acme.test", "feat.acme.test"); err != nil {
 		t.Fatal(err)
 	}
-	b, _ := os.ReadFile(CustomNginxPath("feat.acme.test"))
+	b, _ := os.ReadFile(CustomNginxPath("feat.acme.test", NginxServerScope))
 	if string(b) != "# worktree-specific\n" {
 		t.Fatalf("inherit must not clobber existing worktree override, got %q", string(b))
 	}
@@ -143,7 +143,7 @@ func TestInheritCustomNginxConfig_noParentIsNoOp(t *testing.T) {
 	if err := InheritCustomNginxConfig("acme.test", "feat.acme.test"); err != nil {
 		t.Fatalf("inherit with no parent override should be a no-op, got %v", err)
 	}
-	if _, err := os.Stat(CustomNginxPath("feat.acme.test")); !os.IsNotExist(err) {
+	if _, err := os.Stat(CustomNginxPath("feat.acme.test", NginxServerScope)); !os.IsNotExist(err) {
 		t.Fatal("expected no worktree override to be created")
 	}
 }
@@ -172,5 +172,100 @@ func TestRemoveCustomNginxConfig_deletesLiveAndBackups(t *testing.T) {
 	}
 	if _, err := os.Stat(other); err != nil {
 		t.Fatal("unrelated backup must survive")
+	}
+}
+
+func TestLocationScope_isASeparateFileWithItsOwnTemplate(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	stubReloadTest(t, "ok", nil)
+	if _, err := SaveCustomNginx("acme.test", NginxLocationScope, "fastcgi_param SERVER_NAME $host;\n", false); err != nil {
+		t.Fatal(err)
+	}
+	loc := CustomNginxPath("acme.test", NginxLocationScope)
+	if filepath.Base(loc) != "acme.test.location.conf" {
+		t.Fatalf("unexpected location path %s", loc)
+	}
+	// The server include globs {domain}.conf*, so the location file must not
+	// land inside that glob or nginx would load it twice at the wrong level.
+	if strings.HasPrefix(filepath.Base(loc), "acme.test.conf") {
+		t.Fatalf("location file %s collides with the server include glob", loc)
+	}
+	server, err := ReadCustomNginx("acme.test", NginxServerScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if server.Exists {
+		t.Fatal("saving the location scope must not create the server override")
+	}
+	got, err := ReadCustomNginx("acme.test", NginxLocationScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Exists || !strings.Contains(got.Body, "SERVER_NAME") {
+		t.Fatalf("expected the saved location override, got %+v", got)
+	}
+}
+
+func TestReadCustomNginx_locationTemplateNamesTheScope(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	got, err := ReadCustomNginx("acme.test", NginxLocationScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Exists || !strings.Contains(got.Body, "location scope") {
+		t.Fatalf("expected the seeded location template, got %+v", got)
+	}
+}
+
+func TestResetCustomNginx_leavesTheOtherScopeAlone(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	stubReloadTest(t, "ok", nil)
+	writeOverride(t, "acme.test", "# server\n")
+	if _, err := SaveCustomNginx("acme.test", NginxLocationScope, "# location\n", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := ResetCustomNginx("acme.test", NginxLocationScope); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(CustomNginxPath("acme.test", NginxLocationScope)); !os.IsNotExist(err) {
+		t.Fatalf("expected the location override gone, err=%v", err)
+	}
+	if b, err := os.ReadFile(CustomNginxPath("acme.test", NginxServerScope)); err != nil || string(b) != "# server\n" {
+		t.Fatalf("server override should survive, got %q err=%v", string(b), err)
+	}
+}
+
+func TestInheritAndRemoveCustomNginxConfig_coverBothScopes(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	writeOverride(t, "acme.test", "# server\n")
+	if err := os.WriteFile(CustomNginxPath("acme.test", NginxLocationScope), []byte("# location\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := InheritCustomNginxConfig("acme.test", "feat.acme.test"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(CustomNginxPath("feat.acme.test", NginxLocationScope))
+	if err != nil || string(b) != "# location\n" {
+		t.Fatalf("expected the location override inherited, got %q err=%v", string(b), err)
+	}
+	if err := RemoveCustomNginxConfig("feat.acme.test"); err != nil {
+		t.Fatal(err)
+	}
+	for _, scope := range nginxScopes {
+		if _, err := os.Stat(CustomNginxPath("feat.acme.test", scope)); !os.IsNotExist(err) {
+			t.Fatalf("expected %s override removed, err=%v", scope, err)
+		}
+	}
+}
+
+func TestParseNginxScope(t *testing.T) {
+	for in, want := range map[string]NginxScope{"": NginxServerScope, "server": NginxServerScope, "location": NginxLocationScope} {
+		got, err := ParseNginxScope(in)
+		if err != nil || got != want {
+			t.Fatalf("ParseNginxScope(%q) = %q, %v", in, got, err)
+		}
+	}
+	if _, err := ParseNginxScope("http"); err == nil {
+		t.Fatal("expected an unknown scope to be refused")
 	}
 }

--- a/internal/siteops/vhost.go
+++ b/internal/siteops/vhost.go
@@ -74,32 +74,47 @@ func RegenerateSiteVhost(site *config.Site, oldPrimary string) error {
 }
 
 // MoveCustomNginxConfig follows a site's hand-authored nginx overrides across a
-// primary-domain rename. The main snippet lives at custom.d/{primary}.conf and
-// each worktree's at custom.d/{branch}.{primary}.conf; the generated vhosts
-// include them by name, so without this they are orphaned and the renamed site
-// (and its worktrees) silently lose their custom config. Timestamped backups in
-// custom.d.bkp/ are keyed the same way and moved too so the UI restore dropdown
-// keeps working. Missing files are not an error; renames far outnumber edits.
+// primary-domain rename. Each scope's main snippet lives at custom.d/{primary}
+// plus the scope suffix and each worktree's at custom.d/{branch}.{primary}
+// plus it; the generated vhosts include them by name, so without this they are
+// orphaned and the renamed site (and its worktrees) silently lose their custom
+// config. Timestamped backups in custom.d.bkp/ are keyed the same way and moved
+// too so the UI restore dropdown keeps working. Missing files are not an error;
+// renames far outnumber edits.
 func MoveCustomNginxConfig(oldPrimary, newPrimary string) error {
 	if oldPrimary == newPrimary {
 		return nil
 	}
+	var firstErr error
+	for _, scope := range nginxScopes {
+		if err := moveCustomNginxScope(oldPrimary, newPrimary, scope.suffix()); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// moveCustomNginxScope moves one scope's live override and backups. The suffix
+// is the scope's filename tail (".conf" or ".location.conf"); the two never
+// collide because no name ending in ".location.conf" also ends in ".conf"
+// preceded by the primary domain.
+func moveCustomNginxScope(oldPrimary, newPrimary, suffix string) error {
 	live := config.NginxCustomD()
 	// The main override is keyed solely by primary domain, so any file already
 	// at the new name can only be a stale orphan from a prior rename (active
 	// sites cannot share a primary), hence clobber=true.
 	if err := moveFile(
-		filepath.Join(live, oldPrimary+".conf"),
-		filepath.Join(live, newPrimary+".conf"),
+		filepath.Join(live, oldPrimary+suffix),
+		filepath.Join(live, newPrimary+suffix),
 		true,
 	); err != nil {
 		return err
 	}
 	var firstErr error
-	// Worktree overrides ({branch}.{oldPrimary}.conf) must rewrite the primary
+	// Worktree overrides ({branch}.{oldPrimary}{suffix}) must rewrite the primary
 	// suffix while preserving the branch prefix, else the renamed worktree loses
 	// its config and re-inherits the main one on the next daemon resync.
-	wtSuffix := "." + oldPrimary + ".conf"
+	wtSuffix := "." + oldPrimary + suffix
 	if liveEntries, err := os.ReadDir(live); err == nil {
 		for _, e := range liveEntries {
 			name := e.Name()
@@ -115,7 +130,7 @@ func MoveCustomNginxConfig(oldPrimary, newPrimary string) error {
 			}
 			if err := moveFile(
 				filepath.Join(live, name),
-				filepath.Join(live, branch+"."+newPrimary+".conf"),
+				filepath.Join(live, branch+"."+newPrimary+suffix),
 				true,
 			); err != nil && firstErr == nil {
 				firstErr = err
@@ -133,11 +148,11 @@ func MoveCustomNginxConfig(oldPrimary, newPrimary string) error {
 		}
 		return err
 	}
-	// Move both main ({oldPrimary}.conf.bkp.*) and worktree
-	// ({branch}.{oldPrimary}.conf.bkp.*) backups, never clobbering so a
+	// Move both main ({oldPrimary}{suffix}.bkp.*) and worktree
+	// ({branch}.{oldPrimary}{suffix}.bkp.*) backups, never clobbering so a
 	// same-second collision can't destroy recoverable history.
-	mainPrefix := oldPrimary + ".conf.bkp."
-	wtMarker := "." + oldPrimary + ".conf.bkp."
+	mainPrefix := oldPrimary + suffix + ".bkp."
+	wtMarker := "." + oldPrimary + suffix + ".bkp."
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
@@ -146,7 +161,7 @@ func MoveCustomNginxConfig(oldPrimary, newPrimary string) error {
 		var newName string
 		switch {
 		case strings.HasPrefix(name, mainPrefix):
-			newName = newPrimary + ".conf.bkp." + strings.TrimPrefix(name, mainPrefix)
+			newName = newPrimary + suffix + ".bkp." + strings.TrimPrefix(name, mainPrefix)
 		case strings.Contains(name, wtMarker):
 			idx := strings.Index(name, wtMarker)
 			if idx <= 0 {
@@ -155,7 +170,7 @@ func MoveCustomNginxConfig(oldPrimary, newPrimary string) error {
 			if _, err := config.FindSiteByDomain(name[:idx] + "." + oldPrimary); err == nil {
 				continue // sibling site's backup, not our worktree's
 			}
-			newName = name[:idx] + "." + newPrimary + ".conf.bkp." + name[idx+len(wtMarker):]
+			newName = name[:idx] + "." + newPrimary + suffix + ".bkp." + name[idx+len(wtMarker):]
 		default:
 			continue
 		}

--- a/internal/siteops/vhost_test.go
+++ b/internal/siteops/vhost_test.go
@@ -179,3 +179,35 @@ func TestMoveCustomNginxConfig_samePrimaryIsNoop(t *testing.T) {
 		t.Errorf("override disturbed by same-domain call: %q err=%v", body, err)
 	}
 }
+
+// The location-scope override is keyed by the same primary domain, so a rename
+// has to carry it and its backups too or the renamed site silently loses the
+// only file that can override fastcgi_param.
+func TestMoveCustomNginxConfig_carriesLocationScope(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	live := config.NginxCustomD()
+	bkp := config.NginxCustomDBkp()
+	seedFile(t, filepath.Join(live, "leasebook.test.location.conf"), "# main location\n")
+	seedFile(t, filepath.Join(live, "feat.leasebook.test.location.conf"), "# worktree location\n")
+	seedFile(t, filepath.Join(bkp, "leasebook.test.location.conf.bkp.20260101-101010"), "# location backup\n")
+
+	if err := MoveCustomNginxConfig("leasebook.test", "rentals.test"); err != nil {
+		t.Fatalf("MoveCustomNginxConfig: %v", err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(live, "rentals.test.location.conf"))
+	if err != nil || string(body) != "# main location\n" {
+		t.Errorf("main location override = %q err=%v; want content under new domain", body, err)
+	}
+	body, err = os.ReadFile(filepath.Join(live, "feat.rentals.test.location.conf"))
+	if err != nil || string(body) != "# worktree location\n" {
+		t.Errorf("worktree location override = %q err=%v; want content under new domain", body, err)
+	}
+	if _, err := os.Stat(filepath.Join(bkp, "rentals.test.location.conf.bkp.20260101-101010")); err != nil {
+		t.Errorf("location backup not carried across: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(live, "leasebook.test.location.conf")); !os.IsNotExist(err) {
+		t.Errorf("old location override still present, want renamed")
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -3611,6 +3611,17 @@ type SiteNginxRestoreResponse struct {
 	Content  string `json:"content,omitempty"`
 }
 
+// nginxScopeParam reads the ?scope= query param. Absent means the server-scope
+// override, so older clients and bookmarked URLs keep hitting the same file.
+func nginxScopeParam(w http.ResponseWriter, r *http.Request) (siteops.NginxScope, bool) {
+	scope, err := siteops.ParseNginxScope(r.URL.Query().Get("scope"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return "", false
+	}
+	return scope, true
+}
+
 // handleSiteNginx reads (GET) or saves (POST) a site's custom.d nginx override.
 // The override is bind-mounted into lerd-nginx and included at the end of the
 // site's server block; saving reloads nginx so the change takes effect. The
@@ -3621,8 +3632,12 @@ func handleSiteNginx(w http.ResponseWriter, r *http.Request, domain string) {
 		http.Error(w, "site not found", http.StatusNotFound)
 		return
 	}
+	scope, ok := nginxScopeParam(w, r)
+	if !ok {
+		return
+	}
 	if r.Method == http.MethodGet {
-		got, err := siteops.ReadCustomNginx(domain)
+		got, err := siteops.ReadCustomNginx(domain, scope)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -3637,7 +3652,7 @@ func handleSiteNginx(w http.ResponseWriter, r *http.Request, domain string) {
 		writeJSON(w, SiteNginxWriteResponse{OK: false, Error: "invalid body: " + err.Error()})
 		return
 	}
-	res, err := siteops.SaveCustomNginx(domain, req.Content, req.Backup)
+	res, err := siteops.SaveCustomNginx(domain, scope, req.Content, req.Backup)
 	if err != nil {
 		writeJSON(w, SiteNginxWriteResponse{OK: false, Error: err.Error()})
 		return
@@ -3656,7 +3671,11 @@ func handleSiteNginxBackups(w http.ResponseWriter, r *http.Request, domain strin
 		http.NotFound(w, r)
 		return
 	}
-	list, err := siteops.ListCustomNginxBackups(domain)
+	scope, ok := nginxScopeParam(w, r)
+	if !ok {
+		return
+	}
+	list, err := siteops.ListCustomNginxBackups(domain, scope)
 	if err != nil {
 		http.Error(w, "listing backups: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -3679,7 +3698,11 @@ func handleSiteNginxBackupContent(w http.ResponseWriter, r *http.Request, domain
 		http.NotFound(w, r)
 		return
 	}
-	data, err := siteops.ReadCustomNginxBackup(domain, name)
+	scope, ok := nginxScopeParam(w, r)
+	if !ok {
+		return
+	}
+	data, err := siteops.ReadCustomNginxBackup(domain, scope, name)
 	if err != nil {
 		if os.IsNotExist(err) {
 			http.NotFound(w, r)
@@ -3715,7 +3738,11 @@ func handleSiteNginxReset(w http.ResponseWriter, r *http.Request, domain string)
 		http.NotFound(w, r)
 		return
 	}
-	if err := siteops.ResetCustomNginx(domain); err != nil {
+	scope, ok := nginxScopeParam(w, r)
+	if !ok {
+		return
+	}
+	if err := siteops.ResetCustomNginx(domain, scope); err != nil {
 		writeJSON(w, SiteNginxResetResponse{OK: false, Error: err.Error()})
 		return
 	}
@@ -3739,6 +3766,10 @@ func handleSiteNginxRestore(w http.ResponseWriter, r *http.Request, domain strin
 		http.NotFound(w, r)
 		return
 	}
+	scope, ok := nginxScopeParam(w, r)
+	if !ok {
+		return
+	}
 	var req SiteNginxRestoreRequest
 	// Body is optional (empty name means newest); only a malformed envelope
 	// is refused.
@@ -3748,7 +3779,7 @@ func handleSiteNginxRestore(w http.ResponseWriter, r *http.Request, domain strin
 			return
 		}
 	}
-	res, err := siteops.RestoreCustomNginx(domain, req.Name)
+	res, err := siteops.RestoreCustomNginx(domain, scope, req.Name)
 	if err != nil {
 		writeJSON(w, SiteNginxRestoreResponse{OK: false, Error: err.Error()})
 		return

--- a/internal/ui/site_nginx_test.go
+++ b/internal/ui/site_nginx_test.go
@@ -222,7 +222,7 @@ func TestHandleSiteNginx_postWithBackupRollsExisting(t *testing.T) {
 	if !resp.OK || resp.BackupName == "" {
 		t.Fatalf("want ok with backup name, got %+v", resp)
 	}
-	if !siteops.ValidNginxBackupName("acme.test", resp.BackupName) {
+	if !siteops.ValidNginxBackupName("acme.test", siteops.NginxServerScope, resp.BackupName) {
 		t.Errorf("backup name shape: %q", resp.BackupName)
 	}
 	// The backup must live OUTSIDE custom.d/ so the include glob does not
@@ -721,5 +721,64 @@ func TestHandleSiteNginxRestore_reloadFailurePreservesBackup(t *testing.T) {
 	// Backup must NOT have been removed; the user needs it to retry.
 	if _, err := os.Stat(filepath.Join(bkpDir, name)); err != nil {
 		t.Errorf("backup must survive reload failure: %v", err)
+	}
+}
+
+func TestHandleSiteNginx_scopeParamSelectsTheLocationFile(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	stubNginxReload(t)
+	stubNginxTest(t, "test is successful", nil)
+
+	if err := config.AddSite(config.Site{Name: "acme", Path: t.TempDir(), Domains: []string{"acme.test"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	body := bytes.NewBufferString(`{"content":"fastcgi_param SERVER_NAME $host;\n","backup":false}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/nginx?scope=location", body)
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/sites/acme.test/nginx?scope=location", nil)
+	rec = httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	var resp SiteNginxReadResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.HasSuffix(resp.Path, "/custom.d/acme.test.location.conf") {
+		t.Errorf("path: got %q want the location file", resp.Path)
+	}
+	if !resp.Exists || !strings.Contains(resp.Content, "SERVER_NAME") {
+		t.Errorf("expected the saved location override, got %+v", resp)
+	}
+
+	// The server-scope file must be untouched by a location-scope save.
+	req = httptest.NewRequest(http.MethodGet, "/api/sites/acme.test/nginx", nil)
+	rec = httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	resp = SiteNginxReadResponse{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Exists {
+		t.Errorf("server-scope override should not exist, got %+v", resp)
+	}
+}
+
+func TestHandleSiteNginx_unknownScopeIsRejected(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := config.AddSite(config.Site{Name: "acme", Path: t.TempDir(), Domains: []string{"acme.test"}}); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/sites/acme.test/nginx?scope=http", nil)
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400: %s", rec.Code, rec.Body.String())
 	}
 }

--- a/internal/ui/web/src/modals/ConfirmNginxResetModal.svelte
+++ b/internal/ui/web/src/modals/ConfirmNginxResetModal.svelte
@@ -21,7 +21,7 @@
     busy = true;
     error = '';
     try {
-      const res = await resetSiteNginx(target.domain);
+      const res = await resetSiteNginx(target.domain, target.scope);
       if (!res.ok) {
         error = res.error || m.nginxEditor_resetFailed();
         return;

--- a/internal/ui/web/src/modals/ConfirmNginxRestoreModal.svelte
+++ b/internal/ui/web/src/modals/ConfirmNginxRestoreModal.svelte
@@ -32,7 +32,7 @@
       // Pass the EXACT backup name the user just previewed in the diff so
       // a concurrent save that landed a newer backup between modal-open
       // and accept cannot silently swap a different file into place.
-      const res = await restoreSiteNginx(target.domain, target.backupName);
+      const res = await restoreSiteNginx(target.domain, target.scope, target.backupName);
       if (!res.ok) {
         error = res.error || m.nginxEditor_restoreFailed();
         return;

--- a/internal/ui/web/src/modals/ConfirmNginxSaveModal.svelte
+++ b/internal/ui/web/src/modals/ConfirmNginxSaveModal.svelte
@@ -28,7 +28,7 @@
     error = '';
     validationOutput = '';
     try {
-      const res = await saveSiteNginx(target.domain, target.content, backup);
+      const res = await saveSiteNginx(target.domain, target.scope, target.content, backup);
       if (!res.ok) {
         error = res.error || m.nginxEditor_saveFailed();
         // The validation output carries nginx's actual line-and-directive

--- a/internal/ui/web/src/modals/SiteNginxModal.stub.svelte
+++ b/internal/ui/web/src/modals/SiteNginxModal.stub.svelte
@@ -3,10 +3,11 @@
   interface Props {
     site: Site;
     domain?: string;
+    scope?: string;
     onSaved?: () => void;
   }
-  let { site, domain, onSaved = () => {} }: Props = $props();
+  let { site, domain, scope = 'server', onSaved = () => {} }: Props = $props();
 </script>
 
-<div data-testid="nginx-editor-stub">{domain || site.domain}</div>
+<div data-testid="nginx-editor-stub" data-scope={scope}>{domain || site.domain}</div>
 <button data-testid="stub-saved" onclick={() => onSaved()}>save</button>

--- a/internal/ui/web/src/modals/SiteNginxModal.svelte
+++ b/internal/ui/web/src/modals/SiteNginxModal.svelte
@@ -21,7 +21,11 @@
   // tab; the FrankenPHP container mounts the shared 98-lerd-user.ini, so edits
   // apply to it after the save restarts the container.
   const showPhpIni = $derived(site.runtime === 'frankenphp' && Boolean(site.php_version));
-  let tab = $state<'nginx' | 'phpini'>('nginx');
+
+  // Server scope is included at the end of the server block; location scope
+  // inside the block that serves the site, which is the only level where a
+  // fastcgi_param or proxy_set_header override survives.
+  let tab = $state<'server' | 'location' | 'phpini'>('server');
 
   // Save/Restore/Reset open their own confirm modal on top of this one via
   // the shared modal store. While one is up it owns Escape and the backdrop,
@@ -31,7 +35,7 @@
     onclose();
   }
 
-  const tabBtn = (id: 'nginx' | 'phpini') =>
+  const tabBtn = (id: 'server' | 'location' | 'phpini') =>
     'px-3 py-1.5 text-xs font-medium border-b-2 transition-colors ' +
     (tab === id
       ? 'border-lerd-red text-lerd-red'
@@ -40,20 +44,23 @@
 
 <Modal {open} title={m.sites_nginx_modalTitle({ domain })} onclose={handleClose} size="xl">
   <div class="h-[70vh] flex flex-col overflow-hidden rounded-b-xl">
-    {#if showPhpIni}
-      <div class="flex gap-1 px-3 pt-1 border-b border-gray-200 dark:border-gray-700 shrink-0">
-        <button class={tabBtn('nginx')} onclick={() => (tab = 'nginx')}>Nginx</button>
+    <div class="flex gap-1 px-3 pt-1 border-b border-gray-200 dark:border-gray-700 shrink-0">
+      <button class={tabBtn('server')} onclick={() => (tab = 'server')}>Server block</button>
+      <button class={tabBtn('location')} onclick={() => (tab = 'location')}>Location</button>
+      {#if showPhpIni}
         <button class={tabBtn('phpini')} onclick={() => (tab = 'phpini')}>php.ini</button>
-      </div>
-    {/if}
+      {/if}
+    </div>
     <div class="flex-1 min-h-0 overflow-hidden">
       {#if showPhpIni && tab === 'phpini'}
         <!-- Per-site scope: a FrankenPHP site has its own php.ini, edited via the
              same per-version editor keyed by a "site:<name>" scope token. -->
         <PhpIniTab version={`site:${site.name}`} />
       {:else}
-        {#key domain}
-          <SiteNginxTab {site} {domain} onSaved={onclose} />
+        <!-- Keyed on scope as well as domain so switching tabs remounts the
+             editor and reloads the other file instead of keeping the buffer. -->
+        {#key `${domain}:${tab}`}
+          <SiteNginxTab {site} {domain} scope={tab === 'location' ? 'location' : 'server'} onSaved={onclose} />
         {/key}
       {/if}
     </div>

--- a/internal/ui/web/src/modals/SiteNginxModal.test.ts
+++ b/internal/ui/web/src/modals/SiteNginxModal.test.ts
@@ -31,6 +31,15 @@ describe('SiteNginxModal', () => {
     expect(screen.getByTestId('nginx-editor-stub')).toHaveTextContent('feat.acme.test');
   });
 
+  it('switches the editor to the location-scope file from the Location tab', async () => {
+    render(Harness, { props: { open: true, site, domain: 'acme.test', onclose: () => {} } });
+    expect(screen.getByTestId('nginx-editor-stub')).toHaveAttribute('data-scope', 'server');
+    await fireEvent.click(screen.getByText('Location'));
+    expect(screen.getByTestId('nginx-editor-stub')).toHaveAttribute('data-scope', 'location');
+    await fireEvent.click(screen.getByText('Server block'));
+    expect(screen.getByTestId('nginx-editor-stub')).toHaveAttribute('data-scope', 'server');
+  });
+
   it('closes the editor after a successful save', async () => {
     const onclose = vi.fn();
     render(Harness, { props: { open: true, site, domain: 'acme.test', onclose } });
@@ -50,7 +59,7 @@ describe('SiteNginxModal', () => {
     render(Harness, { props: { open: true, site, domain: 'acme.test', onclose } });
     modal.set({
       kind: 'nginxSave',
-      nginxSave: { domain: 'acme.test', content: '', original: '', exists: true }
+      nginxSave: { domain: 'acme.test', scope: 'server', content: '', original: '', exists: true }
     });
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
     expect(onclose).not.toHaveBeenCalled();

--- a/internal/ui/web/src/stores/modals.ts
+++ b/internal/ui/web/src/stores/modals.ts
@@ -1,5 +1,5 @@
 import { writable } from "svelte/store";
-import type { Site, EnvProposeEntry } from "./sites";
+import type { Site, EnvProposeEntry, NginxScope } from "./sites";
 
 export type ModalKind =
   | "domain"
@@ -78,6 +78,7 @@ export interface EnvDuplicatesTarget {
 
 export interface NginxSaveTarget {
   domain: string;
+  scope: NginxScope;
   content: string;
   original: string;
   /** True when the live override already exists on disk. When false, the
@@ -88,6 +89,7 @@ export interface NginxSaveTarget {
 
 export interface NginxRestoreTarget {
   domain: string;
+  scope: NginxScope;
   current: string;
   backupName: string;
   backup: string;
@@ -95,6 +97,7 @@ export interface NginxRestoreTarget {
 
 export interface NginxResetTarget {
   domain: string;
+  scope: NginxScope;
   path: string;
 }
 

--- a/internal/ui/web/src/stores/sites.actions.test.ts
+++ b/internal/ui/web/src/stores/sites.actions.test.ts
@@ -28,10 +28,27 @@ describe('sites actions', () => {
       async () => new Response(JSON.stringify({ path: '/x/custom.d/a.test.conf', content: '# snippet\n', exists: true }), { status: 200 })
     ) as unknown as typeof fetch;
     const { getSiteNginx } = await import('./sites');
-    const res = await getSiteNginx('a.test');
+    const res = await getSiteNginx('a.test', 'server');
     expect(res.path).toContain('a.test.conf');
     expect(res.content).toContain('# snippet');
     expect(res.exists).toBe(true);
+  });
+
+  it('nginx calls tag the location scope on the URL and leave server scope bare', async () => {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (url: unknown) => {
+      calls.push(String(url));
+      return new Response('{"ok":true}', { status: 200 });
+    }) as unknown as typeof fetch;
+    const { resetSiteNginx, loadSiteNginxBackups } = await import('./sites');
+    await resetSiteNginx('a.test', 'location');
+    await loadSiteNginxBackups('a.test', 'location');
+    await resetSiteNginx('a.test', 'server');
+    expect(calls).toEqual([
+      '/api/sites/a.test/nginx/reset?scope=location',
+      '/api/sites/a.test/nginx/backups?scope=location',
+      '/api/sites/a.test/nginx/reset'
+    ]);
   });
 
   it('saveSiteNginx POSTs the content and backup flag to /nginx', async () => {
@@ -48,7 +65,7 @@ describe('sites actions', () => {
       );
     }) as unknown as typeof fetch;
     const { saveSiteNginx } = await import('./sites');
-    const res = await saveSiteNginx('a.test', 'client_max_body_size 100m;\n', true);
+    const res = await saveSiteNginx('a.test', 'server', 'client_max_body_size 100m;\n', true);
     expect(res.ok).toBe(true);
     expect(res.backupName).toBe('a.test.conf.bkp.20260528-101010');
     expect(res.validationOutput).toBe('nginx -t ok');
@@ -73,7 +90,7 @@ describe('sites actions', () => {
         )
     ) as unknown as typeof fetch;
     const { saveSiteNginx } = await import('./sites');
-    const res = await saveSiteNginx('a.test', 'oops;\n');
+    const res = await saveSiteNginx('a.test', 'server', 'oops;\n');
     expect(res.ok).toBe(false);
     expect(res.error).toContain('rolled back');
     expect(res.validationOutput).toContain('unknown directive');
@@ -93,7 +110,7 @@ describe('sites actions', () => {
         )
     ) as unknown as typeof fetch;
     const { saveSiteNginx } = await import('./sites');
-    const res = await saveSiteNginx('a.test', 'client_max_body_size 100m;\n');
+    const res = await saveSiteNginx('a.test', 'server', 'client_max_body_size 100m;\n');
     expect(res.ok).toBe(true);
     expect(res.content).toContain('client_max_body_size');
     expect(res.exists).toBe(true);
@@ -106,7 +123,7 @@ describe('sites actions', () => {
       return new Response('{"ok":true}', { status: 200 });
     }) as unknown as typeof fetch;
     const { saveSiteNginx } = await import('./sites');
-    await saveSiteNginx('a.test', 'x;\n');
+    await saveSiteNginx('a.test', 'server', 'x;\n');
     expect(JSON.parse(String(calls[0][1]?.body))).toEqual({ content: 'x;\n', backup: false });
   });
 
@@ -115,7 +132,7 @@ describe('sites actions', () => {
       async () => new Response('[{"name":"a.test.conf.bkp.20260528-101010","mtime_unix":1}]', { status: 200 })
     ) as unknown as typeof fetch;
     const { loadSiteNginxBackups } = await import('./sites');
-    const res = await loadSiteNginxBackups('a.test');
+    const res = await loadSiteNginxBackups('a.test', 'server');
     expect(res.ok).toBe(true);
     expect(res.list).toEqual([{ name: 'a.test.conf.bkp.20260528-101010', mtime_unix: 1 }]);
     expect(res.error).toBeUndefined();
@@ -130,7 +147,7 @@ describe('sites actions', () => {
       async () => new Response('internal error', { status: 500 })
     ) as unknown as typeof fetch;
     const { loadSiteNginxBackups } = await import('./sites');
-    const res = await loadSiteNginxBackups('a.test');
+    const res = await loadSiteNginxBackups('a.test', 'server');
     expect(res.ok).toBe(false);
     expect(res.list).toEqual([]);
     expect(res.error).toMatch(/500/);
@@ -143,7 +160,7 @@ describe('sites actions', () => {
       return new Response('{"ok":true}', { status: 200 });
     }) as unknown as typeof fetch;
     const { resetSiteNginx } = await import('./sites');
-    const r = await resetSiteNginx('a.test');
+    const r = await resetSiteNginx('a.test', 'server');
     expect(r.ok).toBe(true);
     expect(calls[0][0]).toBe('/api/sites/a.test/nginx/reset');
     expect(calls[0][1]?.method).toBe('POST');
@@ -163,7 +180,7 @@ describe('sites actions', () => {
       );
     }) as unknown as typeof fetch;
     const { restoreSiteNginx } = await import('./sites');
-    const r = await restoreSiteNginx('a.test', 'a.test.conf.bkp.20260528-101010');
+    const r = await restoreSiteNginx('a.test', 'server', 'a.test.conf.bkp.20260528-101010');
     expect(calls[0][0]).toBe('/api/sites/a.test/nginx/restore');
     expect(JSON.parse(String(calls[0][1]?.body))).toEqual({
       name: 'a.test.conf.bkp.20260528-101010'

--- a/internal/ui/web/src/stores/sites.ts
+++ b/internal/ui/web/src/stores/sites.ts
@@ -519,17 +519,30 @@ export interface LoadNginxBackupsResult {
   error?: string;
 }
 
-export async function getSiteNginx(domain: string): Promise<SiteNginx> {
-  return apiJson<SiteNginx>(site(domain, 'nginx'));
+/** NginxScope picks which of a site's two custom.d override files a call
+ *  targets: the one included at the end of the server block, or the one
+ *  included inside the block that serves the site. Only the latter can
+ *  override fastcgi_param and proxy_set_header, which nginx resolves per
+ *  location and never inherits once a location declares its own. */
+export type NginxScope = 'server' | 'location';
+
+/** Server scope is the default on the backend, so its URL stays unqualified
+ *  and every previously bookmarked nginx URL keeps hitting the same file. */
+const nginxURL = (domain: string, scope: NginxScope, sub = '') =>
+  site(domain, 'nginx') + sub + (scope === 'location' ? '?scope=location' : '');
+
+export async function getSiteNginx(domain: string, scope: NginxScope): Promise<SiteNginx> {
+  return apiJson<SiteNginx>(nginxURL(domain, scope));
 }
 
 export async function saveSiteNginx(
   domain: string,
+  scope: NginxScope,
   content: string,
   backup: boolean = false
 ): Promise<SaveNginxResult> {
   try {
-    const res = await apiFetch(site(domain, 'nginx'), {
+    const res = await apiFetch(nginxURL(domain, scope), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ content, backup })
@@ -555,9 +568,12 @@ export async function saveSiteNginx(
   }
 }
 
-export async function loadSiteNginxBackups(domain: string): Promise<LoadNginxBackupsResult> {
+export async function loadSiteNginxBackups(
+  domain: string,
+  scope: NginxScope
+): Promise<LoadNginxBackupsResult> {
   try {
-    const res = await apiFetch(site(domain, 'nginx') + '/backups');
+    const res = await apiFetch(nginxURL(domain, scope, '/backups'));
     if (!res.ok) {
       return { ok: false, list: [], error: m.common_backupsLoadFailed({ status: res.status }) };
     }
@@ -568,8 +584,12 @@ export async function loadSiteNginxBackups(domain: string): Promise<LoadNginxBac
   }
 }
 
-export async function loadSiteNginxBackupContent(domain: string, name: string): Promise<string> {
-  const res = await apiFetch(site(domain, 'nginx') + '/backups/' + encodeURIComponent(name));
+export async function loadSiteNginxBackupContent(
+  domain: string,
+  scope: NginxScope,
+  name: string
+): Promise<string> {
+  const res = await apiFetch(nginxURL(domain, scope, '/backups/' + encodeURIComponent(name)));
   if (!res.ok) throw new Error(m.common_backupLoadFailed({ status: res.status }));
   return await res.text();
 }
@@ -579,9 +599,12 @@ export interface ResetNginxResult {
   error?: string;
 }
 
-export async function resetSiteNginx(domain: string): Promise<ResetNginxResult> {
+export async function resetSiteNginx(
+  domain: string,
+  scope: NginxScope
+): Promise<ResetNginxResult> {
   try {
-    const res = await apiFetch(site(domain, 'nginx') + '/reset', { method: 'POST' });
+    const res = await apiFetch(nginxURL(domain, scope, '/reset'), { method: 'POST' });
     const data = (await res.json()) as { ok?: boolean; error?: string };
     return { ok: Boolean(data.ok), error: data.error };
   } catch (e) {
@@ -591,10 +614,11 @@ export async function resetSiteNginx(domain: string): Promise<ResetNginxResult> 
 
 export async function restoreSiteNginx(
   domain: string,
+  scope: NginxScope,
   name: string = ''
 ): Promise<RestoreNginxResult> {
   try {
-    const res = await apiFetch(site(domain, 'nginx') + '/restore', {
+    const res = await apiFetch(nginxURL(domain, scope, '/restore'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name })

--- a/internal/ui/web/src/tabs/sites/SiteNginxTab.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteNginxTab.svelte
@@ -5,6 +5,7 @@
     getSiteNginx,
     loadSiteNginxBackups,
     loadSiteNginxBackupContent,
+    type NginxScope,
     type Site,
     type SiteNginxBackup
   } from '$stores/sites';
@@ -16,10 +17,13 @@
     /** Domain whose override to edit. Defaults to the site's primary domain;
      *  pass a worktree's domain to edit that worktree's override instead. */
     domain?: string;
+    /** Which override file to edit: the server block one, or the one included
+     *  inside the block that serves the site. */
+    scope?: NginxScope;
     /** Called after a successful save so the host can close the editor. */
     onSaved?: () => void;
   }
-  let { site, domain, onSaved = () => {} }: Props = $props();
+  let { site, domain, scope = 'server', onSaved = () => {} }: Props = $props();
 
   let original = $state<string>('');
   let text = $state<string>('');
@@ -68,7 +72,7 @@
     text = '';
     path = '';
     backups = [];
-    Promise.all([getSiteNginx(domain), loadSiteNginxBackups(domain)])
+    Promise.all([getSiteNginx(domain, scope), loadSiteNginxBackups(domain, scope)])
       .then(([res, listRes]) => {
         if (currentDomain !== domain) return;
         original = res.content;
@@ -117,8 +121,8 @@
   async function refreshAfterAction(domain: string) {
     try {
       const [res, listRes] = await Promise.all([
-        getSiteNginx(domain),
-        loadSiteNginxBackups(domain)
+        getSiteNginx(domain, scope),
+        loadSiteNginxBackups(domain, scope)
       ]);
       if (currentDomain !== domain) return;
       original = res.content;
@@ -151,10 +155,11 @@
     try {
       const restoredDomain = currentDomain;
       const restoredName = latestBackup.name;
-      const backupContent = await loadSiteNginxBackupContent(restoredDomain, restoredName);
+      const backupContent = await loadSiteNginxBackupContent(restoredDomain, scope, restoredName);
       openNginxRestoreModal(
         {
           domain: restoredDomain,
+          scope,
           current: original,
           backupName: restoredName,
           backup: backupContent
@@ -164,7 +169,7 @@
           original = backupContent;
           text = backupContent;
           exists = true;
-          const listRes = await loadSiteNginxBackups(restoredDomain);
+          const listRes = await loadSiteNginxBackups(restoredDomain, scope);
           if (currentDomain !== restoredDomain) return;
           if (listRes.ok) {
             backups = listRes.list;
@@ -197,7 +202,7 @@
   // bundled-template state with exists=false.
   function reset() {
     const resetDomain = currentDomain;
-    openNginxResetModal({ domain: resetDomain, path }, () => refreshAfterAction(resetDomain));
+    openNginxResetModal({ domain: resetDomain, scope, path }, () => refreshAfterAction(resetDomain));
   }
 
   function save() {
@@ -208,7 +213,7 @@
     // remounts and reloads the saved file from disk, so there's no stale
     // dirty/backup state to refresh.
     openNginxSaveModal(
-      { domain: savedDomain, content: text, original, exists },
+      { domain: savedDomain, scope, content: text, original, exists },
       () => onSaved()
     );
   }


### PR DESCRIPTION
A site's custom.d override is included at the end of its server block, which means it can never win against anything the generated vhost sets inside a location. Nginx resolves fastcgi_param and proxy_set_header per location and drops the inherited set the moment a location declares one of its own, so a fastcgi_param written at server scope never reaches PHP. The practical consequence is that the forwarded host wiring cannot be changed for a single site: a project served through a tunnel always gets SERVER_NAME and HTTP_HOST rewritten to X-Forwarded-Host, and a codebase that compares SERVER_NAME against its own configuration has to hand edit the generated vhost, which the next regeneration wipes.

Every generated vhost now carries a second include, custom.d/{domain}.location.conf, placed at the very end of the block that actually serves the site, the php location on an FPM site and location / on a proxied one. A directive repeated there lands after everything lerd sets, so it wins.

The new file is a first class override rather than one you are left to manage by hand. A site's nginx modal is now tabbed, Server block and Location, both running the same editor with nginx -t validation, backups, restore and reset. The CLI takes --location on show, edit and reset, and the MCP site tool takes a scope property. The file follows a primary domain rename, is seeded into a new worktree and is removed with it, exactly like the server scope one.

Closes #1597