### PR TITLE
fix(uninstall): remove the launcher icon without taking the data directory

### DIFF
--- a/internal/desktopapp/desktopapp_linux.go
+++ b/internal/desktopapp/desktopapp_linux.go
@@ -153,6 +153,10 @@ func refreshDesktopDatabase(dir string) {
 }
 
 // Remove deletes the desktop entry and its icon. Missing is success.
+//
+// Only the icon file: it sits directly in lerd's data directory, so removing
+// its parent takes the whole of ~/.local/share/lerd with it, which an uninstall
+// that was told to keep the data has no business doing.
 func Remove() error {
 	entry := Path()
 	if entry == "" {
@@ -161,7 +165,7 @@ func Remove() error {
 	if err := os.Remove(entry); err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	_ = os.RemoveAll(filepath.Dir(iconPath()))
+	_ = os.Remove(iconPath())
 	refreshDesktopDatabase(filepath.Dir(entry))
 	return nil
 }

--- a/internal/desktopapp/desktopapp_linux_test.go
+++ b/internal/desktopapp/desktopapp_linux_test.go
@@ -77,6 +77,29 @@ func TestRemove_takesTheEntryAndTheIcon(t *testing.T) {
 	}
 }
 
+// The icon lives in lerd's data directory, so a Remove that reached for the
+// directory rather than the file emptied a site registry, the nginx vhosts and
+// the certificates on an uninstall that had been told to keep them.
+func TestRemove_leavesTheRestOfTheDataDirectory(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dir)
+	t.Setenv("XDG_DATA_DIRS", t.TempDir())
+	if _, err := Install(); err != nil {
+		t.Fatal(err)
+	}
+	sites := filepath.Join(dir, "lerd", "sites.yaml")
+	if err := os.WriteFile(sites, []byte("sites: []\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Remove(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(sites); err != nil {
+		t.Errorf("removing the launcher took %s with it: %v", sites, err)
+	}
+}
+
 // The desktop app ships an entry called Lerd of its own, so a second one under
 // that name would put two identical icons in the application list. Where it is
 // installed the launcher says what it adds instead.


### PR DESCRIPTION
An uninstall that answers no to the data prompt still loses the data directory. The launcher icon is written straight into `~/.local/share/lerd`, so removing the icon's parent removed lerd's own state, and that step runs before the branch that honours the prompt. The run then prints "data kept at ~/.local/share/lerd" over an empty directory.

What is left afterwards is only what containers wrote as a subuid, which the removal could not touch. Everything else, the registry, the vhosts, the certificates, the stats, is gone, so the next install comes back with only the sites it can rediscover under a parked directory and nothing points at the uninstall as the cause.

Reproduced end to end in an Ubuntu guest with canary files planted through the data directory: before the fix they were gone the moment the launcher step ran, after it a full uninstall leaves the registry and every canary in place and takes only the icon.

Closes #1635
