### PR TITLE
fix: leave stdout to a passthrough child, and stop scratch builds claiming the shims

### DIFF
--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -117,6 +117,40 @@ PHP runs inside the container, so the AI agent environment variables your coding
 
 Commands the `exec` MCP tool runs (`artisan`, `composer`, `vendor_run` for Pest/PHPUnit) go a step further: because reaching them through the MCP server proves an agent is driving the command, lerd injects a neutral `AI_AGENT=lerd-mcp` marker when no real agent variable is present. Pao therefore returns JSON for MCP-originated test runs even if the host environment carries nothing, while a real agent variable is still forwarded as-is when it exists. Manual terminal runs are never given the marker, so their output is unchanged.
 
+### Running your framework's own MCP server
+
+This is separate from lerd's MCP server. Some frameworks ship their own local MCP server, started as a console command — Laravel MCP does, and it is what [Laravel Boost](https://github.com/laravel/boost) builds on. Such a server has to run where the application runs: started from the host it resolves `lerd-mysql` or `lerd-redis` against nothing, and you end up maintaining a second set of host-only `.env` values just to keep it alive.
+
+lerd's `php` shim already takes care of that. The installer puts lerd's bin directory ahead of the system one on your PATH, and the `php` there execs into the project's container, so the ordinary registration works unchanged:
+
+```json
+{
+  "mcpServers": {
+    "weather": {
+      "command": "php",
+      "args": ["artisan", "mcp:start", "weather"]
+    }
+  }
+}
+```
+
+The server then runs on the same PHP build, the same extensions and the same container network as the site, and the hostnames in your `.env` resolve exactly as they do for a web request.
+
+A client you launch from a desktop icon rather than a terminal may not inherit your login PATH, in which case it finds the system `php` instead of the shim. Name lerd explicitly there:
+
+```json
+{
+  "mcpServers": {
+    "weather": {
+      "command": "lerd",
+      "args": ["artisan", "mcp:start", "weather"]
+    }
+  }
+}
+```
+
+Either form leaves stdout to the server: anything lerd needs to say while starting a container or a service goes to stderr, so it never lands in the middle of the JSON-RPC stream.
+
 ---
 
 ## Available MCP tools

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -1274,7 +1274,9 @@ func ensureServiceRunning(name string) error {
 	unit := "lerd-" + name
 	status, _ := podman.UnitStatus(unit)
 	if status != "active" {
-		envInterrupt(func() { fmt.Printf("  Starting %s...\n", name) })
+		// stderr: a passthrough child (php/console, e.g. a framework MCP server)
+		// owns stdout, and a progress line there corrupts its protocol stream.
+		envInterrupt(func() { fmt.Fprintf(os.Stderr, "  Starting %s...\n", name) })
 	}
 	return serviceops.EnsureServiceRunning(name)
 }

--- a/internal/cli/passthrough_stdout_test.go
+++ b/internal/cli/passthrough_stdout_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// A framework's own MCP server is started through lerd (`lerd artisan mcp:start`,
+// or `php artisan …` via the host shim), so the child owns stdout for the
+// JSON-RPC stream. Every setup notice lerd prints before the exec has to go to
+// stderr, or the first line it writes desynchronises the client.
+
+func TestEnsureServiceRunning_progressStaysOffStdout(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	out := captureStdout(t, func() { _ = ensureServiceRunning("totallycustom") })
+	if out != "" {
+		t.Errorf("stdout = %q, want empty (it belongs to the exec'd child)", out)
+	}
+}
+
+// stoppedUnits reports every unit as inactive, so the paused-site notice is
+// reached whatever is actually running on the machine running the test.
+type stoppedUnits struct{}
+
+func (stoppedUnits) Start(string) error                { return nil }
+func (stoppedUnits) Stop(string) error                 { return nil }
+func (stoppedUnits) Restart(string) error              { return nil }
+func (stoppedUnits) UnitStatus(string) (string, error) { return "inactive", nil }
+func (stoppedUnits) AllUnitStates() map[string]string  { return nil }
+
+func TestStartServicesForSite_noticesStayOffStdout(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	prevUnits := podman.UnitLifecycle
+	podman.UnitLifecycle = stoppedUnits{}
+	t.Cleanup(func() { podman.UnitLifecycle = prevUnits })
+
+	prev := ensureServiceRunningFn
+	ensureServiceRunningFn = func(string) error { return os.ErrNotExist }
+	t.Cleanup(func() { ensureServiceRunningFn = prev })
+
+	dir := t.TempDir()
+	env := "DB_HOST=lerd-mysql\nREDIS_HOST=lerd-redis\n"
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(env), 0644); err != nil {
+		t.Fatalf("writing .env: %v", err)
+	}
+
+	out := captureStdout(t, func() { startServicesForSiteNoticed(dir, "demo") })
+	if out != "" {
+		t.Errorf("stdout = %q, want empty (paused notice and warnings belong on stderr)", out)
+	}
+}

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -339,6 +339,10 @@ func ensureServicesForCwd(cwd string) {
 	startServicesForSiteNoticed(cwd, siteName)
 }
 
+// ensureServiceRunningFn is the service-start seam startServicesForSiteNoticed
+// uses, so tests can exercise the notice path without touching podman.
+var ensureServiceRunningFn = ensureServiceRunning
+
 // startServicesForSite reads the site's .env file and ensures every lerd service
 // it references is running. Called when resuming a paused site.
 func startServicesForSite(sitePath string) {
@@ -368,12 +372,14 @@ func startServicesForSiteNoticed(sitePath, siteName string) {
 		if !envfile.ReferencesContainer(envContent, name) {
 			continue
 		}
-		if siteName != "" && !headerPrinted && !lerdSystemd.IsServiceActive("lerd-"+name) {
-			fmt.Printf("[lerd] site %q is paused — starting required services...\n", siteName)
-			headerPrinted = true
+		if siteName != "" && !headerPrinted {
+			if status, _ := podman.UnitStatus("lerd-" + name); status != "active" {
+				fmt.Fprintf(os.Stderr, "[lerd] site %q is paused — starting required services...\n", siteName)
+				headerPrinted = true
+			}
 		}
-		if err := ensureServiceRunning(name); err != nil {
-			feedback.Warn("could not start %s: %v", name, err)
+		if err := ensureServiceRunningFn(name); err != nil {
+			feedback.WarnOn(os.Stderr, "could not start %s: %v", name, err)
 		}
 	}
 }

--- a/internal/config/lerd_binary.go
+++ b/internal/config/lerd_binary.go
@@ -15,20 +15,58 @@ var selfExecutable = os.Executable
 // later cannot break the file, with Homebrew as the exception: its kegs are
 // version-pinned, so the resolved path names a directory the next
 // `brew upgrade lerd` deletes. Falls back to ~/.local/bin/lerd, lerd's own
-// install location, when the running executable cannot be resolved.
+// install location, when the running executable cannot be resolved or is a
+// build running out of a scratch directory, which is not an install and will
+// be gone by the time a unit or a shim written against it next runs.
 func LerdBinary() string {
 	exe, err := selfExecutable()
 	if err != nil || exe == "" {
-		home, _ := os.UserHomeDir()
-		return filepath.Join(home, ".local", "bin", "lerd")
+		return installedLerdBinary()
 	}
 	if resolved, rErr := filepath.EvalSymlinks(exe); rErr == nil {
 		exe = resolved
+	}
+	if underScratchRoot(exe) {
+		return installedLerdBinary()
 	}
 	if opt := brewOptPath(exe); opt != "" {
 		return opt
 	}
 	return exe
+}
+
+// installedLerdBinary is the path to fall back on when the running executable
+// is not one anything may record: lerd's own install location, which the shims'
+// `[ -x "$LERD" ] || LERD=lerd` line covers if it turns out to be elsewhere.
+func installedLerdBinary() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".local", "bin", "lerd")
+}
+
+// scratchRoots are the throwaway directories a lerd binary gets built and run
+// from during development. Tests override it, since their fixtures live in
+// exactly such a directory.
+var scratchRoots = []string{os.TempDir(), "/tmp", "/var/tmp", "/dev/shm", "/run"}
+
+// underScratchRoot reports whether path sits in one of those directories. Roots
+// are resolved before comparing, so macOS spelling /var against /private/var
+// still matches.
+func underScratchRoot(path string) bool {
+	for _, root := range scratchRoots {
+		if root == "" {
+			continue
+		}
+		if resolved, err := filepath.EvalSymlinks(root); err == nil {
+			root = resolved
+		}
+		if !strings.HasSuffix(root, string(os.PathSeparator)) {
+			root += string(os.PathSeparator)
+		}
+		if strings.HasPrefix(path, root) {
+			return true
+		}
+	}
+	return false
 }
 
 // SupersededBinary reports whether recorded names a lerd binary that current

--- a/internal/config/lerd_binary_test.go
+++ b/internal/config/lerd_binary_test.go
@@ -49,6 +49,7 @@ func TestBrewOptPathIgnoresOrdinaryInstalls(t *testing.T) {
 // The ordinary install resolves symlinks, so a unit written today survives the
 // ~/.local/bin symlink being repointed or removed later.
 func TestLerdBinaryResolvesSymlink(t *testing.T) {
+	noScratchRoots(t)
 	dir := resolvedTempDir(t)
 	real := filepath.Join(dir, "versions", "lerd")
 	link := filepath.Join(dir, "lerd")
@@ -67,6 +68,7 @@ func TestLerdBinaryResolvesSymlink(t *testing.T) {
 }
 
 func TestLerdBinaryPrefersBrewOptPath(t *testing.T) {
+	noScratchRoots(t)
 	prefix := resolvedTempDir(t)
 	keg := filepath.Join(prefix, "Cellar", "lerd", "1.32.0", "bin", "lerd")
 	opt := filepath.Join(prefix, "opt", "lerd", "bin", "lerd")
@@ -126,6 +128,34 @@ func TestSupersededBinaryLeavesAnotherInstallAlone(t *testing.T) {
 // resolvedTempDir is t.TempDir() with symlinks resolved, so a comparison
 // against a path LerdBinary resolved does not fail on macOS, where the temp dir
 // lives under the /var → /private/var symlink.
+// A build run from a scratch directory (an agent's temp dir, a CI checkout
+// under /tmp) is not an install. Recording its path in a shim or a systemd unit
+// leaves them naming a file that gets deleted, so the installed lerd is what
+// they have to carry instead.
+func TestLerdBinaryRefusesAScratchBuildPath(t *testing.T) {
+	scratch := filepath.Join(t.TempDir(), "scratchpad", "lerd-tui-new")
+	writeExecutable(t, scratch)
+
+	prev := selfExecutable
+	selfExecutable = func() (string, error) { return scratch, nil }
+	defer func() { selfExecutable = prev }()
+
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".local", "bin", "lerd")
+	if got := LerdBinary(); got != want {
+		t.Errorf("LerdBinary() = %q; want the installed %q, not a path that disappears", got, want)
+	}
+}
+
+// noScratchRoots lets a test keep its fixtures in a temp directory without
+// LerdBinary rejecting them as a scratch build.
+func noScratchRoots(t *testing.T) {
+	t.Helper()
+	prev := scratchRoots
+	scratchRoots = nil
+	t.Cleanup(func() { scratchRoots = prev })
+}
+
 func resolvedTempDir(t *testing.T) string {
 	t.Helper()
 	dir, err := filepath.EvalSymlinks(t.TempDir())


### PR DESCRIPTION
A post in the discussions showed a framework's own local MCP server, the kind Laravel MCP starts as a console command and Laravel Boost builds on, registered as `lerd artisan mcp:start <server>` so it runs against the same container, network and PHP build as the site instead of against the host. That is the right way to do it, but lerd was not holding up its end. Three setup notices on the passthrough path still went to stdout, and stdout there belongs to the child: a paused site, or a service that had to be started first, would have put a line of lerd's own text in the middle of the server's JSON-RPC stream. They go to stderr now, next to the FPM spinner that was already there for the same reason.

The docs gained a section on this. The registration does not actually need to name lerd at all: the `php` shim the installer puts on PATH already execs into the project's container, so an ordinary `"command": "php"` entry works unchanged. Naming `lerd` explicitly is for clients launched from a desktop icon, which never inherit the login PATH and would otherwise find the system php. lerd does not rewrite anyone's MCP config to arrange this, and should not, since those files are usually committed and shared with people who are not running lerd.

Checking that shim is what turned up the second fix. It was pointing at a build in a temporary directory that no longer existed, left behind by an earlier development build. LerdBinary returns the running executable and that path is written into every shim and every systemd unit, so a binary run out of a scratch directory quietly claims all of them and then disappears. It now falls back to the install location instead, the same one it already used when the running executable cannot be resolved.

Closes #1602
Closes #1603