### PR TITLE
fix(workers): keep a worker that is down in the site's declared set

### DIFF
--- a/docs/usage/framework-workers.md
+++ b/docs/usage/framework-workers.md
@@ -138,6 +138,8 @@ A worker gated on a composer package belongs to the package, not to the framewor
 
 ## Project-specific custom workers
 
+The `workers:` list is what `lerd start` brings back, and it follows the worker units lerd has written rather than what happens to be running at the moment you touch another worker. Starting a worker adds it, stopping one by name removes it, and a worker that is merely down, crash-looping or stopped for a rebuild, stays on the list and starts again with the rest.
+
 Add workers to `.lerd.yaml` for project-specific needs that don't belong in the framework definition:
 
 ```yaml

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -14,6 +14,7 @@ import (
 	"github.com/geodro/lerd/internal/nginx"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/services"
 	"github.com/geodro/lerd/internal/siteinfo"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	"github.com/spf13/cobra"
@@ -385,9 +386,44 @@ func startServicesForSiteNoticed(sitePath, siteName string) {
 }
 
 // CollectRunningWorkerNames returns the names of active workers for the site,
-// including stripe. Used to sync .lerd.yaml.
+// including stripe. Used to snapshot what to bring back after a restart.
 func CollectRunningWorkerNames(site *config.Site) []string {
 	return collectRunningWorkers(site)
+}
+
+// CollectDeclaredWorkerNames returns the workers a site has units installed
+// for. The list in .lerd.yaml is what `lerd start` brings back, so it follows
+// the units on disk rather than what happens to be running: a unit is written
+// when a worker starts and removed when it stops, while a worker that is merely
+// down keeps its own. Snapshotting the running set instead wrote a crash-looping
+// worker out of the file the next time any other worker was touched, and nothing
+// started it again (#1627).
+func CollectDeclaredWorkerNames(site *config.Site) []string {
+	declared := collectRunningWorkers(site)
+	seen := make(map[string]bool, len(declared))
+	for _, w := range declared {
+		seen[w] = true
+	}
+	installed := make(map[string]bool)
+	for _, u := range services.Mgr.ListServiceUnits("lerd-*") {
+		installed[u] = true
+	}
+	for _, u := range services.Mgr.ListTimerUnits("lerd-*") {
+		installed[strings.TrimSuffix(u, ".timer")] = true
+	}
+	if fw, ok := config.GetFrameworkForDir(site.Framework, site.Path); ok && fw.Workers != nil {
+		names := make([]string, 0, len(fw.Workers))
+		for wName := range fw.Workers {
+			names = append(names, wName)
+		}
+		sort.Strings(names)
+		for _, wName := range names {
+			if !seen[wName] && installed["lerd-"+wName+"-"+site.Name] {
+				declared = append(declared, wName)
+			}
+		}
+	}
+	return declared
 }
 
 // collectRunningWorkers returns the names of all active or restarting workers

--- a/internal/cli/stripe.go
+++ b/internal/cli/stripe.go
@@ -133,7 +133,7 @@ func newStripeListenCmd() *cobra.Command {
 				return err
 			}
 			if site, err := config.FindSite(siteName); err == nil && !site.Paused {
-				_ = config.SetProjectWorkers(site.Path, CollectRunningWorkerNames(site))
+				_ = config.SetProjectWorkers(site.Path, CollectDeclaredWorkerNames(site))
 			}
 			return nil
 		},
@@ -162,7 +162,7 @@ func newStripeListenStopCmd() *cobra.Command {
 				return err
 			}
 			if site, err := config.FindSite(siteName); err == nil && !site.Paused {
-				_ = config.SetProjectWorkers(site.Path, CollectRunningWorkerNames(site))
+				_ = config.SetProjectWorkers(site.Path, CollectDeclaredWorkerNames(site))
 			}
 			return nil
 		},

--- a/internal/cli/worker_cmds.go
+++ b/internal/cli/worker_cmds.go
@@ -279,7 +279,7 @@ func runWorkerStart(name string, tuned map[string]string) error {
 		return err
 	}
 	if !site.Paused {
-		_ = config.SetProjectWorkers(site.Path, CollectRunningWorkerNames(site))
+		_ = config.SetProjectWorkers(site.Path, CollectDeclaredWorkerNames(site))
 	}
 	return nil
 }
@@ -305,7 +305,7 @@ func runWorkerStop(name string) error {
 		return err
 	}
 	if !site.Paused {
-		_ = config.SetProjectWorkers(site.Path, CollectRunningWorkerNames(site))
+		_ = config.SetProjectWorkers(site.Path, CollectDeclaredWorkerNames(site))
 	}
 	return nil
 }

--- a/internal/cli/worker_declared_test.go
+++ b/internal/cli/worker_declared_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// listUnitsMgr answers the unit-file listing off a fixed set, which is what
+// tells a worker the user still wants from one that was stopped.
+type listUnitsMgr struct {
+	stopTrackingMgr
+	units []string
+}
+
+func (l *listUnitsMgr) ListServiceUnits(string) []string { return slices.Clone(l.units) }
+func (l *listUnitsMgr) ListTimerUnits(string) []string   { return nil }
+
+// writeWorkerFrameworkFixture puts a store definition carrying the named
+// workers where GetFrameworkForDir will resolve it for a site on that framework.
+func writeWorkerFrameworkFixture(t *testing.T, sitePath string, workers ...string) {
+	t.Helper()
+	storeDir := config.StoreFrameworksDir()
+	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	def := "name: laravel\nlabel: Laravel\nworkers:\n"
+	for _, w := range workers {
+		def += "  " + w + ":\n    label: " + w + "\n    command: php artisan " + w + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(storeDir, "laravel.yaml"), []byte(def), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sitePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sitePath, ".lerd.yaml"), []byte("framework: laravel\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The declared set follows the units on disk rather than what is running. A
+// worker that is merely down when another one is touched still has its unit,
+// and writing it out of .lerd.yaml is what stopped lerd start from ever
+// bringing it back (#1627).
+func TestCollectDeclaredWorkerNames_keepsAWorkerThatIsNotRunning(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	sitePath := filepath.Join(t.TempDir(), "app")
+	writeWorkerFrameworkFixture(t, sitePath, "queue", "horizon")
+	swapServiceMgr(t, &listUnitsMgr{units: []string{"lerd-queue-app", "lerd-horizon-app"}})
+
+	got := CollectDeclaredWorkerNames(&config.Site{Name: "app", Path: sitePath, Framework: "laravel"})
+	for _, want := range []string{"queue", "horizon"} {
+		if !slices.Contains(got, want) {
+			t.Errorf("worker %q has a unit installed and must stay declared, got %v", want, got)
+		}
+	}
+}
+
+// Stopping a worker removes its unit, which is how the set learns the user is
+// done with it.
+func TestCollectDeclaredWorkerNames_dropsAWorkerWithNoUnit(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	sitePath := filepath.Join(t.TempDir(), "app")
+	writeWorkerFrameworkFixture(t, sitePath, "queue", "horizon")
+	swapServiceMgr(t, &listUnitsMgr{units: []string{"lerd-queue-app"}})
+
+	got := CollectDeclaredWorkerNames(&config.Site{Name: "app", Path: sitePath, Framework: "laravel"})
+	if slices.Contains(got, "horizon") {
+		t.Errorf("a worker whose unit a stop removed must leave the set, got %v", got)
+	}
+	if !slices.Contains(got, "queue") {
+		t.Errorf("the remaining worker must stay declared, got %v", got)
+	}
+}

--- a/internal/cli/worker_declared_test.go
+++ b/internal/cli/worker_declared_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/services"
 )
 
 // listUnitsMgr answers the unit-file listing off a fixed set, which is what
@@ -18,6 +19,15 @@ type listUnitsMgr struct {
 
 func (l *listUnitsMgr) ListServiceUnits(string) []string { return slices.Clone(l.units) }
 func (l *listUnitsMgr) ListTimerUnits(string) []string   { return nil }
+
+// useServiceMgr installs m for the duration of the test. The linux-only test
+// files have their own swap helper; this one has to build on macOS too.
+func useServiceMgr(t *testing.T, m services.ServiceManager) {
+	t.Helper()
+	prev := services.Mgr
+	services.Mgr = m
+	t.Cleanup(func() { services.Mgr = prev })
+}
 
 // writeWorkerFrameworkFixture puts a store definition carrying the named
 // workers where GetFrameworkForDir will resolve it for a site on that framework.
@@ -52,7 +62,7 @@ func TestCollectDeclaredWorkerNames_keepsAWorkerThatIsNotRunning(t *testing.T) {
 
 	sitePath := filepath.Join(t.TempDir(), "app")
 	writeWorkerFrameworkFixture(t, sitePath, "queue", "horizon")
-	swapServiceMgr(t, &listUnitsMgr{units: []string{"lerd-queue-app", "lerd-horizon-app"}})
+	useServiceMgr(t, &listUnitsMgr{units: []string{"lerd-queue-app", "lerd-horizon-app"}})
 
 	got := CollectDeclaredWorkerNames(&config.Site{Name: "app", Path: sitePath, Framework: "laravel"})
 	for _, want := range []string{"queue", "horizon"} {
@@ -70,7 +80,7 @@ func TestCollectDeclaredWorkerNames_dropsAWorkerWithNoUnit(t *testing.T) {
 
 	sitePath := filepath.Join(t.TempDir(), "app")
 	writeWorkerFrameworkFixture(t, sitePath, "queue", "horizon")
-	swapServiceMgr(t, &listUnitsMgr{units: []string{"lerd-queue-app"}})
+	useServiceMgr(t, &listUnitsMgr{units: []string{"lerd-queue-app"}})
 
 	got := CollectDeclaredWorkerNames(&config.Site{Name: "app", Path: sitePath, Framework: "laravel"})
 	if slices.Contains(got, "horizon") {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -4126,7 +4126,7 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if !site.Paused {
-			_ = config.SetProjectWorkers(site.Path, cli.CollectRunningWorkerNames(site))
+			_ = config.SetProjectWorkers(site.Path, cli.CollectDeclaredWorkerNames(site))
 		}
 		writeJSON(w, SiteActionResponse{OK: true})
 		return
@@ -4183,7 +4183,7 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if !site.Paused {
-			_ = config.SetProjectWorkers(site.Path, cli.CollectRunningWorkerNames(site))
+			_ = config.SetProjectWorkers(site.Path, cli.CollectDeclaredWorkerNames(site))
 		}
 		writeJSON(w, SiteActionResponse{OK: true})
 		return
@@ -4202,7 +4202,7 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if !site.Paused {
-			_ = config.SetProjectWorkers(site.Path, cli.CollectRunningWorkerNames(site))
+			_ = config.SetProjectWorkers(site.Path, cli.CollectDeclaredWorkerNames(site))
 		}
 		writeJSON(w, SiteActionResponse{OK: true})
 		return
@@ -4233,7 +4233,7 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if !site.Paused {
-			_ = config.SetProjectWorkers(site.Path, cli.CollectRunningWorkerNames(site))
+			_ = config.SetProjectWorkers(site.Path, cli.CollectDeclaredWorkerNames(site))
 		}
 		writeJSON(w, SiteActionResponse{OK: true})
 		return
@@ -4252,7 +4252,7 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if !site.Paused {
-			_ = config.SetProjectWorkers(site.Path, cli.CollectRunningWorkerNames(site))
+			_ = config.SetProjectWorkers(site.Path, cli.CollectDeclaredWorkerNames(site))
 		}
 		writeJSON(w, SiteActionResponse{OK: true})
 		return
@@ -4724,7 +4724,7 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 					if branch == "" && !site.Paused {
-						_ = config.SetProjectWorkers(site.Path, cli.CollectRunningWorkerNames(site))
+						_ = config.SetProjectWorkers(site.Path, cli.CollectDeclaredWorkerNames(site))
 					}
 				} else {
 					fwN := site.Framework
@@ -6405,6 +6405,6 @@ func handleSiteWorktreeAdd(w http.ResponseWriter, r *http.Request) {
 func syncLerdYAMLWorkersDelayed(site *config.Site) {
 	time.Sleep(2 * time.Second)
 	if !site.Paused {
-		_ = config.SetProjectWorkers(site.Path, cli.CollectRunningWorkerNames(site))
+		_ = config.SetProjectWorkers(site.Path, cli.CollectDeclaredWorkerNames(site))
 	}
 }


### PR DESCRIPTION
The workers list in a site's .lerd.yaml is what lerd start brings back, and it was rewritten after every worker action as the set of workers running at that moment. A worker that was merely down when an unrelated one was started or stopped was not in that snapshot and was written out of the file, and nothing put it back, so from then on it never started again.

That is how a crash-looping worker disappeared for good. It is down by definition, so any worker action taken while it was failing, from the CLI or from the dashboard, dropped its declaration, and disarming those units at boot removed the accident that had been starting it. It is the second half of what #1531 reported.

The list is a declaration, so it now follows the units on disk. A worker unit is written when the worker starts and removed when it stops, which makes its presence the honest record of what was asked for, and the running set is still consulted for stripe, the host proxy dev server and orphans, which have no unit the framework definition knows about.

Closes #1627
Refs #1531