### PR TITLE
feat(mcp): scaffold the framework major the caller asked for

### DIFF
--- a/internal/cli/aidocs/lerd-reference.md
+++ b/internal/cli/aidocs/lerd-reference.md
@@ -103,9 +103,9 @@ Actions: `artisan` (Laravel), `console` (other frameworks), `composer`, `vendor_
 #### `framework` — framework definitions & scaffolding
 Actions: `list`, `add`, `remove`, `prune`, `search`, `update`, `project_new`, `setup`.
 - `add` with `name: "laravel"` merges custom workers/setup into the built-in framework; a worker or command gated on a composer package is declared once in the store as `packages/<vendor>-<name>.yaml` and merged onto the resolved definition, so it is not always in the framework's own file
-- `remove` refuses to drop a definition a linked site still uses (pass `force: true` to override); `prune` removes every framework definition no site uses
+- `remove` refuses to drop a definition a linked site still uses (pass `force: true` to override); `prune` removes every definition no site uses
 - `search`/`update` use the community store; definitions auto-fetch on link, so `update` is the manual refresh (no `name` refreshes the catalogue and all installed definitions; with `name` it fetches that one, auto-detecting version from `composer.lock`)
-- `project_new` scaffolds a new project (requires absolute `path`, default framework laravel) from the definition the store publishes today; follow with `site` `link` + `env` `setup`. `lerd setup --list-steps` prints a project's setup plan as JSON and `--step` runs the named ones, which is the scriptable way to drive setup piecemeal
+- `project_new` scaffolds a new project (absolute `path`, default laravel) from the definition the store publishes today, with `version` for an older major, refused when the store has none; follow with `site` `link` + `env` `setup`. `lerd setup --list-steps` prints a project's setup plan as JSON and `--step` runs the named ones, for driving setup piecemeal
 - `setup` runs the framework's post-install steps (migrations, storage:link…) — MANDATORY after `env setup` on new/cloned projects; idempotent
 
 #### `diag` — diagnostics & observability

--- a/internal/mcp/groups.go
+++ b/internal/mcp/groups.go
@@ -507,16 +507,16 @@ func execTool() mcpTool {
 func frameworkTool() mcpTool {
 	return mcpTool{
 		Name:        "framework",
-		Description: "Framework definitions and scaffolding. action: list, add (bare name installs from store, else authors custom; laravel merges built-in), remove (force=true overrides in-use guard), prune (remove unused), search (store), update (fetch a definition from the store), project_new (scaffold), setup (post-install steps, MANDATORY after env setup).",
+		Description: "Framework definitions and scaffolding. action: list, add (bare name installs from store, else authors custom; laravel merges built-in), remove (force=true overrides in-use guard), prune (remove unused), search (store), update (fetch from the store), project_new (scaffold), setup (post-install steps, MANDATORY after env setup).",
 		InputSchema: mcpSchema{
 			Type: "object",
 			Properties: map[string]mcpProp{
 				"action":              {Type: "string", Enum: []string{"list", "add", "remove", "prune", "search", "update", "project_new", "setup"}},
 				"name":                {Type: "string", Description: "add/remove/update: framework slug."},
-				"force":               {Type: "boolean", Description: "remove: delete even if a site uses it."},
+				"force":               {Type: "boolean", Description: "remove: delete even if in use."},
 				"label":               {Type: "string", Description: "add: human-readable name."},
 				"public_dir":          {Type: "string", Description: "add: document root."},
-				"detect_files":        {Type: "array", Items: stringItems, Description: "add: filenames that signal this framework."},
+				"detect_files":        {Type: "array", Items: stringItems, Description: "add: filenames that signal it."},
 				"detect_packages":     {Type: "array", Items: stringItems, Description: "add: composer packages that signal it."},
 				"env_file":            {Type: "string", Description: `add: primary env file (default ".env").`},
 				"env_format":          {Type: "string", Description: "add: dotenv (default) or php-const."},
@@ -525,7 +525,7 @@ func frameworkTool() mcpTool {
 				"workers":             {Type: "object", Description: "add: map name → {label, command, restart, check?}."},
 				"setup":               {Type: "array", Items: objectItems, Description: "add: {label, command, default?, check?} entries."},
 				"logs":                {Type: "array", Items: objectItems, Description: `add: {path, format?} entries.`},
-				"version":             {Type: "string", Description: "remove/install: version (omit to auto)."},
+				"version":             {Type: "string", Description: "remove/install/project_new: framework version or major (omit to auto)."},
 				"query":               {Type: "string", Description: "search: name/label query."},
 				"path":                {Type: "string", Description: "project_new: new project dir. setup: project root."},
 				"framework":           {Type: "string", Description: `project_new: framework (default "laravel").`},

--- a/internal/mcp/project_new_test.go
+++ b/internal/mcp/project_new_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -86,5 +87,109 @@ func TestExecProjectNew_UnknownStaysUnknown(t *testing.T) {
 	}
 	if text := resultText(t, resp); !strings.Contains(text, "unknown framework") {
 		t.Errorf("error should report an unknown framework, got: %s", text)
+	}
+}
+
+// projectNewMultiVersionStore publishes two majors of one framework, each with a
+// create command of its own, so a test can tell which definition was scaffolded
+// from rather than trusting the resolution.
+func projectNewMultiVersionStore(t *testing.T, name string, versions map[string]string, latest string) *httptest.Server {
+	t.Helper()
+	list := make([]string, 0, len(versions))
+	for v := range versions {
+		list = append(list, v)
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(list)))
+	mux := http.NewServeMux()
+	mux.HandleFunc("/index.json", func(w http.ResponseWriter, _ *http.Request) {
+		data, _ := json.Marshal(store.Index{
+			Frameworks: []store.IndexEntry{{Name: name, Label: name, Versions: list, Latest: latest}},
+		})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+	})
+	for version, create := range versions {
+		body := "name: " + name + "\nlabel: " + name + "\nversion: \"" + version + "\"\npublic_dir: public\ncreate: \"" + create + "\"\n"
+		mux.HandleFunc("/"+name+"/"+version+".yaml", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(body))
+		})
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// A caller that names a major gets that major's create command, not the newest
+// one the store publishes, which is what `lerd new --framework-version` does.
+func TestExecProjectNew_ScaffoldsTheRequestedMajor(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	srv := projectNewMultiVersionStore(t, "codeigniter", map[string]string{"4": "touch", "5": "true"}, "5")
+	t.Setenv("LERD_STORE_BASE_URL", srv.URL)
+
+	path := filepath.Join(tmp, "proj")
+	resp, rpcErr := execProjectNew(map[string]any{
+		"path":      path,
+		"framework": "codeigniter",
+		"version":   "4",
+	})
+	if rpcErr != nil {
+		t.Fatalf("rpc error: %v", rpcErr)
+	}
+	if resultIsError(resp) {
+		t.Fatalf("project_new refused a published major: %s", resultText(t, resp))
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected major 4's create command to have run: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(config.StoreFrameworksDir(), "codeigniter@4.yaml")); err != nil {
+		t.Errorf("expected major 4's definition cached locally: %v", err)
+	}
+}
+
+// A major the store does not publish is refused by name and version, rather than
+// silently scaffolding whatever is current.
+func TestExecProjectNew_UnpublishedMajorIsRefused(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	srv := projectNewMultiVersionStore(t, "codeigniter", map[string]string{"4": "touch", "5": "true"}, "5")
+	t.Setenv("LERD_STORE_BASE_URL", srv.URL)
+
+	resp, rpcErr := execProjectNew(map[string]any{
+		"path":      filepath.Join(tmp, "proj"),
+		"framework": "codeigniter",
+		"version":   "99",
+	})
+	if rpcErr != nil {
+		t.Fatalf("rpc error: %v", rpcErr)
+	}
+	if !resultIsError(resp) {
+		t.Fatalf("expected an unknown-major error, got: %s", resultText(t, resp))
+	}
+	if text := resultText(t, resp); !strings.Contains(text, "99") {
+		t.Errorf("error should name the major that is missing, got: %s", text)
+	}
+}
+
+// A version with no framework behind it is a mistake the CLI refuses too: the
+// default framework would silently absorb a major meant for another one.
+func TestExecProjectNew_VersionNeedsAFramework(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	resp, rpcErr := execProjectNew(map[string]any{
+		"path":    filepath.Join(tmp, "proj"),
+		"version": "11",
+	})
+	if rpcErr != nil {
+		t.Fatalf("rpc error: %v", rpcErr)
+	}
+	if !resultIsError(resp) {
+		t.Fatalf("expected a version-without-framework error, got: %s", resultText(t, resp))
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3772,14 +3772,24 @@ func execProjectNew(args map[string]any) (any, *rpcError) {
 		return toolErr("path is required — provide an absolute path for the new project directory"), nil
 	}
 	frameworkName := strArg(args, "framework")
+	frameworkVersion := strArg(args, "version")
 	if frameworkName == "" {
+		if frameworkVersion != "" {
+			return toolErr("version needs a framework to apply it to — pass framework alongside it"), nil
+		}
 		frameworkName = "laravel"
 	}
 	extraArgs := strSliceArg(args, "args")
 
-	fw, ok := config.GetFrameworkForScaffold(frameworkName, "")
+	fw, ok := config.GetFrameworkForScaffold(frameworkName, frameworkVersion)
 	if !ok {
 		return toolErr(fmt.Sprintf("unknown framework %q — use framework_list to see available frameworks", frameworkName)), nil
+	}
+	// A major nothing publishes resolves to the current one rather than failing,
+	// which is right for a person who picked from a list and wrong here: the
+	// caller asked for a major and would otherwise be handed another one.
+	if frameworkVersion != "" && fw.Version != frameworkVersion {
+		return toolErr(fmt.Sprintf("framework %q does not publish major %q (the store serves %q) — use framework_list to see the majors it publishes", frameworkName, frameworkVersion, fw.Version)), nil
 	}
 	if fw.Create == "" {
 		return toolErr(fmt.Sprintf("framework %q has no create command — add a 'create' field to its YAML definition", frameworkName)), nil


### PR DESCRIPTION
lerd new can scaffold an older major since it became a wizard, and the docs say a scaffold installs the major that was picked, but project_new resolved the definition with an empty version. An assistant asked for a Laravel 11 project got whatever the store publishes as current, and the mismatch only surfaced later in a composer.json nobody asked for.

The tool now takes the version the rest of the framework tool already takes, so the major reaches the resolution and its definition is fetched before the create command runs. A major nothing publishes resolves to the current one rather than failing, which is the right call for a person picking from a list and the wrong one for a caller that named a major, so the tool compares what came back against what was asked for and refuses the mismatch rather than scaffolding something else. A version with no framework beside it is refused as well, since the default framework would otherwise absorb a major meant for another one.

The CLI keeps its lenient fallback on purpose. A person who typed a major sees the scaffold line naming the framework and version before anything runs, so silence is not the same risk there.

Closes #1616