### PR TITLE
fix: publish services on IPv4 alone when the host has no ::1

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -514,6 +514,22 @@ export LERD_DISABLE_IPV6=1
 Either path writes `~/.local/share/lerd/ipv6-probe-failed-lerd`, which `EnsureNetwork` honors on every code path (initial create, migration, recreate). To re-enable dual-stack, delete that marker file and re-run `lerd install`.
 :::
 
+::: details Every service fails with "rootlessport listen tcp [::1]:80: bind: cannot assign requested address"
+
+Symptom: nothing starts. nginx, mysql, redis, mailpit and every other service exit with status 126, and the journal shows a bind failure on an IPv6 loopback address:
+
+```
+Error: rootlessport listen tcp [::1]:3306: bind: cannot assign requested address
+lerd-mysql.service: Main process exited, code=exited, status=126/n/a
+```
+
+Cause: the host no longer has `::1`. IPv6 was turned off kernel-wide, either at boot with `ipv6.disable=1` or at runtime by a VPN client doing leak prevention (the NordVPN Linux client sets `net.ipv6.conf.{all,default,lo}.disable_ipv6=1` while connected). Lerd published each service on both `127.0.0.1` and `[::1]`, and podman treats a publish it cannot bind as fatal rather than falling back to the address that would have worked.
+
+Lerd now checks for `::1` before writing a unit and publishes on IPv4 alone when it is gone, so a host in this state comes up normally. Existing units written by an older build are repaired on the next `lerd start`, which rewrites them and restarts whatever was already running. If IPv6 comes back later, the following start restores the dual-stack publish.
+
+Note that this is a different check from the one the network schema uses. That one wants a routable address; the publish only needs loopback, so a VM with just `::1` and `fe80::` still gets its `[::1]` binds while the network stays v4-only.
+:::
+
 ::: details Every DNS lookup inside a lerd container stalls ~5 seconds
 Symptom: pages that hit the database or any container-to-container hostname feel slow, and `time dig <anything> @<container>` takes roughly five seconds before returning an answer. The network looks fine in `podman network inspect lerd` (both IPv4 and IPv6 subnets present), but aardvark-dns's on-disk config has the v6 gateway absent from its listen-ips line.
 

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -345,7 +345,7 @@ func TestRefreshUnreferencedCustomQuadlets_globalCustomServiceGetsV6Pair(t *test
 	if want := fmt.Sprintf("PublishPort=127.0.0.1:%d:8081", port); !strings.Contains(got, want) {
 		t.Errorf("v4 bind missing from rewritten quadlet:\n%s", got)
 	}
-	if want := fmt.Sprintf("PublishPort=[::1]:%d:8081", port); !strings.Contains(got, want) {
+	if want := fmt.Sprintf("PublishPort=[::1]:%d:8081", port); podman.HostHasIPv6Loopback() && !strings.Contains(got, want) {
 		t.Errorf("v6 pair missing — PairIPv6Binds did not apply during refresh:\n%s", got)
 	}
 }

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -534,6 +534,23 @@ func startLerd(emit func(StartEvent), skip []string) error {
 	// missing quadlet, drop an orphan quadlet with no YAML. Data dirs untouched.
 	reconcileCustomServices()
 
+	// Heal quadlets whose IPv6 publish lines the host can no longer bind. A
+	// VPN client that turns IPv6 off host-wide takes ::1 with it, and every
+	// unit still carrying a [::1] line dies with exit 126 (#1634).
+	if healed, err := podman.HealIPv6Binds(); err != nil {
+		fmt.Printf("  WARN: healing IPv6 binds: %v\n", err)
+	} else if len(healed) > 0 {
+		fmt.Printf("  Rewrote %d unit(s) to match the host's IPv6 support\n", len(healed))
+		_ = podman.DaemonReloadFn()
+		for _, name := range healed {
+			if status, _ := services.Mgr.UnitStatus(name); status == "active" || status == "activating" {
+				if err := podman.RestartUnit(name); err != nil {
+					fmt.Printf("  WARN: restarting %s: %v\n", name, err)
+				}
+			}
+		}
+	}
+
 	// If the configured default PHP version has never been installed (no plist /
 	// quadlet / container), install it now so CoreUnits can include it.
 	ensureDefaultPHPInstalled()

--- a/internal/podman/network.go
+++ b/internal/podman/network.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -457,4 +458,27 @@ func friendlyNetworkCreateError(err error) error {
 		"releases (Ubuntu 22.04, Zorin 17, Debian 11/12) still ship older builds, see " +
 		"https://lerd.sh/getting-started/requirements for options"
 	return fmt.Errorf("%s: %w", prose, err)
+}
+
+// HostHasIPv6Loopback reports whether the host still carries ::1. It is a
+// weaker predicate than HostHasUsableIPv6 on purpose: a loopback publish only
+// needs ::1, and rootlessport takes the whole unit down when it cannot bind it.
+func HostHasIPv6Loopback() bool {
+	if runtime.GOOS != "linux" {
+		return true
+	}
+	data, err := os.ReadFile(ipv6IfInet6Path)
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		if scope, err := strconv.ParseUint(fields[3], 16, 32); err == nil && scope == 0x10 {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/podman/network_test.go
+++ b/internal/podman/network_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -374,5 +375,42 @@ func TestAardvarkNetworkDrifted_readsExistingConfig_v4Only(t *testing.T) {
 	first := strings.SplitN(content, "\n", 2)[0]
 	if aardvarkListenHasV6(first) {
 		t.Errorf("drifted first line %q should not contain v6 listen", first)
+	}
+}
+
+func TestHostHasIPv6Loopback(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("the ::1 probe reads /proc; every other platform short-circuits to true")
+	}
+	tests := []struct {
+		name    string
+		ifInet6 string
+		want    bool
+	}{
+		{
+			name: "loopback only is enough",
+			ifInet6: "00000000000000000000000000000001 01 80 10 80       lo\n" +
+				"fe80000000000000505400fffed9f609 02 40 20 80   enp1s0\n",
+			want: true,
+		},
+		{
+			name:    "ipv6 disabled host-wide leaves no addresses",
+			ifInet6: "",
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "if_inet6")
+			if err := os.WriteFile(path, []byte(tt.ifInet6), 0644); err != nil {
+				t.Fatal(err)
+			}
+			old := ipv6IfInet6Path
+			ipv6IfInet6Path = path
+			defer func() { ipv6IfInet6Path = old }()
+			if got := HostHasIPv6Loopback(); got != tt.want {
+				t.Errorf("HostHasIPv6Loopback() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/podman/quadlet.go
+++ b/internal/podman/quadlet.go
@@ -69,7 +69,7 @@ func WriteQuadletDiff(name, content string) (changed bool, err error) {
 		autostartDisabled = cfg.Autostart.Disabled
 	}
 	content = BindQuadletForLAN(name, content, lanExposed, servicesExposed)
-	content = PairIPv6Binds(content)
+	content = applyIPv6BindPolicy(content)
 	content = StripInstallSection(content, autostartDisabled)
 	// Centralised platform image rewrite + podman-run flags so every quadlet
 	// writer emits identical units. On Apple Silicon PlatformImage swaps
@@ -191,7 +191,7 @@ func RebindInstalledQuadletsForLAN() ([]string, error) {
 			return nil, fmt.Errorf("reading %s: %w", filepath.Base(path), err)
 		}
 		name := strings.TrimSuffix(filepath.Base(path), ".container")
-		updated := PairIPv6Binds(BindQuadletForLAN(name, string(content), lanExposed, servicesExposed))
+		updated := applyIPv6BindPolicy(BindQuadletForLAN(name, string(content), lanExposed, servicesExposed))
 		if string(content) != updated {
 			config.GuardRealWrite(path)
 			if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
@@ -210,6 +210,41 @@ func RebindInstalledQuadletsForLAN() ([]string, error) {
 		}
 	}
 	return restart, nil
+}
+
+// HealIPv6Binds reapplies the IPv6 bind policy to every installed quadlet and
+// returns the units it rewrote. A host that loses ::1 after install (a VPN
+// client disabling IPv6, a reboot with ipv6.disable=1) leaves stale [::1]
+// publish lines behind, and rootlessport treats a bind it cannot satisfy as
+// fatal, so those units never start again until the file is fixed (#1634).
+func HealIPv6Binds() ([]string, error) {
+	paths, err := filepath.Glob(filepath.Join(config.QuadletDir(), "lerd-*.container"))
+	if err != nil {
+		return nil, err
+	}
+	healed := make([]string, 0, len(paths))
+	for _, path := range paths {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", filepath.Base(path), err)
+		}
+		updated := applyIPv6BindPolicy(string(content))
+		if updated == string(content) {
+			continue
+		}
+		name := strings.TrimSuffix(filepath.Base(path), ".container")
+		config.GuardRealWrite(path)
+		if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+			return nil, fmt.Errorf("rewriting %s: %w", filepath.Base(path), err)
+		}
+		if AfterQuadletWriteFn != nil {
+			if err := AfterQuadletWriteFn(name, updated); err != nil {
+				return nil, fmt.Errorf("syncing %s: %w", name, err)
+			}
+		}
+		healed = append(healed, name)
+	}
+	return healed, nil
 }
 
 // quadletWantsLAN reports whether the given quadlet content publishes beyond

--- a/internal/podman/quadlet_embed.go
+++ b/internal/podman/quadlet_embed.go
@@ -442,3 +442,73 @@ func PairIPv6Binds(content string) string {
 	}
 	return strings.Join(out, "\n")
 }
+
+// hostIPv6LoopbackFn is swapped in tests to stage a host without ::1.
+var hostIPv6LoopbackFn = HostHasIPv6Loopback
+
+// applyIPv6BindPolicy pairs PublishPort lines across both stacks, or reduces
+// them to IPv4 on a host that has no ::1 (VPN clients and ipv6.disable=1 both
+// take it away). rootlessport treats a failed v6 bind as fatal, so a stale
+// [::1] line stops the unit from starting at all instead of degrading.
+func applyIPv6BindPolicy(content string) string {
+	if hostIPv6LoopbackFn() {
+		return PairIPv6Binds(content)
+	}
+	return StripIPv6Binds(content)
+}
+
+// StripIPv6Binds is the inverse of PairIPv6Binds: every IPv6 PublishPort line
+// is dropped when its IPv4 twin is already there, and rewritten to that twin
+// when it is not, so the unit keeps serving on IPv4 alone. Operator-set
+// addresses are left verbatim. Idempotent.
+func StripIPv6Binds(content string) string {
+	lines := strings.Split(content, "\n")
+
+	v4Loopback := map[string]bool{}
+	v4Any := map[string]bool{}
+	for _, line := range lines {
+		value, ok := publishPortValue(line)
+		if !ok || strings.HasPrefix(value, "[") {
+			continue
+		}
+		if rest, isLoopback := strings.CutPrefix(value, "127.0.0.1:"); isLoopback {
+			v4Loopback[rest] = true
+			continue
+		}
+		v4Any[strings.TrimPrefix(value, "0.0.0.0:")] = true
+	}
+
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		value, ok := publishPortValue(line)
+		if !ok {
+			out = append(out, line)
+			continue
+		}
+		if rest, isV6Loopback := strings.CutPrefix(value, "[::1]:"); isV6Loopback {
+			if !v4Loopback[rest] {
+				v4Loopback[rest] = true
+				out = append(out, "PublishPort=127.0.0.1:"+rest)
+			}
+			continue
+		}
+		if rest, isV6Any := strings.CutPrefix(value, "[::]:"); isV6Any {
+			if !v4Any[rest] {
+				v4Any[rest] = true
+				out = append(out, "PublishPort="+rest)
+			}
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
+}
+
+// publishPortValue returns the address:port body of a PublishPort= line.
+func publishPortValue(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "PublishPort=") {
+		return "", false
+	}
+	return strings.TrimPrefix(trimmed, "PublishPort="), true
+}

--- a/internal/podman/quadlet_embed_test.go
+++ b/internal/podman/quadlet_embed_test.go
@@ -812,3 +812,68 @@ func TestDNSQuadletHasNoStartRateLimit(t *testing.T) {
 		t.Errorf("StartLimitIntervalSec must sit in [Unit], not a later section:\n%s", tpl)
 	}
 }
+
+// --- StripIPv6Binds ---
+
+func TestStripIPv6Binds_dropsPairedV6Lines(t *testing.T) {
+	// A host without ::1 cannot bind the v6 line, and rootlessport treats
+	// that as fatal, so the IPv4 twin has to carry the unit alone (#1634).
+	in := "[Container]\nNetwork=lerd\nPublishPort=127.0.0.1:80:80\nPublishPort=[::1]:80:80\nPublishPort=127.0.0.1:443:443\nPublishPort=[::1]:443:443\n"
+	out := StripIPv6Binds(in)
+	if strings.Contains(out, "[::1]") {
+		t.Errorf("expected no v6 binds, got:\n%s", out)
+	}
+	for _, want := range []string{"PublishPort=127.0.0.1:80:80", "PublishPort=127.0.0.1:443:443"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %s to survive, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestStripIPv6Binds_rewritesLoneV6Lines(t *testing.T) {
+	in := "Network=lerd\nPublishPort=[::1]:5300:5300/udp\nPublishPort=[::]:80:80\n"
+	out := StripIPv6Binds(in)
+	if !strings.Contains(out, "PublishPort=127.0.0.1:5300:5300/udp") {
+		t.Errorf("expected lone [::1] rewritten to 127.0.0.1, got:\n%s", out)
+	}
+	if !strings.Contains(out, "PublishPort=80:80") {
+		t.Errorf("expected lone [::] rewritten to the bare LAN form, got:\n%s", out)
+	}
+	if strings.Contains(out, "[::") {
+		t.Errorf("expected no v6 binds, got:\n%s", out)
+	}
+}
+
+func TestStripIPv6Binds_idempotent(t *testing.T) {
+	in := "Network=lerd\nPublishPort=127.0.0.1:80:80\nPublishPort=[::1]:80:80\nPublishPort=[::]:443:443\n"
+	once := StripIPv6Binds(in)
+	twice := StripIPv6Binds(once)
+	if once != twice {
+		t.Errorf("StripIPv6Binds is not idempotent:\nonce:\n%s\ntwice:\n%s", once, twice)
+	}
+}
+
+func TestStripIPv6Binds_preservesOperatorOverrides(t *testing.T) {
+	in := "Network=lerd\nPublishPort=192.168.1.10:80:80\nPublishPort=[fe80::1%eth0]:80:80\n"
+	out := StripIPv6Binds(in)
+	if out != in {
+		t.Errorf("operator overrides should be preserved verbatim:\nin:\n%s\nout:\n%s", in, out)
+	}
+}
+
+func TestApplyIPv6BindPolicy_followsHostLoopback(t *testing.T) {
+	in := "[Container]\nNetwork=lerd\nPublishPort=127.0.0.1:3306:3306\n"
+
+	old := hostIPv6LoopbackFn
+	defer func() { hostIPv6LoopbackFn = old }()
+
+	hostIPv6LoopbackFn = func() bool { return true }
+	if got := applyIPv6BindPolicy(in); !strings.Contains(got, "PublishPort=[::1]:3306:3306") {
+		t.Errorf("host with ::1 should get the v6 pair, got:\n%s", got)
+	}
+
+	hostIPv6LoopbackFn = func() bool { return false }
+	if got := applyIPv6BindPolicy(in); strings.Contains(got, "[::1]") {
+		t.Errorf("host without ::1 must not get a v6 bind, got:\n%s", got)
+	}
+}

--- a/internal/podman/testmain_test.go
+++ b/internal/podman/testmain_test.go
@@ -1,0 +1,14 @@
+package podman
+
+import (
+	"os"
+	"testing"
+)
+
+// Quadlet writes consult the host for ::1 to decide whether IPv6 publish lines
+// are safe. Pin it so the suite asserts the dual-stack shape everywhere,
+// regardless of the machine or CI container the tests run on.
+func TestMain(m *testing.M) {
+	hostIPv6LoopbackFn = func() bool { return true }
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
A host with IPv6 off kernel wide still got a [::1] publish line paired onto every 127.0.0.1 one, because the pairing was gated only on the unit carrying a Network= key. rootlessport cannot bind that address, podman treats the failure as fatal rather than falling back to the IPv4 bind that would have worked, and every service dies with exit 126. The trigger in the report was the NordVPN Linux client, which disables IPv6 host wide as leak prevention while connected, but booting with ipv6.disable=1 lands in exactly the same place.

Quadlet writes now check for ::1 before pairing and reduce the publish lines to IPv4 when it is missing, dropping a v6 line whose v4 twin is already present and rewriting it to that twin when it is not. Operator set addresses stay verbatim. This is deliberately a weaker check than the one that steers the network schema, which requires a routable address, since a loopback publish only needs the loopback.

Units written by an earlier build carry the unbindable line until something rewrites them, so lerd start now repairs them and restarts whatever was already running. The host is read on every write, which means a machine that regains IPv6 gets its dual stack pairs back on the next start with nothing to run by hand.

Linux only in practice. On macOS the containers live inside the podman machine VM, so probing the host would be asking the wrong machine, and the launchd path already drops IPv6 publish lines.

Refs #1634