### PR TITLE
fix(php): stop a declared bundled extension from replacing the image's build

### DIFF
--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -349,6 +349,8 @@ To add an extension that isn't in the bundle:
 lerd php:ext add swoole
 ```
 
+An extension the image already ships is refused, since the bundle is the better build of it. The image compiles those extensions as part of its own configure run, with flags a standalone rebuild on top of the image cannot pass, so redeclaring one would quietly replace it with a lesser build: `ftp` declared this way came back without FTPS support and no `ftp_ssl_connect`. Builds skip any bundled name left over in an existing declared set for the same reason.
+
 Extensions belong to you, not to a PHP version. One declared set applies to every PHP image lerd builds, so a site that changes version keeps them. The version you are on is rebuilt and verified straight away; other installed versions carry the old set until they are rebuilt, and lerd says which ones those are.
 
 Those deferred versions are rebuilt by the next command that touches them, which is usually `lerd use`, `lerd link`, `lerd fetch`, `lerd unpause` or `lerd start`. When that happens to a version whose container is already running, lerd restarts the container onto the image it just built, so the running PHP always matches what `lerd php:ext list` and the dashboard report for it.

--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -349,7 +349,7 @@ To add an extension that isn't in the bundle:
 lerd php:ext add swoole
 ```
 
-An extension the image already ships is refused, since the bundle is the better build of it. The image compiles those extensions as part of its own configure run, with flags a standalone rebuild on top of the image cannot pass, so redeclaring one would quietly replace it with a lesser build: `ftp` declared this way came back without FTPS support and no `ftp_ssl_connect`. Builds skip any bundled name left over in an existing declared set for the same reason.
+An extension the image already ships is refused, since the bundle is the better build of it. The image compiles those extensions as part of its own configure run, with flags a standalone rebuild on top of the image cannot pass, so redeclaring one would quietly replace it with a lesser build: `ftp` declared this way came back without FTPS support and no `ftp_ssl_connect`. Builds skip any bundled name left over in an existing declared set for the same reason, and an image built while one was still being rebuilt reads as out of date, so the next build puts the image's own version back with nothing to run by hand.
 
 Extensions belong to you, not to a PHP version. One declared set applies to every PHP image lerd builds, so a site that changes version keeps them. The version you are on is rebuilt and verified straight away; other installed versions carry the old set until they are rebuilt, and lerd says which ones those are.
 

--- a/internal/cli/php_ext.go
+++ b/internal/cli/php_ext.go
@@ -51,6 +51,13 @@ func newPhpExtAddCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// Declaring a bundled extension makes every build rebuild it on top
+			// of the base image, which loses the configure flags that build gave
+			// it (ftp lost FTPS that way, #1576).
+			if len(podman.WithoutBundled(version, []string{ext})) == 0 {
+				return fmt.Errorf("extension %q already ships in the PHP %s image, nothing to add", ext, version)
+			}
+
 			rawDeps, _ := cmd.Flags().GetString("apk-deps")
 			deps, err := podman.ParseApkDeps(rawDeps)
 			if err != nil {

--- a/internal/cli/php_ext_test.go
+++ b/internal/cli/php_ext_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
@@ -110,5 +111,43 @@ func TestPhpExtAdd_keepsAnAlreadyDeclaredExtensionWhenTheRebuildFails(t *testing
 	}
 	if !slices.Contains(cfg.GetExtensions(), "leveldb") {
 		t.Error("a failed re-add removed the extension that was already declared and working")
+	}
+}
+
+// Declaring an extension the image already ships makes the build rebuild it
+// generically on top of the base image, which drops the configure flags the
+// base build gave it (ftp lost FTPS that way, #1576). Reject it up front.
+func TestPhpExtAdd_rejectsABundledExtension(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+
+	orig := rebuildFPMImage
+	t.Cleanup(func() { rebuildFPMImage = orig })
+	rebuilt := false
+	rebuildFPMImage = func(string, bool) error { rebuilt = true; return nil }
+
+	cmd := newPhpExtAddCmd()
+	cmd.SetArgs([]string{"ftp"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("adding a bundled extension must fail")
+	}
+	if !strings.Contains(err.Error(), "already ships") {
+		t.Errorf("error should say the image already ships it, got: %v", err)
+	}
+	if rebuilt {
+		t.Error("a rejected add must not rebuild the image")
+	}
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if slices.Contains(cfg.GetExtensions(), "ftp") {
+		t.Errorf("a rejected add must not declare the extension: %v", cfg.GetExtensions())
 	}
 }

--- a/internal/mcp/php_ext_add_test.go
+++ b/internal/mcp/php_ext_add_test.go
@@ -1,0 +1,37 @@
+package mcp
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// The MCP path takes the same guard as the CLI: declaring an extension the
+// image already ships rebuilds it generically on top of the base image and
+// loses the configure flags that build gave it (#1576).
+func TestExecPHPExtAdd_RejectsABundledExtension(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+
+	res, rpcErr := execPHPExtAdd(map[string]any{"extension": "ftp", "version": "8.5"})
+	if rpcErr != nil {
+		t.Fatalf("execPHPExtAdd: %v", rpcErr)
+	}
+	text, isErr := textOf(t, res)
+	if !isErr || !strings.Contains(text, "already ships") {
+		t.Fatalf("adding a bundled extension must fail with an 'already ships' message, got isError=%v: %s", isErr, text)
+	}
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if slices.Contains(cfg.GetExtensions(), "ftp") {
+		t.Errorf("a rejected add must not declare the extension: %v", cfg.GetExtensions())
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -4479,6 +4479,12 @@ func execPHPExtAdd(args map[string]any) (any, *rpcError) {
 		return toolErr(err.Error()), nil
 	}
 
+	// Declaring a bundled extension makes every build rebuild it on top of the
+	// base image, which loses the configure flags that build gave it (#1576).
+	if len(podman.WithoutBundled(version, []string{ext})) == 0 {
+		return toolErr(fmt.Sprintf("extension %q already ships in the PHP %s image, nothing to add", ext, version)), nil
+	}
+
 	deps, err := podman.ParseApkDeps(strArg(args, "apk_deps"))
 	if err != nil {
 		return toolErr(err.Error()), nil

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -262,7 +262,7 @@ func FPMImageCurrent(version string) bool {
 		return false
 	}
 	return fpmImageCurrent(FPMImageName(version), hash,
-		customSetHash(cfg.GetExtensions(), cfg.AllExtApkDeps(), cfg.GetPackages()))
+		customSetHash(version, cfg.GetExtensions(), cfg.AllExtApkDeps(), cfg.GetPackages()))
 }
 
 // imageLabel reads a single label from a local image. Returns "" on any
@@ -501,7 +501,7 @@ func buildFPMImage(version string, force, local bool, customExts []string, extDe
 	if hashErr != nil {
 		return false, fmt.Errorf("computing Containerfile hash for label: %w", hashErr)
 	}
-	customHash := customSetHash(customExts, extDeps, packages)
+	customHash := customSetHash(version, customExts, extDeps, packages)
 
 	if !force && fpmImageCurrent(imageName, canonicalHash, customHash) {
 		return false, nil

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -535,7 +535,7 @@ func buildFPMImage(version string, force, local bool, customExts []string, extDe
 			baseDigest, _ = refreshManifestDigestFn(baseRef)
 			containerfile = "FROM " + baseRef + "\n" +
 				mysqlClientCompatBlock +
-				buildCustomExtBlockWithToolchain(customExts, extDeps) +
+				buildCustomExtBlockWithToolchain(version, customExts, extDeps) +
 				buildCustomPackagesBlock(packages) +
 				mkcertCABlock(tmp)
 			goto build
@@ -558,8 +558,8 @@ func buildFPMImage(version string, force, local bool, customExts []string, extDe
 		// The placeholder carries the upstream php image tag, which is not the
 		// lerd version for a prerelease: 8.6 has no plain -fpm-alpine tag yet.
 		containerfile = strings.ReplaceAll(tmpl, "{{.Version}}", config.UpstreamPHPTag(version))
-		containerfile = strings.ReplaceAll(containerfile, "{{.CustomExtensions}}", buildCustomExtBlock(customExts, extDeps))
-		containerfile = strings.ReplaceAll(containerfile, "{{.CustomExtensionsRuntime}}", buildCustomExtRuntimeDeps(customExts, extDeps))
+		containerfile = strings.ReplaceAll(containerfile, "{{.CustomExtensions}}", buildCustomExtBlock(version, customExts, extDeps))
+		containerfile = strings.ReplaceAll(containerfile, "{{.CustomExtensionsRuntime}}", buildCustomExtRuntimeDeps(version, customExts, extDeps))
 		containerfile = strings.ReplaceAll(containerfile, "{{.CustomPackages}}", buildCustomPackagesBlock(packages))
 		containerfile = strings.ReplaceAll(containerfile, "{{.MkcertCA}}", mkcertCABlock(tmp))
 	}
@@ -652,10 +652,10 @@ func apkDepsForExt(ext string, userDeps map[string][]string) []string {
 // buildCustomExtRuntimeDeps emits an apk RUN line that reinstalls the
 // builder-stage deps in the runtime stage so compiled .so files can
 // dlopen against those system libs. Empty when no custom exts have deps.
-func buildCustomExtRuntimeDeps(exts []string, userDeps map[string][]string) string {
+func buildCustomExtRuntimeDeps(phpVersion string, exts []string, userDeps map[string][]string) string {
 	seen := map[string]bool{}
 	var deps []string
-	for _, ext := range exts {
+	for _, ext := range WithoutBundled(phpVersion, exts) {
 		for _, pkg := range apkDepsForExt(ext, userDeps) {
 			if seen[pkg] {
 				continue
@@ -678,19 +678,20 @@ var phpizeToolchain = []string{"autoconf", "make", "g++", "linux-headers"}
 // buildCustomExtBlock generates Dockerfile RUN blocks for user-configured
 // extensions, apk-adding any extra build deps (built-in map ∪ userDeps) first.
 // This is the builder stage's block, which already has a toolchain to build in.
-func buildCustomExtBlock(exts []string, userDeps map[string][]string) string {
-	return customExtBlock(exts, userDeps, false)
+func buildCustomExtBlock(phpVersion string, exts []string, userDeps map[string][]string) string {
+	return customExtBlock(phpVersion, exts, userDeps, false)
 }
 
 // buildCustomExtBlockWithToolchain is the same block for the fast path, which
 // layers straight onto the pre-built runtime image and so has no toolchain to
 // build against. It installs one virtually and purges it inside the same layer,
 // leaving the runtime image the size it was.
-func buildCustomExtBlockWithToolchain(exts []string, userDeps map[string][]string) string {
-	return customExtBlock(exts, userDeps, true)
+func buildCustomExtBlockWithToolchain(phpVersion string, exts []string, userDeps map[string][]string) string {
+	return customExtBlock(phpVersion, exts, userDeps, true)
 }
 
-func customExtBlock(exts []string, userDeps map[string][]string, withToolchain bool) string {
+func customExtBlock(phpVersion string, exts []string, userDeps map[string][]string, withToolchain bool) string {
+	exts = WithoutBundled(phpVersion, exts)
 	if len(exts) == 0 {
 		return ""
 	}

--- a/internal/podman/build_test.go
+++ b/internal/podman/build_test.go
@@ -67,7 +67,7 @@ func TestBaseImagePullResolvesFromRegistry(t *testing.T) {
 }
 
 func TestBuildCustomExtBlock_Empty(t *testing.T) {
-	if got := buildCustomExtBlock(nil, nil); got != "" {
+	if got := buildCustomExtBlock("8.5", nil, nil); got != "" {
 		t.Errorf("expected empty block for no extensions, got:\n%s", got)
 	}
 }
@@ -123,7 +123,7 @@ func TestBaseContainerfileHash_StripsCustomPackages(t *testing.T) {
 func TestBuildCustomExtBlock_BuiltinDeps(t *testing.T) {
 	// imap's PECL build needs Alpine packages that aren't in the base image
 	// (otherwise "U8T_CANONICAL is missing"), and it asks interactive prompts.
-	block := buildCustomExtBlock([]string{"imap"}, nil)
+	block := buildCustomExtBlock("8.5", []string{"imap"}, nil)
 	if !strings.Contains(block, "apk add --no-cache imap-dev krb5-dev openssl-dev c-client && ") {
 		t.Errorf("imap block must apk add its built-in deps before installing:\n%s", block)
 	}
@@ -140,7 +140,7 @@ func TestBuildCustomExtBlock_UserDepsUnionedWithBuiltin(t *testing.T) {
 		"imap": {"krb5-dev", "extra-pkg"}, // krb5-dev is also built-in → deduped
 		"ssh2": {"libssh2-dev"},
 	}
-	block := buildCustomExtBlock([]string{"imap", "ssh2", "redis"}, userDeps)
+	block := buildCustomExtBlock("8.5", []string{"imap", "ssh2", "yaml"}, userDeps)
 	// imap: built-in (imap-dev krb5-dev openssl-dev c-client) ∪ user (krb5-dev extra-pkg)
 	if !strings.Contains(block, "apk add --no-cache imap-dev krb5-dev openssl-dev c-client extra-pkg && ") {
 		t.Errorf("imap block must union built-in + user deps without duplicates:\n%s", block)
@@ -149,20 +149,20 @@ func TestBuildCustomExtBlock_UserDepsUnionedWithBuiltin(t *testing.T) {
 	if !strings.Contains(block, "apk add --no-cache libssh2-dev && ") {
 		t.Errorf("ssh2 block must apk add the user-supplied dep:\n%s", block)
 	}
-	// redis: no deps anywhere → no apk add
+	// yaml: no deps anywhere → no apk add
 	for _, line := range strings.Split(block, "\n") {
-		if strings.Contains(line, "pecl install redis") && strings.Contains(line, "apk add") {
-			t.Errorf("redis block should not have an apk add line:\n%s", line)
+		if strings.Contains(line, "pecl install yaml") && strings.Contains(line, "apk add") {
+			t.Errorf("yaml block should not have an apk add line:\n%s", line)
 		}
 	}
 }
 
 func TestBuildCustomExtBlockWithToolchain(t *testing.T) {
-	if got := buildCustomExtBlockWithToolchain(nil, nil); got != "" {
+	if got := buildCustomExtBlockWithToolchain("8.5", nil, nil); got != "" {
 		t.Errorf("expected empty block for no extensions, got:\n%s", got)
 	}
 	// The prebuilt base is the runtime image, so phpize has no toolchain there.
-	block := buildCustomExtBlockWithToolchain([]string{"yaml"}, map[string][]string{"yaml": {"yaml-dev"}})
+	block := buildCustomExtBlockWithToolchain("8.5", []string{"yaml"}, map[string][]string{"yaml": {"yaml-dev"}})
 	for _, pkg := range phpizeToolchain {
 		if !strings.Contains(block, pkg) {
 			t.Errorf("fast-path block must install %q for phpize:\n%s", pkg, block)
@@ -190,17 +190,17 @@ func TestBuildCustomExtBlockWithToolchain(t *testing.T) {
 // The builder stage already carries the toolchain, so the local path must not
 // install or purge it: purging there would take the stage's own compilers out.
 func TestBuildCustomExtBlock_NoToolchainOnLocalPath(t *testing.T) {
-	block := buildCustomExtBlock([]string{"yaml"}, nil)
+	block := buildCustomExtBlock("8.5", []string{"yaml"}, nil)
 	if strings.Contains(block, ".lerd-ext-build") {
 		t.Errorf("builder-stage block must not manage the toolchain:\n%s", block)
 	}
 }
 
 func TestBuildCustomExtRuntimeDeps_Empty(t *testing.T) {
-	if got := buildCustomExtRuntimeDeps(nil, nil); got != "" {
+	if got := buildCustomExtRuntimeDeps("8.5", nil, nil); got != "" {
 		t.Errorf("empty input should produce empty runtime block, got: %q", got)
 	}
-	if got := buildCustomExtRuntimeDeps([]string{"redis"}, nil); got != "" {
+	if got := buildCustomExtRuntimeDeps("8.5", []string{"yaml"}, nil); got != "" {
 		t.Errorf("extension with no apk deps should produce empty block, got: %q", got)
 	}
 }
@@ -219,8 +219,8 @@ func TestBuildCustomExtRuntimeDeps_MatchesBuilderDeps(t *testing.T) {
 		{[]string{"imap"}, map[string][]string{"imap": {"extra-pkg"}}},
 	}
 	for _, c := range cases {
-		runtime := buildCustomExtRuntimeDeps(c.exts, c.userDeps)
-		builder := buildCustomExtBlock(c.exts, c.userDeps)
+		runtime := buildCustomExtRuntimeDeps("8.5", c.exts, c.userDeps)
+		builder := buildCustomExtBlock("8.5", c.exts, c.userDeps)
 		if runtime == "" {
 			t.Errorf("exts=%v deps=%v: runtime block unexpectedly empty", c.exts, c.userDeps)
 			continue
@@ -245,6 +245,7 @@ func TestBuildCustomExtRuntimeDeps_DedupsAcrossExts(t *testing.T) {
 	// Two extensions sharing the same dep (krb5-dev appears in imap's
 	// built-in list and is also a user dep) must list it exactly once.
 	got := buildCustomExtRuntimeDeps(
+		"8.5",
 		[]string{"imap", "ssh2"},
 		map[string][]string{
 			"imap": {"krb5-dev"},
@@ -614,5 +615,29 @@ func TestPhpFpmContainerfile_PrereleaseBuildsFromPrereleaseTag(t *testing.T) {
 		if !strings.Contains(cf, "php:"+v+"-rc-fpm-alpine") {
 			t.Errorf("PHP %s does not build FROM the prerelease tag", v)
 		}
+	}
+}
+
+// The custom-extension block must skip anything the image already ships: a bare
+// `docker-php-ext-install ftp` layered on the base image rebuilds ext/ftp
+// without the OpenSSL configure flags the base build passes, so ftp_ssl_connect
+// disappears again (#1576).
+func TestBuildCustomExtBlock_SkipsBundledExtensions(t *testing.T) {
+	for name, block := range map[string]string{
+		"builder":   buildCustomExtBlock("8.5", []string{"ftp", "yaml"}, nil),
+		"toolchain": buildCustomExtBlockWithToolchain("8.5", []string{"ftp", "yaml"}, nil),
+	} {
+		if strings.Contains(block, "ftp") {
+			t.Errorf("%s block rebuilds the bundled ftp extension:\n%s", name, block)
+		}
+		if !strings.Contains(block, "yaml") {
+			t.Errorf("%s block dropped the custom yaml extension:\n%s", name, block)
+		}
+	}
+	if got := buildCustomExtBlock("8.5", []string{"ftp"}, nil); got != "" {
+		t.Errorf("a bundled-only set must produce no block, got:\n%s", got)
+	}
+	if got := buildCustomExtRuntimeDeps("8.5", []string{"ftp"}, map[string][]string{"ftp": {"openssl-dev"}}); got != "" {
+		t.Errorf("a bundled extension must not pull runtime deps, got:\n%s", got)
 	}
 }

--- a/internal/podman/custom_set.go
+++ b/internal/podman/custom_set.go
@@ -19,11 +19,16 @@ import (
 // declared, so a second label carries what the first cannot.
 const fpmCustomSetHashLabel = "dev.lerd.fpm.custom-set-hash"
 
-// customSetHash fingerprints the declared set. Sorted, so the order entries were
-// added in never rebuilds an image; empty for an empty set, so images built
-// before this label existed (which read back as "") still count as current for
-// the users who declare nothing.
-func customSetHash(exts []string, extDeps map[string][]string, packages []string) string {
+// customSetHash fingerprints the declared set the build will actually realise.
+// Sorted, so the order entries were added in never rebuilds an image; empty for
+// an empty set, so images built before this label existed (which read back as
+// "") still count as current for the users who declare nothing.
+//
+// Bundled names are dropped because the build skips them: an image built while
+// a declared ftp still clobbered the base image's own keeps the fingerprint of
+// that set, so leaving the name in would leave it looking current forever.
+func customSetHash(phpVersion string, exts []string, extDeps map[string][]string, packages []string) string {
+	exts = WithoutBundled(phpVersion, exts)
 	if len(exts) == 0 && len(packages) == 0 {
 		return ""
 	}
@@ -33,6 +38,9 @@ func customSetHash(exts []string, extDeps map[string][]string, packages []string
 	}
 	deps := make([]string, 0, len(extDeps))
 	for ext, d := range extDeps {
+		if len(WithoutBundled(phpVersion, []string{ext})) == 0 {
+			continue
+		}
 		deps = append(deps, ext+"="+strings.Join(sortedCopy(d), ","))
 	}
 	parts = append(parts, sortedCopy(deps)...)
@@ -129,7 +137,7 @@ func FPMImageStale(version string) bool {
 	if err != nil {
 		return false
 	}
-	want := customSetHash(cfg.GetExtensions(), cfg.AllExtApkDeps(), cfg.GetPackages())
+	want := customSetHash(version, cfg.GetExtensions(), cfg.AllExtApkDeps(), cfg.GetPackages())
 	return imageLabelFn(FPMImageName(version), fpmCustomSetHashLabel) != want
 }
 
@@ -163,7 +171,7 @@ func RecordRealisedSet(version string, declaredExts, declaredPkgs []string) {
 	if err != nil {
 		return
 	}
-	set.Hash = customSetHash(declaredExts, cfg.AllExtApkDeps(), declaredPkgs)
+	set.Hash = customSetHash(version, declaredExts, cfg.AllExtApkDeps(), declaredPkgs)
 	cfg.SetRealised(version, set)
 	_ = config.SaveGlobal(cfg)
 }

--- a/internal/podman/custom_set_test.go
+++ b/internal/podman/custom_set_test.go
@@ -12,18 +12,18 @@ import (
 // The declared set is what drives a version's image content, so its fingerprint
 // must move when the set does and stay put when it doesn't.
 func TestCustomSetHash_tracksTheDeclaredSet(t *testing.T) {
-	base := customSetHash([]string{"mongodb"}, map[string][]string{"mongodb": {"openssl-dev"}}, []string{"chromium"})
+	base := customSetHash("8.5", []string{"ssh2"}, map[string][]string{"ssh2": {"libssh2-dev"}}, []string{"chromium"})
 
-	if got := customSetHash([]string{"mongodb"}, map[string][]string{"mongodb": {"openssl-dev"}}, []string{"chromium"}); got != base {
+	if got := customSetHash("8.5", []string{"ssh2"}, map[string][]string{"ssh2": {"libssh2-dev"}}, []string{"chromium"}); got != base {
 		t.Error("the same declared set produced a different hash")
 	}
 	for _, tc := range []struct {
 		name string
 		hash string
 	}{
-		{"added extension", customSetHash([]string{"mongodb", "imagick"}, map[string][]string{"mongodb": {"openssl-dev"}}, []string{"chromium"})},
-		{"added package", customSetHash([]string{"mongodb"}, map[string][]string{"mongodb": {"openssl-dev"}}, []string{"chromium", "jq"})},
-		{"changed apk deps", customSetHash([]string{"mongodb"}, map[string][]string{"mongodb": {"krb5-dev"}}, []string{"chromium"})},
+		{"added extension", customSetHash("8.5", []string{"ssh2", "yaml"}, map[string][]string{"ssh2": {"libssh2-dev"}}, []string{"chromium"})},
+		{"added package", customSetHash("8.5", []string{"ssh2"}, map[string][]string{"ssh2": {"libssh2-dev"}}, []string{"chromium", "jq"})},
+		{"changed apk deps", customSetHash("8.5", []string{"ssh2"}, map[string][]string{"ssh2": {"krb5-dev"}}, []string{"chromium"})},
 	} {
 		if tc.hash == base {
 			t.Errorf("%s did not drift the hash", tc.name)
@@ -34,8 +34,8 @@ func TestCustomSetHash_tracksTheDeclaredSet(t *testing.T) {
 // The set is a set: the order the user happened to add entries in must not
 // rebuild every image.
 func TestCustomSetHash_ignoresDeclarationOrder(t *testing.T) {
-	a := customSetHash([]string{"mongodb", "imagick"}, nil, []string{"chromium", "jq"})
-	b := customSetHash([]string{"imagick", "mongodb"}, nil, []string{"jq", "chromium"})
+	a := customSetHash("8.5", []string{"ssh2", "yaml"}, nil, []string{"chromium", "jq"})
+	b := customSetHash("8.5", []string{"yaml", "ssh2"}, nil, []string{"jq", "chromium"})
 	if a != b {
 		t.Error("declaration order changed the hash, which would rebuild images for nothing")
 	}
@@ -45,8 +45,27 @@ func TestCustomSetHash_ignoresDeclarationOrder(t *testing.T) {
 // label existed carry no label, which reads back as "": a user with no custom
 // extensions must not have every image rebuilt on upgrade for nothing.
 func TestCustomSetHash_emptySetIsEmpty(t *testing.T) {
-	if got := customSetHash(nil, nil, nil); got != "" {
+	if got := customSetHash("8.5", nil, nil, nil); got != "" {
 		t.Errorf("customSetHash(empty) = %q, want empty so unlabelled images still match", got)
+	}
+}
+
+// The build skips a declared extension the image already ships, so it must not
+// fingerprint the image either. An install that declared ftp before #1576 keeps
+// the label it was built with, so dropping the name from the fingerprint is what
+// makes that image read as stale once and rebuild onto the base image's own ftp.
+func TestCustomSetHash_ignoresBundledExtensions(t *testing.T) {
+	if got := customSetHash("8.5", []string{"ftp"}, map[string][]string{"ftp": {"openssl-dev"}}, nil); got != "" {
+		t.Errorf("a set of nothing but bundled extensions must fingerprint as empty, got %q", got)
+	}
+	withBundled := customSetHash("8.5", []string{"ftp", "yaml"}, nil, nil)
+	withoutBundled := customSetHash("8.5", []string{"yaml"}, nil, nil)
+	if withBundled != withoutBundled {
+		t.Error("a bundled extension alongside a custom one changed the fingerprint, so the image tracks something it never builds")
+	}
+	// The version gate still holds: 8.1's image has no ext/random to preserve.
+	if customSetHash("8.1", []string{"random"}, nil, nil) == "" {
+		t.Error("random is a real custom extension on 8.1 and must still fingerprint the image")
 	}
 }
 

--- a/internal/podman/extensions.go
+++ b/internal/podman/extensions.go
@@ -60,6 +60,24 @@ func BundledExtensions(phpVersion string) []string {
 	return bundled
 }
 
+// WithoutBundled drops the extensions the image for phpVersion already ships.
+// Rebuilding one as a custom extension layers a bare docker-php-ext-install on
+// top of the base image, which loses the configure flags the base build passed
+// it: that is how ftp lost FTPS support after #1583 (#1576).
+func WithoutBundled(phpVersion string, exts []string) []string {
+	bundled := map[string]bool{}
+	for _, e := range BundledExtensions(phpVersion) {
+		bundled[e] = true
+	}
+	kept := make([]string, 0, len(exts))
+	for _, e := range exts {
+		if !bundled[CanonicalExtension(e)] {
+			kept = append(kept, e)
+		}
+	}
+	return kept
+}
+
 // BundledSince returns the first PHP version that ships ext, for the extensions an
 // older image genuinely cannot build. The second result is false for every other
 // extension, which is the ones php:ext add can install on request.

--- a/internal/podman/extensions_test.go
+++ b/internal/podman/extensions_test.go
@@ -97,3 +97,25 @@ func TestBundledExtensionsDropsPECLOnPrerelease(t *testing.T) {
 		t.Error("BundledExtensions(8.5) lost xdebug; the prerelease rule leaked into a released version")
 	}
 }
+
+// A declared extension the image already ships must be dropped: rebuilding it
+// generically on top of the base image loses the configure flags the base build
+// gave it, which is how ftp lost FTPS support again after #1583 (#1576).
+func TestWithoutBundled(t *testing.T) {
+	got := WithoutBundled("8.5", []string{"ftp", "yaml", "Zend-OPcache", "ssh2"})
+	want := []string{"yaml", "ssh2"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("WithoutBundled = %v, want %v", got, want)
+	}
+}
+
+// Version-gated names are not bundled everywhere, so a version whose image
+// cannot build one must still be allowed to install it as a custom extension.
+func TestWithoutBundled_KeepsVersionGatedNames(t *testing.T) {
+	if got := WithoutBundled("8.1", []string{"random"}); len(got) != 1 {
+		t.Errorf("WithoutBundled dropped random on 8.1, where the image does not ship it: %v", got)
+	}
+	if got := WithoutBundled("8.2", []string{"random"}); len(got) != 0 {
+		t.Errorf("WithoutBundled kept random on 8.2, where the image ships it: %v", got)
+	}
+}


### PR DESCRIPTION
The image compiles its bundled extensions as part of its own configure run, with flags a standalone build layered on top cannot pass. A declared custom extension that names one of them rebuilds it generically anyway, so the better build is quietly replaced: ftp came back without OpenSSL and lost `ftp_ssl_connect` again, right after the base image had been fixed to ship it.

Builds now skip any bundled name in the declared set, which heals a declaration that is already there, and `php:ext add` refuses one up front rather than starting a rebuild that can only make the image worse.

Refs #1576