### PR TITLE
fix(test): pick a free host port in the quadlet refresh test

### DIFF
--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/freeport"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/services"
 )
@@ -319,10 +322,13 @@ func TestRefreshUnreferencedCustomQuadlets_globalCustomServiceGetsV6Pair(t *test
 	t.Cleanup(func() { podman.DaemonReloadFn = origReload })
 	podman.DaemonReloadFn = func() error { return nil }
 
+	// A port the host already publishes is shifted to a free one, so the
+	// assertions below have to run on a port nothing here holds.
+	port := freeHostPort(t)
 	svc := &config.CustomService{
 		Name:  "mongo-express",
 		Image: "docker.io/library/mongo-express:latest",
-		Ports: []string{"127.0.0.1:8082:8081"},
+		Ports: []string{fmt.Sprintf("127.0.0.1:%d:8081", port)},
 	}
 	if err := config.SaveCustomService(svc); err != nil {
 		t.Fatalf("SaveCustomService: %v", err)
@@ -336,12 +342,32 @@ func TestRefreshUnreferencedCustomQuadlets_globalCustomServiceGetsV6Pair(t *test
 		t.Fatalf("quadlet not written at %s: %v", path, err)
 	}
 	got := string(data)
-	if !strings.Contains(got, "PublishPort=127.0.0.1:8082:8081") {
+	if want := fmt.Sprintf("PublishPort=127.0.0.1:%d:8081", port); !strings.Contains(got, want) {
 		t.Errorf("v4 bind missing from rewritten quadlet:\n%s", got)
 	}
-	if !strings.Contains(got, "PublishPort=[::1]:8082:8081") {
+	if want := fmt.Sprintf("PublishPort=[::1]:%d:8081", port); !strings.Contains(got, want) {
 		t.Errorf("v6 pair missing — PairIPv6Binds did not apply during refresh:\n%s", got)
 	}
+}
+
+// freeHostPort returns a port the quadlet writer's own guard agrees is free,
+// asking the kernel for an ephemeral one rather than naming a number some
+// other service on the developer's machine may already publish.
+func freeHostPort(t *testing.T) int {
+	t.Helper()
+	for i := 0; i < 20; i++ {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		port := ln.Addr().(*net.TCPAddr).Port
+		_ = ln.Close()
+		if freeport.Bindable(port) {
+			return port
+		}
+	}
+	t.Fatal("no free host port after 20 tries")
+	return 0
 }
 
 func TestRefreshUnreferencedCustomQuadlets_skipsSeenServices(t *testing.T) {


### PR DESCRIPTION
`TestRefreshUnreferencedCustomQuadlets_globalCustomServiceGetsV6Pair` pinned 127.0.0.1:8082 and asserted the rewritten quadlet published exactly that on both stacks. The published-port guard in serviceops moves a service off a host port something already holds, so on a machine running mongo-express the refresh landed on the next free port and both assertions missed, reading as a PairIPv6Binds regression that was never there.

It fails or passes depending on which services happen to be up when the suite runs, which is how it slipped through: the same tree was green an hour earlier with lerd stopped.

The port now comes from the kernel as an ephemeral one and is confirmed with `freeport.Bindable` before use, so what the test asserts on is a port nothing on the host holds.

Closes #1636
