### PR TITLE
fix(install): build stale PHP images behind the progress loader

### DIFF
--- a/docs/usage/lifecycle.md
+++ b/docs/usage/lifecycle.md
@@ -65,14 +65,19 @@ Every command that can pull or rebuild a container image says so before a single
 byte moves. The block lists what is being fetched, how big it is, and why:
 
 ```
-lerd will download 2 images (~247.9 MiB total)
-  pull    docker.io/library/mysql:8.0   ~222.8 MiB  missing, needed by mysql
-  rebuild PHP 8.4 image                  ~25.1 MiB  missing, needed by php84-fpm
+ ↓ lerd will download 2 images (~247.9 MiB total)
+    pull    docker.io/library/mysql:8.0  ~222.8 MiB  missing, needed by mysql
+    rebuild PHP 8.4 image                 ~25.1 MiB  missing, needed by php84-fpm
 ```
 
 Sizes come from the registry manifest, so nothing is downloaded to work them
 out. A registry that does not answer in time leaves the line without a number
 rather than holding the command up.
+
+`lerd install` reports the same block for the PHP versions it has to rebuild,
+usually after an upgrade that changed the image recipe. Each version then builds
+behind its own progress line instead of streaming the raw build log; press
+Ctrl+O while it runs to see the output.
 
 To see what a start would fetch without fetching it:
 

--- a/internal/cli/fpm_install_ensure_test.go
+++ b/internal/cli/fpm_install_ensure_test.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// The default version comes first and every active site adds its own once, so
+// install brings up exactly the runtimes something on this machine points at.
+func TestFPMVersionsToEnsure_defaultFirstThenEachActiveSiteOnce(t *testing.T) {
+	sites := []config.Site{
+		{Name: "shop", PHPVersion: "8.4"},
+		{Name: "blog", PHPVersion: "8.3"},
+		{Name: "api", PHPVersion: "8.4"},
+		{Name: "inherits", PHPVersion: ""},
+	}
+
+	got := fpmVersionsToEnsure("8.3", sites)
+
+	if want := []string{"8.3", "8.4"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("versions = %v, want %v", got, want)
+	}
+}
+
+// A paused or ignored site is not served, so its version is not worth a build.
+func TestFPMVersionsToEnsure_skipsPausedAndIgnoredSites(t *testing.T) {
+	sites := []config.Site{
+		{Name: "paused", PHPVersion: "8.2", Paused: true},
+		{Name: "ignored", PHPVersion: "8.1", Ignored: true},
+		{Name: "live", PHPVersion: "8.5"},
+	}
+
+	got := fpmVersionsToEnsure("8.4", sites)
+
+	if want := []string{"8.4", "8.5"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("versions = %v, want %v", got, want)
+	}
+}
+
+// No default configured yet (a fresh install) must not queue an empty version.
+func TestFPMVersionsToEnsure_dropsEmptyVersions(t *testing.T) {
+	got := fpmVersionsToEnsure("", []config.Site{{Name: "orphan", PHPVersion: ""}})
+
+	if len(got) != 0 {
+		t.Errorf("versions = %v, want none", got)
+	}
+}
+
+// Only a version with something to build gets the progress loader. The rest are
+// no-ops whose podman output would otherwise land raw in the install log.
+func TestFPMEnsurePlan_splitsOnWhatActuallyBuilds(t *testing.T) {
+	orig := fpmImageCurrentFn
+	t.Cleanup(func() { fpmImageCurrentFn = orig })
+	fpmImageCurrentFn = func(v string) bool { return v == "8.3" }
+
+	build, quiet := fpmEnsurePlan([]string{"8.3", "8.4", "8.5"})
+
+	if want := []string{"8.4", "8.5"}; !reflect.DeepEqual(build, want) {
+		t.Errorf("build = %v, want %v", build, want)
+	}
+	if want := []string{"8.3"}; !reflect.DeepEqual(quiet, want) {
+		t.Errorf("quiet = %v, want %v", quiet, want)
+	}
+}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -663,34 +663,25 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	// Then restore quadlets for any additional PHP versions and services from registered sites.
 	{
 		cfg, _ := config.LoadGlobal()
-		seenPHP := map[string]bool{}
 		seenSvc := map[string]bool{}
 
-		if cfg != nil && cfg.PHP.DefaultVersion != "" {
-			seenPHP[cfg.PHP.DefaultVersion] = true
-			if err := ensureFPMQuadlet(cfg.PHP.DefaultVersion); err != nil {
-				fmt.Printf("  WARN: default PHP %s FPM quadlet: %v\n", cfg.PHP.DefaultVersion, err)
-			}
+		defaultPHP := ""
+		if cfg != nil {
+			defaultPHP = cfg.PHP.DefaultVersion
 		}
 
 		reg, regErr := config.LoadSites()
+		var sites []config.Site
+		if regErr == nil {
+			sites = reg.Sites
+		}
+		ensureFPMQuadlets(fpmVersionsToEnsure(defaultPHP, sites))
+
 		if regErr == nil {
 
 			for _, s := range reg.Sites {
 				if s.Paused || s.Ignored {
 					continue
-				}
-
-				// Restore FPM quadlet.
-				v := s.PHPVersion
-				if v == "" && cfg != nil {
-					v = cfg.PHP.DefaultVersion
-				}
-				if v != "" && !seenPHP[v] {
-					seenPHP[v] = true
-					if err := ensureFPMQuadlet(v); err != nil {
-						fmt.Printf("  WARN: PHP %s FPM quadlet: %v\n", v, err)
-					}
 				}
 
 				// Restore service quadlets from .lerd.yaml.

--- a/internal/cli/park.go
+++ b/internal/cli/park.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/feedback"
+	"github.com/geodro/lerd/internal/imagepull"
 	"github.com/geodro/lerd/internal/linker"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
@@ -412,4 +413,82 @@ func ensureFPMQuadletTo(phpVersion string, w io.Writer) error {
 		return restartUnitFn(unitName)
 	}
 	return startUnitFn(unitName)
+}
+
+// fpmImageCurrentFn is a seam for the check that decides whether a version has
+// anything to build, and so whether it needs the loader.
+var fpmImageCurrentFn = podman.FPMImageCurrent
+
+// fpmVersionsToEnsure lists the PHP versions install has to bring up: the
+// global default first, then the version of every site that is actually
+// served, once each. A site with no version of its own runs the default.
+func fpmVersionsToEnsure(defaultVersion string, sites []config.Site) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(v string) {
+		if v == "" || seen[v] {
+			return
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+
+	add(defaultVersion)
+	for _, s := range sites {
+		if s.Paused || s.Ignored {
+			continue
+		}
+		v := s.PHPVersion
+		if v == "" {
+			v = defaultVersion
+		}
+		add(v)
+	}
+	return out
+}
+
+// fpmEnsurePlan splits versions into the ones with an image to build and the
+// ones already current, which have nothing to show.
+func fpmEnsurePlan(versions []string) (build, quiet []string) {
+	for _, v := range versions {
+		if fpmImageCurrentFn(v) {
+			quiet = append(quiet, v)
+			continue
+		}
+		build = append(build, v)
+	}
+	return build, quiet
+}
+
+// ensureFPMQuadlets ensures the quadlet, image and unit of every PHP version.
+// The ones that really build go through the loader with their downloads
+// disclosed first; before this they streamed raw podman build output into the
+// middle of the install log, past the point where the disclosure is printed.
+func ensureFPMQuadlets(versions []string) {
+	build, quiet := fpmEnsurePlan(versions)
+
+	for _, v := range quiet {
+		if err := ensureFPMQuadletTo(v, io.Discard); err != nil {
+			feedback.Warn("PHP %s FPM quadlet: %v", v, err)
+		}
+	}
+	if len(build) == 0 {
+		return
+	}
+
+	jobs := make([]BuildJob, len(build))
+	plan := make(imagepull.Plan, len(build))
+	for i, v := range build {
+		ver := v
+		jobs[i] = BuildJob{
+			Label: "PHP " + ver,
+			Run:   func(w io.Writer) error { return ensureFPMQuadletTo(ver, w) },
+		}
+		plan[i] = imagepull.Build("PHP "+ver+" image", podman.PHPBaseImageRef(ver),
+			"the PHP "+ver+" runtime")
+	}
+
+	feedback.Header("Building PHP images")
+	plan.Fill().Report(os.Stdout)
+	RunParallel(jobs) //nolint:errcheck
 }

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -213,7 +213,7 @@ func NewStartCmd() *cobra.Command {
 func ReportPendingDownloads(w io.Writer) {
 	work := pendingImageWork()
 	if len(work) == 0 {
-		fmt.Fprintln(w, "Nothing to download: every image lerd needs is already in the local store.")
+		feedback.LineOn(w, "Nothing to download: every image lerd needs is already in the local store.")
 		return
 	}
 	plan := make(imagepull.Plan, len(work))

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -85,10 +85,12 @@ var (
 // Status glyphs for query/report output that renders its own layout rather than
 // using the Step/Live progress flow.
 const (
-	GlyphOK   = "✓"
-	GlyphFail = "✗"
-	GlyphWarn = "⚠"
-	GlyphLock = "🔒"
+	GlyphOK = "✓"
+	// GlyphDownload heads the block disclosing what a command is about to fetch.
+	GlyphDownload = "↓"
+	GlyphFail     = "✗"
+	GlyphWarn     = "⚠"
+	GlyphLock     = "🔒"
 )
 
 // Title styles a fragment as the bold accent (terminal-green) title colour.
@@ -110,6 +112,17 @@ func Dim(s string) string   { return paint(dimStyle, s) }
 func GreenIf(on bool, s string) string { return paintIf(on, okStyle, s) }
 func RedIf(on bool, s string) string   { return paintIf(on, redStyle, s) }
 func AmberIf(on bool, s string) string { return paintIf(on, warnStyle, s) }
+func DimIf(on bool, s string) string   { return paintIf(on, dimStyle, s) }
+func ValIf(on bool, s string) string   { return paintIf(on, valueStyle, s) }
+
+// ColorFor reports whether w should carry colour, for a package that renders a
+// block of its own on an explicit writer and wants the same per-writer gate the
+// glyph lines here use.
+func ColorFor(w io.Writer) bool { return colorEnabledFor(w) }
+
+// Prefix is the left margin every glyph line here starts with, exported so an
+// externally rendered block lines up with them.
+const Prefix = pad
 
 // spinnerFrames is the Braille spinner used by the Live progress line.
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}

--- a/internal/imagepull/imagepull_test.go
+++ b/internal/imagepull/imagepull_test.go
@@ -131,6 +131,25 @@ func TestReportDisclosesSizeAndReason(t *testing.T) {
 	}
 }
 
+// The disclosure is a lerd feedback block, not a bare printf: the download
+// glyph heads it on the same left margin as the step lines around it, and the
+// items are indented under it.
+func TestReportUsesTheGlyphLayout(t *testing.T) {
+	var buf bytes.Buffer
+	Plan{{Ref: "redis:7-alpine", Reason: "redis is not installed", Bytes: 100}}.Report(&buf)
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("report = %d lines, want a headline and one item:\n%s", len(lines), buf.String())
+	}
+	if !strings.HasPrefix(lines[0], " ↓ lerd will download 1 image") {
+		t.Errorf("headline = %q, want the download glyph on the feedback margin", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "    pull ") {
+		t.Errorf("item = %q, want it indented under the headline", lines[1])
+	}
+}
+
 func TestReportDryRunSaysNothingWasDownloaded(t *testing.T) {
 	SetDryRun(true)
 	t.Cleanup(func() { SetDryRun(false) })

--- a/internal/imagepull/plan.go
+++ b/internal/imagepull/plan.go
@@ -3,8 +3,9 @@ package imagepull
 import (
 	"fmt"
 	"io"
-	"strings"
 	"sync"
+
+	"github.com/geodro/lerd/internal/feedback"
 )
 
 // Item is one image a command is about to download or build.
@@ -83,7 +84,9 @@ func (p Plan) Report(w io.Writer) {
 	if n := p.Total(); n > 0 {
 		total = fmt.Sprintf(" (~%s total)", Human(n))
 	}
-	fmt.Fprintf(w, "lerd %s %d %s%s%s\n", verb, len(p), noun, total, tail)
+	on := feedback.ColorFor(w)
+	fmt.Fprintf(w, "%s%s lerd %s %d %s%s%s\n", feedback.Prefix,
+		feedback.DimIf(on, feedback.GlyphDownload), verb, len(p), noun, total, tail)
 
 	sizes := make([]string, len(p))
 	labelWidth, sizeWidth := 0, 0
@@ -95,16 +98,21 @@ func (p Plan) Report(w io.Writer) {
 		labelWidth = max(labelWidth, len(it.label()))
 		sizeWidth = max(sizeWidth, len(sizes[i]))
 	}
+	// Painted per cell rather than per line, so the columns are padded on the
+	// plain text and stay aligned once the escapes are in.
 	for i, it := range p {
 		action := "pull"
 		if it.Build {
 			action = "rebuild"
 		}
-		line := fmt.Sprintf("  %-7s %-*s  %*s", action, labelWidth, it.label(), sizeWidth, sizes[i])
+		line := fmt.Sprintf("%s   %s %s  %s", feedback.Prefix,
+			feedback.DimIf(on, fmt.Sprintf("%-7s", action)),
+			feedback.ValIf(on, fmt.Sprintf("%-*s", labelWidth, it.label())),
+			fmt.Sprintf("%*s", sizeWidth, sizes[i]))
 		if it.Reason != "" {
-			line += "  " + it.Reason
+			line += "  " + feedback.DimIf(on, it.Reason)
 		}
-		fmt.Fprintln(w, strings.TrimRight(line, " "))
+		fmt.Fprintln(w, line)
 	}
 }
 


### PR DESCRIPTION
A PHP image whose recipe had moved was rebuilt from inside install's quadlet restore pass, which wrote podman's build log straight to stdout. The run broke in half: a block of STEP lines, layer hashes and a COMMIT landed between the arrow steps, once per installed version. It also ran before the block that discloses what a command is about to download, so the prebuilt base each version pulls, around 180 MiB a piece, moved with nothing said about it, and the later section that would have rebuilt them behind a loader found them already current and skipped.

Install now collects the versions it has to bring up before touching any of them, and splits them on whether there is anything to build. A version already on the current recipe is a silent no-op, the way it always looked. The rest go through the same loader every other image build uses, with their downloads disclosed first, so a rebuild reads as three progress lines instead of three pages of build output.

The disclosure block was itself plain left-flush text with no glyph, which read as raw output next to the steps around it. It now heads with a download glyph on the shared left margin and indents its items under it, with the action dimmed, the image name in the accent colour and the reason dimmed. Painting happens per cell so the columns stay aligned, and it is gated per writer so a piped or captured report stays plain text.

Closes #1605
