### PR TITLE
docs: lead the Sail and Laradock pages with what only they can say

### DIFF
--- a/docs/getting-started/laradock.md
+++ b/docs/getting-started/laradock.md
@@ -1,10 +1,7 @@
 ---
 title: Laradock alternative
-description: 'Laradock gives every project its own Docker Compose stack and a workspace container. Lerd replaces it with one shared rootless Podman environment: automatic .test domains, HTTPS, per-project PHP 7.4 to 8.5, and no docker-compose.yml in the repo.'
+description: 'Laradock puts a submodule in your repo and a workspace container between you and artisan. Lerd removes both: composer and artisan run from your own shell, images are pulled rather than built from source, and one shared nginx and service layer serves every project on its own .test domain.'
 head:
-  - - meta
-    - name: keywords
-      content: laradock alternative, laradock replacement, laradock linux, laradock too slow, laradock vs, migrate from laradock, laradock without docker, local php development linux, laradock laravel alternative
   - - script
     - type: application/ld+json
     - |
@@ -17,7 +14,7 @@ head:
             "name": "What is the best Laradock alternative?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Lerd, if the part of Laradock you want to keep is having every service available and the part you want to lose is a Compose stack and a workspace container per project. Lerd runs one shared nginx, PHP-FPM and service layer as rootless Podman containers, gives each project a .test domain and HTTPS automatically, and needs no files committed to the repo. DDEV and Lando are the alternatives if you would rather stay on per-project Docker."
+              "text": "Lerd, if what you want to keep from Laradock is having every service on tap and what you want to lose is the workspace container and the submodule in the repo. Lerd pulls prebuilt images instead of building them from source, runs composer and artisan from your own shell rather than through docker compose exec, and lets the project directory live wherever you keep it instead of beside a laradock checkout. DDEV and Lando are the alternatives if you would rather stay on a per-project Docker stack."
             }
           },
           {
@@ -58,17 +55,21 @@ head:
 
 # Laradock alternative
 
-[Laradock](https://laradock.io) solved a real problem: every service a PHP project might want, prebuilt, behind one `docker-compose.yml`. The cost is the shape it leaves behind. A `laradock/` submodule inside the repo, a Compose file and an `.env` to keep in sync, a `workspace` container you have to shell into before you can run `artisan` or `composer`, images that build from source the first time, and one full stack per project when you have four projects open.
-
-**Lerd keeps the useful half and drops the rest.** One shared nginx, one PHP-FPM per version and one instance of each service, all as rootless Podman containers under your own user. Every project gets a `.test` domain and a trusted certificate automatically. Nothing is committed to the repo, nothing is built from source, and `composer` and `artisan` run from your own shell.
+**Laradock puts two things between you and your project: a `laradock/` checkout inside the repo, and a `workspace` container you have to shell into before `artisan` will run.** Lerd removes both. Tooling runs from your own shell, in your own directory, against your own files.
 
 ```bash
 curl -fsSL https://lerd.sh/install.sh | bash
 cd ~/code/myapp
 lerd link
+lerd composer install
+lerd artisan migrate
 ```
 
-Your project is live at `https://myapp.test`. No Compose file, no workspace container, no port to remember.
+No `docker compose exec workspace bash` first, no Compose file in the repo, no port to remember. The project is live at `https://myapp.test` with a trusted certificate.
+
+[Laradock](https://laradock.io) solved a real problem, and solved it early: every service a PHP project might want, behind one `docker-compose.yml`. What dates it is the shape it leaves behind. A submodule and an `.env` to keep in sync, a parent folder the project has to sit inside because `APP_CODE_PATH_HOST` points at it, images that compile from source on first run, and one full stack per project once four repos are open at the same time.
+
+Lerd keeps the part that was worth having, every service one command away, and drops the rest. Images are pulled, not built. One nginx, one PHP-FPM per version and one instance of each service are shared across every site, as rootless Podman containers under your own user, so the memory cost stops scaling with how many projects you have open.
 
 ## Every Laradock habit, and the Lerd equivalent
 
@@ -165,7 +166,7 @@ Full detail lives in the [quick start](/getting-started/quick-start) and the [si
 
 These are the places where the mental model changes, worth knowing before you commit to the move:
 
-- **Services are shared, not per project.** One MySQL, one Redis, one Mailpit across every site. That is where the memory saving comes from, and it is also the one thing Laradock does that Lerd does not: pinning a different MySQL major version per project.
+- **Services are shared, not per project.** One MySQL, one Redis, one Mailpit across every site, which is where the memory saving comes from. It is also the one thing Laradock does that Lerd does not: uncommenting a second database service and pinning a different MySQL major version for one project.
 - **No workspace container.** PHP tooling runs through `lerd php`, `lerd composer` and `lerd artisan`, which execute in the project's PHP container but from your own shell, in your own directory, with your own files. There is nothing to `exec` into first.
 - **The environment is not in the repo.** Instead of a committed Compose file, you commit an optional [`.lerd.yaml`](/configuration#per-project-config-lerd-yaml) describing the PHP version, Node version, services and workers. A teammate with Lerd installed gets the same environment from it; a teammate without Lerd is unaffected, since nothing else in the project changed.
 - **Nginx, not Apache.** If a project leaned on Laradock's Apache container and `.htaccess` rules, translate them into an [nginx override](/usage/nginx-overrides).

--- a/docs/getting-started/omarchy.md
+++ b/docs/getting-started/omarchy.md
@@ -2,9 +2,6 @@
 title: PHP development on Omarchy
 description: 'Omarchy ships an opinionated Arch and Hyprland desktop, but no PHP stack. Lerd adds one: automatic .test domains, HTTPS, per-project PHP 7.4 to 8.5, shared MySQL, PostgreSQL and Redis, rootless Podman, plus a native Omarchy bar widget.'
 head:
-  - - meta
-    - name: keywords
-      content: omarchy php, php development omarchy, omarchy laravel, laravel omarchy, omarchy web development, local php environment arch linux, omarchy dev environment, hyprland php development
   - - script
     - type: application/ld+json
     - |

--- a/docs/getting-started/sail.md
+++ b/docs/getting-started/sail.md
@@ -1,10 +1,7 @@
 ---
 title: Laravel Sail alternative
-description: 'Laravel Sail gives every project its own Docker Compose stack. Lerd replaces it with one shared rootless Podman environment, and lerd import sail migrates a Sail project database and S3 files across in a single command.'
+description: 'Lerd is the only local PHP environment that migrates a Laravel Sail project for you. lerd sail import lifts the database and the S3 files out of the Compose stack in one command, and the project comes back up on https://myapp.test with docker-compose.yml left untouched.'
 head:
-  - - meta
-    - name: keywords
-      content: laravel sail alternative, sail without docker, migrate from laravel sail, laravel sail slow, laravel sail linux, sail vs herd, laravel local development linux, replace laravel sail
   - - script
     - type: application/ld+json
     - |
@@ -17,7 +14,7 @@ head:
             "name": "What is the best Laravel Sail alternative?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Lerd, if you work across several Laravel projects at once and do not want a Docker Compose stack per repo. It runs one shared nginx, PHP-FPM and service layer as rootless Podman containers, gives each project a .test domain and HTTPS automatically, and needs no files committed to the project. DDEV and Lando are the alternatives if you would rather stay on per-project Docker."
+              "text": "Lerd, and it is the only one that will move the project across for you rather than leaving you to hand-write the migration. lerd sail import starts Sail's data services on remapped ports, dumps the database, mirrors the S3 and MinIO files and stops Sail again, so the repo goes from sail up to https://myapp.test in one command. DDEV and Lando are the alternatives if you would rather stay on a per-project Docker stack."
             }
           },
           {
@@ -58,31 +55,30 @@ head:
 
 # Laravel Sail alternative
 
-[Laravel Sail](https://laravel.com/docs/sail) is the official per-project Docker Compose setup: a `docker-compose.yml` in the repo, a container per service, and `./vendor/bin/sail` in front of every command. It works, and it is the right answer when a team wants the environment described inside the project.
-
-The friction shows up when you have several projects open. Each one is a full stack, so five repos means five copies of PHP, five databases and five Redis instances, plus a port to remember for each. **Lerd takes the shared-infrastructure route instead**: one nginx, one PHP-FPM per version, one instance of each service, across every site, as rootless Podman containers under your own user. Every project gets a `.test` domain and a trusted certificate with nothing committed to the repo.
+**Sail is the one environment Lerd migrates for you.** Every other move in this documentation is a manual dump and restore. A Sail stack has a predictable shape, so Lerd can read the Compose file and lift the project out of it in a single command.
 
 ```bash
 curl -fsSL https://lerd.sh/install.sh | bash
 cd ~/code/myapp
+lerd sail import
 lerd link
 ```
 
-`https://myapp.test`, no port, no `sail up`.
+The project is now on `https://myapp.test` with a trusted certificate, no port to remember and no `sail up` to run first. `docker-compose.yml` is still sitting in the repo, untouched, if you want to go back.
 
 ## The one-command migration
 
-Sail is the only tool with an automated importer in Lerd, because a Sail stack has a predictable shape. From the project root:
+`lerd sail import` reads the Compose file and remaps any port that would clash with Lerd's running services, so Sail and Lerd can be up at the same time without a fight. Then it starts **only** the data services with `--no-deps`, which is the part that matters in practice: the app image is never built, so a Node quirk or a private registry login that breaks `sail up` cannot block the migration. It waits for the database, detects the real database name, dumps it, imports it into Lerd's MySQL or PostgreSQL, mirrors the S3 and MinIO objects into Lerd's storage, and stops Sail when it is done.
 
-```bash
-lerd sail import
-```
+You rarely have to remember the command. `lerd link` on a project with `laravel/sail` in its `composer.json` offers the import before setup.
 
-It reads the Compose file, remaps any ports that would clash with Lerd's running services, starts **only** the data services (so a slow or broken app image build never blocks you), waits for the database, dumps it, imports it into Lerd's MySQL or PostgreSQL, mirrors S3 and MinIO files into Lerd's storage, then stops Sail again.
+The flags, the credential overrides and the `.env.before_lerd` behaviour are all in [Importing from Laravel Sail](/usage/import-sail).
 
-You rarely have to remember the command: running `lerd link` on a project with `laravel/sail` in its `composer.json` offers the import before setup.
+## What Sail costs once several projects are open
 
-The flags, the credential handling and the `.env.before_lerd` behaviour are all covered in [Importing from Laravel Sail](/usage/import-sail).
+[Laravel Sail](https://laravel.com/docs/sail) is the official per-project Docker Compose setup: a `docker-compose.yml` in the repo, a container per service, `./vendor/bin/sail` in front of every command. For one project at a time that is a good deal, and when a team wants the environment described inside the repo it is the right answer outright.
+
+The bill arrives when the projects multiply. Each repo is a full stack, so five open repos means five copies of PHP, five databases, five Redis instances and five ports to keep straight. Lerd's answer is to stop the cost scaling with the project count: one nginx, one PHP-FPM per version and one instance of each service, shared across every site as rootless Podman containers under your own user, with a `.test` domain and a certificate handed to each project and nothing committed to the repo.
 
 ## Every Sail habit, and the Lerd equivalent
 
@@ -105,7 +101,6 @@ The flags, the credential handling and the `.env.before_lerd` behaviour are all 
 |  | Lerd | Laravel Sail |
 |---|---|---|
 | Platforms | Linux (systemd), macOS, Windows via WSL2 (beta) | Linux, macOS, Windows |
-| License | Open source (MIT) | Open source (MIT) |
 | Container runtime | Rootless Podman, no daemon | Docker Desktop / Orbstack / Colima |
 | Architecture | One shared nginx, PHP-FPM and service layer | A per-project Compose stack |
 | PHP versions | 7.4, 8.0 to 8.5, per project, no rebuild | Per-project Sail image |
@@ -119,7 +114,6 @@ The flags, the credential handling and the `.env.before_lerd` behaviour are all 
 | Per-project service versions | No, services are shared and versioned globally | Yes, each project pins its own |
 | Dashboard | [Web UI](/features/web-ui), [system tray](/features/system-tray), [terminal dashboard](/features/tui) | CLI + Docker Desktop |
 | AI / MCP | Built-in [MCP server](/features/mcp) | Not built in |
-| Cost | Free | Free |
 
 **Choose Sail when:** your team already standardised on it, two projects need different major versions of the same database at the same time, or you want the infrastructure defined in the repo.
 
@@ -139,8 +133,8 @@ That makes the migration reversible per project, which is the sane way to move a
 
 ## What is genuinely different
 
-- **Services are shared, not per project.** One MySQL, one Redis, one Mailpit across every site. That is where the memory saving comes from, and it is the one thing Sail does that Lerd does not: pinning a different database major version per project.
-- **No `sail` prefix.** `lerd artisan` and `lerd composer` run in the project's PHP container but from your own shell and your own directory.
+- **The database outlives the project.** In Sail the data lives in a Compose volume belonging to that repo, so `sail down -v` in the wrong directory takes it with it. In Lerd one MySQL and one PostgreSQL hold every site's databases, independently of whether the site is linked. That is also the one thing Sail does that Lerd does not: pinning a different database major version per project.
+- **No `sail` prefix, and no `sail up`.** `lerd artisan` and `lerd composer` run in the project's PHP container but from your own shell, in your own directory. There is no per-project stack to bring up first, so a project you have not opened in a month responds the moment you load its URL.
 - **The environment is not in the repo.** Instead of a Compose file, you commit an optional [`.lerd.yaml`](/configuration#per-project-config-lerd-yaml) describing PHP, Node, services and workers. Teammates without Lerd are unaffected, since nothing else changed.
 - **One `sudo` at install time.** Only to point the system resolver at the `.test` domains.
 


### PR DESCRIPTION
The Sail and Laradock guides both opened on the same paragraph about shared infrastructure versus a stack per project, which is the argument every comparison page here already makes. They now open on the thing that is true only of them. Sail is the one environment lerd migrates automatically, so that page starts with lerd sail import and the flow it produces. Laradock is the one that puts a submodule in the repo and a workspace container between you and artisan, so that page starts by running composer and artisan straight from your own shell.

The Sail page also advertised lerd import sail in its meta description while the body used lerd sail import. Both forms work, the body wins.

Drops the keywords meta from all three pages. Google has ignored it for years and it appeared nowhere else in the docs, which left them looking like a cluster written for a crawler rather than a reader. The licence and cost rows come out of the Sail comparison table for the same reason, both projects are MIT and free, so the rows carried nothing.

Omarchy keeps its content, it was already unique, and only gets the meta cleanup.

Closes #1600