### PR TITLE
fix: keep lerd stripe:listen pointing at the starter

### DIFF
--- a/internal/cli/stripe.go
+++ b/internal/cli/stripe.go
@@ -16,7 +16,6 @@ import (
 func NewStripeCmds() []*cobra.Command {
 	return []*cobra.Command{
 		newStripeListenCmd(),
-		newStripeListenStopCmd(),
 		newStripeConfigCmd(),
 	}
 }
@@ -141,12 +140,16 @@ func newStripeListenCmd() *cobra.Command {
 	cmd.Flags().StringVar(&apiKey, "api-key", "", "Stripe API key (defaults to the secret in .env)")
 	cmd.Flags().StringVar(&webhookPath, "path", config.DefaultStripeWebhookPath, "Webhook route path on your app (persisted to .lerd.yaml)")
 	cmd.Flags().StringVar(&secretEnvKey, "secret-env-key", "", "Which .env key holds the Stripe secret (persisted to .lerd.yaml)")
+	// stop hangs off the starter rather than sitting beside it at the root:
+	// two root commands whose Use began with stripe:listen made cobra resolve
+	// the documented `lerd stripe:listen` to an arbitrary one of the two.
+	cmd.AddCommand(newStripeListenStopCmd())
 	return cmd
 }
 
 func newStripeListenStopCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "stripe:listen stop",
+		Use:   "stop",
 		Short: "Stop the Stripe webhook listener for the current site",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {

--- a/internal/cli/stripe_test.go
+++ b/internal/cli/stripe_test.go
@@ -40,3 +40,39 @@ func TestNewStripeCmds_ConfigCommandAndFlags(t *testing.T) {
 		}
 	}
 }
+
+// The stop command used to be registered at the root under the name
+// stripe:listen, which left two root commands sharing that name and made
+// `lerd stripe:listen` resolve to whichever cobra walked into first.
+func TestNewStripeCmds_ListenStopIsASubcommand(t *testing.T) {
+	root := &cobra.Command{Use: "lerd"}
+	for _, c := range NewStripeCmds() {
+		root.AddCommand(c)
+	}
+
+	listen := 0
+	for _, c := range root.Commands() {
+		if c.Name() == "stripe:listen" {
+			listen++
+		}
+	}
+	if listen != 1 {
+		t.Fatalf("root has %d commands named stripe:listen, want 1", listen)
+	}
+
+	start, _, err := root.Find([]string{"stripe:listen"})
+	if err != nil {
+		t.Fatalf("finding stripe:listen: %v", err)
+	}
+	if start.Flags().Lookup("api-key") == nil {
+		t.Error("lerd stripe:listen must resolve to the starter, which carries --api-key")
+	}
+
+	stop, _, err := root.Find([]string{"stripe:listen", "stop"})
+	if err != nil {
+		t.Fatalf("finding stripe:listen stop: %v", err)
+	}
+	if stop.Name() != "stop" {
+		t.Errorf("lerd stripe:listen stop resolved to %q, want the stop subcommand", stop.Name())
+	}
+}


### PR DESCRIPTION
The Stripe stop command was declared with Use "stripe:listen stop" and added to the root right next to the start command. Cobra takes a command name from the first word of Use, so the root carried two commands both called stripe:listen. Help printed the entry twice, once as the starter and once as the stopper, and plain lerd stripe:listen resolved to whichever of the two cobra reached first, which on current main is the stopper. That left the documented start form, with its path, api-key and secret-env-key flags, landing on a command that accepts none of them and tears the listener down instead.

Stop now hangs off the start command as a plain stop child, which is the shape the generated worker commands already use for their start and stop pairs. lerd stripe:listen reaches the starter again, lerd stripe:listen stop keeps working exactly as the reference table documents it, and the root lists the entry once.

This has been there since the listener became a systemd service in v0.6.0, so it predates the worker command generation work rather than coming out of it.

Closes #1609