### PR TITLE
fix(install): build the dnsmasq image on the host network when the namespace resolves nothing

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -171,9 +171,9 @@ This makes glibc consult the plain `dns` module before systemd-resolved's `nss-r
 ::: details `lerd install` fails at "Building dnsmasq" with "unable to select packages"
 The dnsmasq image is the one thing lerd builds rather than pulls, and the `apk add` inside that build resolves names from the build's own network namespace, not through the host resolver that just pulled the base image. When that namespace has no working resolver, the build fails with `WARNING: fetching https://dl-cdn.alpinelinux.org/...: DNS: transient error` followed by `ERROR: unable to select packages`, even though every pull before it succeeded.
 
-lerd retries the build once with your host's real upstream nameservers pinned, which covers the common case of a stub resolver (`127.0.0.53`) that podman's default handling does not translate correctly on your setup. A rootless build cannot join the lerd network, so pinning the servers is the only lever available.
+lerd retries the build with your host's real upstream nameservers pinned, which covers the common case of a stub resolver (`127.0.0.53`) that podman's default handling does not translate correctly on your setup. When that still resolves nothing, it builds once more on the host network, which is the namespace that pulled the base image a moment earlier and so is known to work. A rootless build cannot join the lerd network, so those two are the levers available.
 
-If both attempts fail, lerd says so at the end of the install rather than reporting a clean finish: without the image, lerd-dns cannot start and no `.test` name resolves. Check what the container network can reach with `lerd doctor`, in particular the `internet DNS from containers` line, fix it, then run `lerd install` again.
+If every attempt fails, lerd says so at the end of the install rather than reporting a clean finish: without the image, lerd-dns cannot start and no `.test` name resolves. Check what the container network can reach with `lerd doctor`, in particular the `internet DNS from containers` line, fix it, then run `lerd install` again.
 :::
 
 ::: details composer or npm fails with "could not resolve host" inside a container

--- a/internal/podman/dnsmasq.go
+++ b/internal/podman/dnsmasq.go
@@ -15,25 +15,36 @@ const DNSMasqBaseImage = "docker.io/library/alpine:latest"
 
 const dnsmasqContainerfile = "FROM " + DNSMasqBaseImage + "\nRUN apk add --no-cache dnsmasq\n"
 
-// BuildDNSMasqImage builds the dnsmasq image, retrying once with nameservers
-// pinned via --dns when the plain build fails. apk resolves from inside the
-// build's own network namespace rather than through the host resolver that
-// just pulled the base image, and podman's handling of a stub resolver there
-// does not hold on every rootless host (#1537). Joining the lerd network is
-// not an alternative: a rootless build cannot attach to a named network.
+// BuildDNSMasqImage builds the dnsmasq image, falling back when apk cannot
+// resolve names. apk resolves from inside the build's own network namespace
+// rather than through the host resolver that just pulled the base image, and
+// on some rootless hosts nothing reaches a nameserver from in there at all,
+// pinned servers included (#1537). So the last attempt drops the namespace and
+// builds on the host network, which is the one that demonstrably resolved the
+// base image a moment earlier. Joining the lerd network is not an alternative:
+// a rootless build cannot attach to a named network.
 func BuildDNSMasqImage(w io.Writer, nameservers []string) error {
-	err := buildDNSMasq(w, nil)
-	if err == nil || len(nameservers) == 0 {
-		return err
+	err := buildDNSMasq(w, nil, false)
+	if err == nil {
+		return nil
 	}
-	fmt.Fprintf(w, "\nretrying with the host resolvers (%s)\n", strings.Join(nameservers, ", "))
-	return buildDNSMasq(w, nameservers)
+	if len(nameservers) > 0 {
+		fmt.Fprintf(w, "\nretrying with the host resolvers (%s)\n", strings.Join(nameservers, ", "))
+		if err = buildDNSMasq(w, nameservers, false); err == nil {
+			return nil
+		}
+	}
+	fmt.Fprintf(w, "\nretrying on the host network\n")
+	return buildDNSMasq(w, nil, true)
 }
 
-func buildDNSMasq(w io.Writer, nameservers []string) error {
+func buildDNSMasq(w io.Writer, nameservers []string, hostNetwork bool) error {
 	args := []string{"build", "-t", DNSMasqImage}
 	for _, ns := range nameservers {
 		args = append(args, "--dns", ns)
+	}
+	if hostNetwork {
+		args = append(args, "--network", "host")
 	}
 	cmd := Cmd(append(args, "-")...)
 	cmd.Stdin = strings.NewReader(dnsmasqContainerfile)

--- a/internal/podman/dnsmasq_test.go
+++ b/internal/podman/dnsmasq_test.go
@@ -32,6 +32,15 @@ func hasDNSFlag(args []string, server string) bool {
 	return false
 }
 
+func hasHostNetwork(args []string) bool {
+	for i, a := range args {
+		if a == "--network" && i+1 < len(args) && args[i+1] == "host" {
+			return true
+		}
+	}
+	return false
+}
+
 // The plain build is what works on a healthy host, so a passing one must not
 // drag the host's resolvers into the image build.
 func TestBuildDNSMasqImage_NoRetryWhenTheFirstBuildPasses(t *testing.T) {
@@ -75,15 +84,59 @@ func TestBuildDNSMasqImage_RetriesWithTheHostResolvers(t *testing.T) {
 	}
 }
 
-// With nothing to pin, a second identical build would only double the wait
-// before the same failure.
-func TestBuildDNSMasqImage_NoRetryWithoutNameservers(t *testing.T) {
+// With nothing to pin, the pinned retry has no servers to use, so the host
+// network is the only fallback left.
+func TestBuildDNSMasqImage_FallsBackToTheHostNetworkWithoutNameservers(t *testing.T) {
 	prev := execCommand
 	t.Cleanup(func() { execCommand = prev })
 	var calls [][]string
-	execCommand = recordExec(&calls, 1, 1)
+	execCommand = recordExec(&calls, 1, 0)
 
-	err := BuildDNSMasqImage(io.Discard, nil)
+	if err := BuildDNSMasqImage(io.Discard, nil); err != nil {
+		t.Fatalf("BuildDNSMasqImage() = %v, want nil once the host-network build succeeds", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("ran %d builds, want 2", len(calls))
+	}
+	if !hasHostNetwork(calls[1]) {
+		t.Errorf("fallback args %v do not build on the host network", calls[1])
+	}
+}
+
+// The reported host resolves nothing from inside the build namespace, pinned
+// servers included, so the host network has to be tried after the pinned retry.
+func TestBuildDNSMasqImage_FallsBackToTheHostNetworkAfterThePinnedRetry(t *testing.T) {
+	prev := execCommand
+	t.Cleanup(func() { execCommand = prev })
+	var calls [][]string
+	execCommand = recordExec(&calls, 1, 1, 0)
+
+	if err := BuildDNSMasqImage(io.Discard, []string{"192.0.2.1"}); err != nil {
+		t.Fatalf("BuildDNSMasqImage() = %v, want nil once the host-network build succeeds", err)
+	}
+	if len(calls) != 3 {
+		t.Fatalf("ran %d builds, want 3", len(calls))
+	}
+	if hasDNSFlag(calls[2], "192.0.2.1") {
+		t.Error("the host-network build must not also pin resolvers the namespace could not reach")
+	}
+	if !hasHostNetwork(calls[2]) {
+		t.Errorf("fallback args %v do not build on the host network", calls[2])
+	}
+	if calls[2][len(calls[2])-1] != "-" {
+		t.Errorf("fallback args %v must still read the Containerfile from stdin", calls[2])
+	}
+}
+
+// When even the host network cannot build, the caller has to see the real
+// failure rather than a wrapped one.
+func TestBuildDNSMasqImage_ReturnsTheLastFailure(t *testing.T) {
+	prev := execCommand
+	t.Cleanup(func() { execCommand = prev })
+	var calls [][]string
+	execCommand = recordExec(&calls, 1, 1, 1)
+
+	err := BuildDNSMasqImage(io.Discard, []string{"192.0.2.1"})
 	if err == nil {
 		t.Fatal("BuildDNSMasqImage() = nil, want the build error")
 	}
@@ -91,8 +144,8 @@ func TestBuildDNSMasqImage_NoRetryWithoutNameservers(t *testing.T) {
 	if !errors.As(err, &exitErr) {
 		t.Errorf("err = %v, want the underlying build failure", err)
 	}
-	if len(calls) != 1 {
-		t.Fatalf("ran %d builds, want 1", len(calls))
+	if len(calls) != 3 {
+		t.Fatalf("ran %d builds, want 3", len(calls))
 	}
 }
 


### PR DESCRIPTION
The retry added in #1579 pins the host's real upstream nameservers, which fixes a stub resolver podman does not translate into the build namespace. The reporter came back with the same failure after building by hand with a public resolver pinned, so on that machine nothing in the build namespace reaches a nameserver at all and there is no server worth pinning.

So the build now falls back once more, on the host network. That is the namespace that pulled the alpine base image successfully seconds earlier, which is why every step above the build succeeded in the original log while only the build failed. A rootless build still cannot attach to the lerd network, so this is the last lever there is.

Checked on Arch and on Ubuntu 26.04 with podman 5.7, where the host-network build resolves through the systemd stub without trouble.

Refs #1537
