### PR TITLE
fix: the two bugs the pre-release pass found, and a test plan that matches the app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Build UI
         run: make build-ui
 
+      - name: Test UI
+        run: make test-ui
+
       - name: Install tray build dependencies
         run: |
           sudo apt-get update

--- a/install.sh
+++ b/install.sh
@@ -129,6 +129,28 @@ MISSING_PKGS=()
 # (certutil / nss-tools) when the user only wants .localhost.
 DNS_MODE="managed"
 
+# saved_dns_mode echoes the DNS mode already recorded in the config, or nothing
+# when there is no config to read. Scoped to the dns block so an enabled: key
+# belonging to some other section is never mistaken for this one.
+saved_dns_mode() {
+  local cfg="${LERD_CONFIG_DIR}/config.yaml"
+  [ -f "$cfg" ] || return 0
+  awk '
+    /^[^[:space:]#]/ { in_dns = ($0 ~ /^dns:/) }
+    in_dns && /^[[:space:]]+enabled:/ {
+      print ($0 ~ /false/) ? "localhost" : "managed"; exit
+    }
+  ' "$cfg"
+}
+
+# should_pass_dns_mode reports whether `lerd install` should be told the mode.
+# Only a first install names it: the binary settles the question once and
+# honours the saved choice on every run after that, and --dns is the one input
+# that overrides it. The argument is the version already installed, if any.
+should_pass_dns_mode() {
+  [ -z "${1:-}" ]
+}
+
 ask_dns_mode() {
   local _ans=""
   header "DNS mode"
@@ -624,7 +646,15 @@ cmd_install() {
     [ -f "$local_binary" ] || die "File not found: $local_binary"
   fi
 
-  ask_dns_mode
+  # Only a first install asks. A machine that already has lerd keeps the mode it
+  # settled on, read back here so the prerequisite check knows whether this run
+  # needs certutil, and left to the binary rather than forced with --dns.
+  if [ -z "$was_installed" ]; then
+    ask_dns_mode
+  else
+    DNS_MODE="$(saved_dns_mode)"
+    DNS_MODE="${DNS_MODE:-managed}"
+  fi
   check_prerequisites
 
   if ! command -v podman &>/dev/null; then
@@ -671,10 +701,16 @@ cmd_install() {
   # When this script is piped through `curl|bash`, our own stdin is the pipe
   # and lerd's prompts would silently hit EOF. Hand it /dev/tty when one is
   # available so [Y/n] questions reach the user.
+  # The +expansion keeps an empty array from tripping set -u on the bash 3.2
+  # macOS still ships.
+  local dns_args=()
+  if should_pass_dns_mode "$was_installed"; then
+    dns_args=(--dns "$DNS_MODE")
+  fi
   if have_tty; then
-    "${INSTALL_DIR}/${BINARY}" install --dns "$DNS_MODE" </dev/tty
+    "${INSTALL_DIR}/${BINARY}" install ${dns_args[@]+"${dns_args[@]}"} </dev/tty
   else
-    "${INSTALL_DIR}/${BINARY}" install --dns "$DNS_MODE"
+    "${INSTALL_DIR}/${BINARY}" install ${dns_args[@]+"${dns_args[@]}"}
   fi
 
   # Offer the desktop app on a fresh Linux install. Its own installer does the

--- a/internal/systemd/dbus_linux.go
+++ b/internal/systemd/dbus_linux.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"time"
@@ -17,8 +18,52 @@ import (
 
 // errUnitOpTimedOut is the sentinel a single unit-op attempt returns when the
 // job channel does not report a result within the per-attempt deadline. It is
-// mapped back to the historic "timed out after 30s" message by dbusUnitOp.
+// wrapped into the caller-facing message by unitOpTimeoutError.
 var errUnitOpTimedOut = errors.New("unit op timed out")
+
+// jobWaitFloor is the shortest a unit op waits for systemd to report its job
+// result, and the whole wait for anything that declares no window of its own.
+const jobWaitFloor = 30 * time.Second
+
+// jobWaitMargin is added to a declared stop window so the wait outlasts the
+// SIGKILL systemd sends at the end of it, leaving room for the container to be
+// reaped and the job result to arrive.
+const jobWaitMargin = 10 * time.Second
+
+// stopJobWait is how long a stop waits for its job result, given the window the
+// unit declares as TimeoutStopSec. A service that asks for a long graceful
+// shutdown is guaranteed to outlast a fixed wait, and the caller then acts on a
+// "stopped" that has not happened yet, so the wait is read from the unit. A
+// unit that declares nothing, or less than the floor, keeps the historic 30s.
+func stopJobWait(declared time.Duration) time.Duration {
+	if w := declared + jobWaitMargin; declared > 0 && w > jobWaitFloor {
+		return w
+	}
+	return jobWaitFloor
+}
+
+// unitOpTimeoutError builds the caller-facing timeout message, reporting the
+// wait that actually elapsed rather than the fixed number it used to name.
+func unitOpTimeoutError(verb, name string, wait time.Duration) error {
+	return fmt.Errorf("%s %s timed out after %s", verb, name, wait)
+}
+
+// declaredStopTimeout reads the unit's own TimeoutStopSec, which quadlet
+// generation sets from the service definition. Anything unreadable, absent or
+// infinite reports zero, which stopJobWait resolves to the floor.
+func declaredStopTimeout(conn *dbus.Conn, unit string) time.Duration {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	prop, err := conn.GetUnitTypePropertyContext(ctx, unit, "Service", "TimeoutStopUSec")
+	if err != nil || prop == nil {
+		return 0
+	}
+	usec, ok := prop.Value.Value().(uint64)
+	if !ok || usec == 0 || usec == math.MaxUint64 {
+		return 0
+	}
+	return time.Duration(usec) * time.Microsecond
+}
 
 // stopRetryAttempts bounds how many times a "stop" job is re-issued when
 // systemd reports the result "canceled". `lerd stop` deactivates many units
@@ -61,12 +106,19 @@ func dbusUnitOp(op, verb, name string) error {
 	}
 	unit := withServiceSuffix(name)
 
+	// A stop is the one op that has to outlast a window the unit itself sets,
+	// so it is read from the unit; the others keep the floor.
+	wait := jobWaitFloor
+	if op == "stop" {
+		wait = stopJobWait(declaredStopTimeout(conn, unit))
+	}
+
 	// attempt enqueues one job and waits for systemd to report its result,
 	// returning the result string ("done", "canceled", "failed", …) or a
 	// transport/timeout error.
 	attempt := func() (string, error) {
 		ch := make(chan string, 1)
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), wait)
 		defer cancel()
 		var opErr error
 		switch op {
@@ -97,7 +149,7 @@ func dbusUnitOp(op, verb, name string) error {
 	result, err := runUnitOpWithRetry(maxAttempts, settleBetweenStops, attempt)
 	if err != nil {
 		if errors.Is(err, errUnitOpTimedOut) {
-			return fmt.Errorf("%s %s timed out after 30s", verb, name)
+			return unitOpTimeoutError(verb, name, wait)
 		}
 		return fmt.Errorf("%s %s failed: %w", verb, name, err)
 	}

--- a/internal/systemd/dbus_linux_test.go
+++ b/internal/systemd/dbus_linux_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	godbus "github.com/godbus/dbus/v5"
 )
@@ -190,5 +191,44 @@ func TestUnitNotLoaded(t *testing.T) {
 	}
 	if unitNotLoaded(errors.New("stop lerd-mysql timed out after 30s")) {
 		t.Error("a timeout was swallowed")
+	}
+}
+
+// A stop has to outlast the graceful window the unit itself declares. mysql
+// and postgres declare stop_timeout 60, which reaches the unit as
+// TimeoutStopSec=75, so the fixed 30s wait returned as though the service had
+// come down while podman was still counting; the SIGKILL that followed left
+// the unit failed behind an uninstall that had already finished (#1510).
+func TestStopJobWait(t *testing.T) {
+	cases := []struct {
+		name     string
+		declared time.Duration
+		want     time.Duration
+	}{
+		{"a unit that declares nothing keeps the historic wait", 0, jobWaitFloor},
+		{"an unreadable window keeps the historic wait", -1, jobWaitFloor},
+		{"a window shorter than the floor keeps the floor", 5 * time.Second, jobWaitFloor},
+		{"the default service window still fits the floor", 20 * time.Second, jobWaitFloor},
+		{"a database's window outlasts its own SIGKILL", 75 * time.Second, 85 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stopJobWait(tc.declared); got != tc.want {
+				t.Errorf("stopJobWait(%s) = %s, want %s", tc.declared, got, tc.want)
+			}
+		})
+	}
+}
+
+// The timeout message reports the wait that actually elapsed. It used to say
+// 30s unconditionally, which names the wrong number the moment the wait comes
+// from the unit, and unitNotLoaded reads these messages.
+func TestUnitOpTimeoutMessageReportsTheRealWait(t *testing.T) {
+	err := unitOpTimeoutError("stop", "lerd-mysql", 85*time.Second)
+	if got, want := err.Error(), "stop lerd-mysql timed out after 1m25s"; got != want {
+		t.Errorf("message = %q, want %q", got, want)
+	}
+	if unitNotLoaded(err) {
+		t.Error("a timeout must not read as an already-stopped unit")
 	}
 }

--- a/internal/ui/web/vite.config.ts
+++ b/internal/ui/web/vite.config.ts
@@ -42,6 +42,11 @@ export default defineConfig(() => ({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./src/test-setup.ts']
+    setupFiles: ['./src/test-setup.ts'],
+    // A store test resets the module registry and re-imports, paying the
+    // transform cost again while every other file is transforming too, which
+    // outruns the 5s default on a loaded machine. The assertions themselves
+    // finish in milliseconds.
+    testTimeout: 20000
   }
 }));

--- a/tests/installer/installer.bats
+++ b/tests/installer/installer.bats
@@ -894,3 +894,62 @@ _undeletable_dir() {
   run run_with_tty "source '$INSTALLER'; ask proceed? && echo GOT_YES || echo GOT_NO"
   [[ "$output" == *"GOT_YES"* ]]
 }
+
+# ── saved_dns_mode / the DNS question on a re-install ─────────────────────────
+# `lerd install` settles the DNS mode once and honours the saved choice on every
+# later run, flipped afterwards with dns:enable / dns:disable. Re-running the
+# installer used to ask again and pass --dns, which is the one input that beats
+# the saved choice, so a .localhost machine was converted to managed DNS, in
+# silence where there was no terminal to show the question (#1647).
+
+_write_dns_config() {
+  mkdir -p "$LERD_CONFIG_DIR"
+  cat > "$LERD_CONFIG_DIR/config.yaml" <<EOF
+php:
+    default: "8.5"
+dns:
+    enabled: $1
+    tld: $2
+auto_cleanup: true
+EOF
+}
+
+@test "saved_dns_mode reads managed from an existing config" {
+  _write_dns_config true test
+  run saved_dns_mode
+  [ "$output" = "managed" ]
+}
+
+@test "saved_dns_mode reads localhost from an existing config" {
+  _write_dns_config false localhost
+  run saved_dns_mode
+  [ "$output" = "localhost" ]
+}
+
+@test "saved_dns_mode says nothing when there is no config" {
+  run saved_dns_mode
+  [ -z "$output" ]
+}
+
+@test "saved_dns_mode ignores an enabled key outside the dns block" {
+  mkdir -p "$LERD_CONFIG_DIR"
+  cat > "$LERD_CONFIG_DIR/config.yaml" <<EOF
+telemetry:
+    enabled: false
+dns:
+    enabled: true
+    tld: test
+EOF
+  run saved_dns_mode
+  [ "$output" = "managed" ]
+}
+
+@test "should_pass_dns_mode names the mode on a first install" {
+  run should_pass_dns_mode ""
+  [ "$status" -eq 0 ]
+}
+
+@test "should_pass_dns_mode leaves the saved choice alone when lerd is installed" {
+  run should_pass_dns_mode "1.33.0"
+  [ "$status" -ne 0 ]
+}

--- a/tests/release-test-plan.md
+++ b/tests/release-test-plan.md
@@ -21,7 +21,7 @@ the check against the site you created in phase 2:
 
 ```bash
 curl -s -o /dev/null -w '%{http_code}\n' -k https://demo.test        # expect 200
-curl -s -o /dev/null -w '%{http_code}\n' http://demo.test            # expect 200 or 301 to https
+curl -s -o /dev/null -w '%{http_code}\n' http://demo.test            # expect 200 or 302 to https
 ```
 
 On a `.localhost` guest (external-DNS mode, see phase 3) the same check is:
@@ -30,7 +30,7 @@ On a `.localhost` guest (external-DNS mode, see phase 3) the same check is:
 curl -s -o /dev/null -w '%{http_code}\n' http://demo.localhost       # expect 200
 ```
 
-Anything other than 200 (or the documented 301) fails the phase, even if every
+Anything other than 200 (or the documented 302) fails the phase, even if every
 command before it printed success. Record the code you actually saw in the
 sign-off table, not the code you expected.
 
@@ -48,21 +48,48 @@ without sudo. **Run at most two guests at a time** (the host has 32 GB).
 | `ubuntu26.04` (snapshot) | Ubuntu 26.04 | B — upgrade/rollback | Needs an N-1 install to upgrade *from* |
 | `omarchy` | Arch, Hyprland | C — DNS variants | NetworkManager + `dns=dnsmasq`, resolved masked |
 | `fedora43-2-clone` | Fedora 44 | D — packaging | Homebrew-on-Linux path, `/usr`-owned binary |
-| `ubuntu-24` | Ubuntu 24.04 | D — packaging | apt / PPA path, older systemd + podman |
 | `silverblue` | Fedora Silverblue | E — immutable | rpm-ostree host, no writable `/usr` |
-| `nixos` | NixOS | E — immutable | Non-FHS, no `~/.local/bin` on PATH by default |
+| `bazzite` | Bazzite (Kinoite) | E — immutable | The one guest kept in `.localhost` mode |
 
 Lane A is mandatory every release. Lanes B and C are mandatory for any release
 that touches the installer, DNS, or systemd units. Lanes D and E are mandatory
 for a minor or major bump, optional for a patch that touches neither packaging
 nor the host layer.
 
-Guest notes worth remembering: `omarchy` is LUKS-encrypted and needs George at
-the console to unlock, so ask before starting it, and never `pacman -Sy` there.
-`ubuntu26.04` ships configured with `dns.tld: localhost`, so flip it back with
-`lerd dns:enable` before running lane A, or run lane A's `.test` phases after
-phase 3's round trip. `virsh shutdown` is ignored on `ubuntu26.04`: `sync` over
-SSH then `virsh destroy`.
+Guest notes worth remembering: never `pacman -Sy` on `omarchy`, its package set
+is old enough that a partial upgrade breaks it, and it is the only guest with a
+real graphical session, so the tray and a spawned terminal only appear there.
+`bazzite` is deliberately left on `.localhost`, so put it back with
+`lerd dns:disable` if a run converts it, and it is the guest lane E's
+external-DNS phases belong on. `virsh shutdown` is ignored on `ubuntu26.04`:
+`sync` over SSH then `virsh destroy`. The `ubuntu25.10` domain is not Ubuntu, it
+boots Zorin to a login screen with no sshd, so nothing in this plan can drive
+it.
+
+---
+
+## What 1.34.0 adds to this plan
+
+The checks a release brings live in the phase they belong to rather than in a
+section of their own, so a phase is always the whole story for its subject. This
+index is only a reminder of where 1.34.0's went, and of what to delete from the
+phases once the next release makes it ordinary.
+
+| Change | Phase |
+|---|---|
+| Image downloads disclosed first, `--no-pull`, `LERD_OFFLINE`, `start --dry-run` | 1, 4, 5 |
+| A host with IPv6 turned off | 1 |
+| Starting lerd from the dashboard, the desktop entry and the macOS app | 1 |
+| PHP 8.6 as a prerelease tier, and a shell in a version's container | 4 |
+| Worker options in `.lerd.yaml`, worker commands generated from the definition | 6 |
+| The store's package layer under `lerd framework list` | 6, 9 |
+| NativePHP, desktop and mobile | 9 |
+| A pinned command on the site's control row | 10 |
+| The tray being optional, and the desktop's own terminal | 10 |
+| The TUI's databases pane and service facets | 10 |
+| `lerd doctor` sweeping every linked site | 11 |
+| `lerd update` reporting what changed once it lands | 12 |
+| An uninstall that says it keeps the data keeping it | 13 |
 
 ---
 
@@ -105,6 +132,35 @@ make build && bash install.sh --local ./build/lerd
 ```
 
 - [ ] `--local` install completes and `lerd status` is healthy
+- [ ] Re-running the installer on this machine does **not** ask the DNS question
+      again and does not change the mode it settled on
+
+Nothing may download without saying so first, and there has to be a way to say
+no. The estimates are read off the registry manifest, so working them out must
+itself download nothing.
+
+- [ ] `lerd start --dry-run` reports what a start would pull or rebuild, and
+      exits without starting anything
+- [ ] Every command that can pull names the image and roughly its size before
+      the first byte moves: `start`, `install`, `fetch`, `php:rebuild`, the
+      service install and update paths, the FrankenPHP switch
+- [ ] `--no-pull` and `LERD_OFFLINE=1` skip pulls and rebuilds unless the image
+      is missing outright, and an already-working stack still starts
+- [ ] Pull an image with the network down: the failure names the image, and
+      nothing is left half-installed
+
+A host with IPv6 turned off used to exit every container, so it gets its own
+pass on one guest:
+
+- [ ] With IPv6 disabled on the host, `lerd install --no-ipv6` (or
+      `LERD_DISABLE_IPV6=1`) brings the stack up and **https → 200**
+
+Then the ways in that are not a terminal:
+
+- [ ] Opening the dashboard on a stopped lerd offers a Start button, and the
+      start streams back unit by unit rather than leaving a dead page
+- [ ] The Linux application entry cold-starts lerd and reports its progress
+- [ ] macOS: the Lerd app's splash reads the same stream
 
 ---
 
@@ -140,7 +196,7 @@ site is only correct when the *other* scheme behaves correctly too.
 Start secured (`lerd secure demo` if it isn't):
 
 - [ ] **`curl -k https://demo.test` → 200**
-- [ ] **`curl http://demo.test` → 301 redirecting to `https://demo.test`**
+- [ ] **`curl http://demo.test` → 302 redirecting to `https://demo.test`**
 - [ ] `curl https://demo.test` **without** `-k` also returns 200, proving the
       mkcert CA is trusted by the system store, not just tolerated
 - [ ] `APP_URL` in `.env` is `https://demo.test`
@@ -160,7 +216,7 @@ Flip to plain HTTP:
 Flip back:
 
 - [ ] `lerd secure demo` reissues the cert
-- [ ] **`curl -k https://demo.test` → 200** and **`curl http://demo.test` → 301**
+- [ ] **`curl -k https://demo.test` → 200** and **`curl http://demo.test` → 302**
 - [ ] `APP_URL` is back to `https://`, nothing else in `.env` was rewritten
 - [ ] `lerd secure --renew demo` reissues on demand, expiry resets, **https → 200**
 
@@ -226,6 +282,15 @@ than flipping it to the canonical default.
 - [ ] `lerd php:ini shared` opens in `$EDITOR` and an edit survives a rebuild
 - [ ] Legacy tier: `lerd isolate 7.4` on a throwaway site pulls the frozen image
       and serves **200**, then put the site back on 8.4
+- [ ] Prerelease tier: a bare `lerd fetch` leaves 8.6 alone, `lerd use 8.6`
+      marks it as a prerelease wherever a version is picked, **https → 200**
+      on it, and FrankenPHP does not offer it
+- [ ] On 8.6 the image ships redis, imagick and mongodb (built without pecl,
+      which 8.6 removed) and advertises no igbinary, pcov or xdebug
+- [ ] `lerd shell 8.5` drops into that version's container from anywhere, and
+      the dashboard's shell button opens the same one
+- [ ] `lerd php:ports` and `lerd php:pkg` report the version's ports and packages
+- [ ] `lerd php:rebuild` discloses the base image and its size before pulling
 
 ---
 
@@ -267,6 +332,17 @@ Database operations:
 - [ ] `lerd db:shell` opens an interactive shell
 - [ ] `lerd db:move --from mysql --to mariadb --site demo` moves the schema and
       repoints `.env`, **https → 200**
+- [ ] `lerd db:extension` lists what the engine can create, and adds one
+- [ ] `lerd minio:migrate` moves an existing MinIO volume onto RustFS
+
+Every service path that can pull says what it will fetch first:
+
+- [ ] The install, update, migrate, rollback and reinstall paths each name the
+      image and roughly its size before downloading
+- [ ] The dashboard turns the same estimate into a confirmation naming the image
+      and the download, and an image already in the local store needs no click
+- [ ] The MCP server answers with the image and its size instead of starting a
+      download on behalf of someone who never typed the command
 
 ---
 
@@ -284,6 +360,40 @@ Database operations:
       hit the site and confirm they resume, **https → 200**
 - [ ] `lerd idle pin demo` keeps it awake; `lerd idle status` reports both states
 - [ ] `lerd idle off` resumes everything
+
+The named start commands are generated from the framework definition now, so
+what they accept has to come from the definition rather than from a fixed set:
+
+- [ ] Each generated command's flags match its worker's `tune_command`
+      placeholders, and each default is the value in the plain command
+- [ ] A worker with a reload variant gets its reload toggle the same way
+- [ ] A project cloned but not linked yet still gets its worker commands,
+      resolved from the framework named in `.lerd.yaml`, and they answer with
+      the link hint rather than an unknown command
+- [ ] A worker declaring `requires_service` refuses to start without it, and its
+      unit orders after that service rather than racing it at boot
+
+A project's answers to those flags are committed rather than retyped:
+
+- [ ] Passing a flag to a start command writes it under `worker_options` in
+      `.lerd.yaml` instead of tuning a single run
+- [ ] A value equal to the framework's default is not stored, so a later store
+      change to that default still lands
+- [ ] A value carrying whitespace is refused
+- [ ] The dashboard's gear beside a worker offers one field per declared option,
+      prefilled from the project and showing the definition's default, and
+      saving restarts a running worker
+- [ ] `lerd workers` reports what is running across the machine
+
+The store's package layer sits under the definitions:
+
+- [ ] `lerd framework list` prints every package the store publishes, what each
+      declares, which file answers for the project you are in, and whether that
+      project requires it, reading the cache without fetching
+- [ ] A package declaration wins a name collision with a version file, and a
+      user overlay and the project's `.lerd.yaml` still sit above both
+- [ ] With the network down, a version never fetched falls back to the newest
+      cached file below it rather than losing the worker
 
 ---
 
@@ -316,6 +426,10 @@ lerd worktree add -b feat-x
 - [ ] Remove the isolated one with the drop-database option **off**, re-add the
       branch, and confirm the preserved schema is offered for reuse
 - [ ] Remove it again with drop-database **on**, schema is gone
+- [ ] `lerd db:isolate` on a worktree that shares the parent's schema clones it
+      and repoints the worktree `.env`, **200**
+- [ ] `lerd db:share` drops the isolated schema and puts the worktree back on
+      the parent's, **200**
 - [ ] **Parent site still → 200 after all worktree churn**
 
 ---
@@ -333,15 +447,27 @@ lerd worktree add -b feat-x
 - [ ] Groups: `lerd group add demo admin` serves the secondary at
       `admin.demo.test` → **200**; `lerd group db share` then `separate` both
       work; `lerd group list`; `lerd group remove` restores a standalone domain
-- [ ] Workspaces: `add`, `assign`, `move`, `rename`, `list`, `rm` and the
-      dashboard grouping reflects each one
+- [ ] Workspaces: `lerd workspace add`, `assign`, `move`, `rename`, `list`, `rm`
+      and the dashboard grouping reflects each one
 - [ ] `lerd lan:share` prints a URL and QR; from a second machine or the host,
       **`curl http://<lan-ip>:<port>` → 200** with assets loading (URL rewriting)
 - [ ] `lerd lan:unshare` releases the port
 - [ ] `lerd lan:expose` / `lan:status` / `lan:services on|off` / `lan:unexpose`
-- [ ] `lerd remote-control full-access on|off|status` gates host actions
+- [ ] `lerd remote-setup` pairs a device, and `lerd remote-control full-access
+      on|off|status` gates host actions
+- [ ] `lerd domain add` and `remove` on a site that already carries the TLD:
+      the name is not doubled, and each domain serves **200**
+- [ ] A domain declared in the project's `.lerd.yaml` is registered once, with
+      the TLD applied once
+- [ ] `lerd share:tool`, `share:domain` and `share:token` record the tunnel
+      settings, and `lerd share` then uses them without asking again
 - [ ] `lerd share` with one tunnel tool: the public URL answers **200**, then
       stop it. Cover a signup-free one (`--serveo` or `--pinggy`) at minimum
+- [ ] `lerd stripe:config` stores the keys and `lerd stripe:listen` **starts**
+      the listener (it once stopped one instead), then stops it
+- [ ] `lerd nginx` opens the site's override, a location-scope block survives a
+      `lerd restart`, and `lerd nginx reset` puts it back, **200** after each
+- [ ] `lerd import` pulls a project in from another local environment
 - [ ] Custom container path: a non-PHP project with `Containerfile.lerd` plus
       `container: {port: N}` links, `lerd rebuild` works, **200**
 
@@ -363,6 +489,17 @@ cd shop && lerd setup --all --skip-open
 - [ ] **https → 200 on the second site**
 - [ ] `lerd framework list` shows both, `lerd framework prune` leaves both alone
 - [ ] Both sites serve simultaneously, **200 on each**
+- [ ] A package the project requires contributes its workers, commands, setup
+      steps and doctor checks to whichever framework carries it, and a package
+      scoped to one framework stays out of the other
+- [ ] `lerd sail` maps a Sail-shaped project onto lerd's own containers
+
+NativePHP is supported end to end, and both halves need a look:
+
+- [ ] A NativePHP desktop project links, `lerd setup --all` completes, and its
+      workers and commands come from the package layer rather than the framework
+- [ ] The mobile half builds and its commands are offered on Laravel only
+- [ ] `lerd site:doctor` runs the package's own checks and names what is missing
 
 ---
 
@@ -376,6 +513,10 @@ Dashboard (drive it in a browser, not with curl):
       and the modal streams progress
 - [ ] No empty cards or placeholder widgets anywhere
 - [ ] The System tab's LAN and remote-access toggles match the CLI state
+- [ ] A command pinned to a site's control row runs from there, survives a
+      reload, and unpins again
+- [ ] The shell button opens the terminal the desktop is configured to use, not
+      whatever happens to be on PATH, on both platforms
 - [ ] After every UI action, **the affected site still → 200**
 
 TUI:
@@ -383,12 +524,18 @@ TUI:
 - [ ] `lerd tui` renders sites, services, workers with live status
 - [ ] Detail pane, inline domain and version editing, filter, sort all work
 - [ ] Shell drop-in and log tail work
+- [ ] The databases pane lists the databases and opens one
+- [ ] A service's client tools, tuning and entities are reachable, matching what
+      the web UI offers
+- [ ] Services with a web dashboard are marked, and opening one works
 - [ ] Destructive commands are **absent** (scope guard)
 
 Tray:
 
 - [ ] `lerd tray` appears in the system tray, menu actions work
 - [ ] `lerd tray icon high-contrast` changes the running icon
+- [ ] The tray can be turned off, and everything else keeps working with no
+      tray unit running and nothing reporting it as broken
 
 Other surfaces:
 
@@ -402,10 +549,22 @@ Other surfaces:
       host shell config is bind-mounted
 - [ ] `lerd mcp:inject`, an assistant can call the MCP tools; `lerd mcp:eject`
 - [ ] `lerd mcp:enable-global` / `mcp:disable-global`
+- [ ] The MCP config lands for OpenCode as well as the other assistants
+- [ ] Over MCP: a worker's tunable values come off its framework definition, an
+      action that would download names the image and its size instead of
+      fetching, and `project_new` scaffolds the major it was asked for
 - [ ] `lerd man` browses docs in the terminal
 - [ ] `lerd completion bash|zsh|fish` produces working completion
+- [ ] `lerd path:disable` takes lerd's shims off PATH and `path:enable` puts
+      them back, with `lerd shims` reporting the same state either way
 - [ ] `lerd open demo` opens the browser
 - [ ] Node: `node:install`, `node:use`, `isolate:node`, `lerd npm run build`
+- [ ] `lerd node:manage` installs the shims and a default, `node:manager` shows
+      and switches the manager, `node:unmanage` and `node:uninstall` undo it
+- [ ] `lerd npx` and `lerd cpx` both run through the project's own versions
+- [ ] `lerd pest:browser` runs headed, and the headless Playwright binary is
+      shimmed so a plain run works too
+- [ ] `lerd code` and `lerd test` reach the project's editor and test runner
 - [ ] `lerd js:runtime bun`, `lerd php:bun install`, a bun build runs, **200**
 - [ ] Runtime: `lerd runtime frankenphp` → **200**, `--worker` → **200**,
       `lerd octane:reload on`, then `lerd runtime fpm` → **200**
@@ -418,7 +577,14 @@ Other surfaces:
 - [ ] Break something on purpose (stop `lerd-nginx`), confirm doctor names it,
       `lerd doctor --fix --dry-run` previews, `--fix --yes` repairs it,
       **https → 200 afterwards**
+- [ ] `lerd doctor` sweeps **every** linked site, not only the host, and names
+      the site each finding belongs to
+- [ ] Drop a site's database, then let the doctor create it from the finding
+      itself, **https → 200** afterwards
+- [ ] The doctor reports whether containers can resolve an internet name, and
+      says so honestly with the network down
 - [ ] `lerd site:doctor --json` on both sites
+- [ ] `lerd dns:repair` fixes a deliberately broken but enabled `.test` setup
 - [ ] `lerd check` validates `.lerd.yaml`, and rejects a deliberately broken one
 - [ ] `lerd cleanup --dry-run` then `lerd cleanup --yes` reclaims only what it
       listed, and no in-use image, database or volume is touched
@@ -428,6 +594,8 @@ Other surfaces:
 - [ ] `lerd tools:update` brings Composer/fnm/mkcert to the current pins
 - [ ] `lerd env:check`, `lerd env:override`, `lerd env:restore` round trip
 - [ ] `lerd auth ssh` loads a key and `lerd composer` reaches a private repo
+- [ ] `lerd autostart on|status|off`, and with autostart **off** no worker is
+      armed for boot
 - [ ] `lerd stop` then `lerd start`: everything comes back, **200 on both sites**
 - [ ] Reboot the guest: with autostart enabled everything comes back on login,
       **200 on both sites without any manual command**
@@ -447,6 +615,9 @@ install with real sites survives the jump.
 - [ ] Config, sites, services and databases all survive untouched
 - [ ] **https → 200 immediately after the upgrade, before any manual repair**
 - [ ] Any migration the release needs runs automatically or is clearly announced
+- [ ] Once the update lands it reports what changed, without being asked
+- [ ] No step is drawn as failed for a built-in service that was simply not
+      running
 - [ ] `lerd doctor` clean post-upgrade
 - [ ] `lerd update --rollback` reverts to N-1, **https → 200**
 - [ ] `lerd update` again returns to the RC, **https → 200**
@@ -456,7 +627,6 @@ install with real sites survives the jump.
 
 Repeat the upgrade leg on the packaging lanes:
 
-- [ ] apt: `sudo apt upgrade` on `ubuntu-24`, **200 after**
 - [ ] dnf: `sudo dnf upgrade` on a COPR guest, **200 after**
 - [ ] brew: `brew upgrade lerd` on `fedora43-2-clone`, **200 after**
 
@@ -476,6 +646,11 @@ Run last on each guest, because it is destructive.
 - [ ] `.test` no longer resolves, and the system resolver is back to its
       pre-lerd state (nothing broken, general DNS still works)
 - [ ] Project directories, `.env` files and databases on disk are untouched
+- [ ] Answering **keep my data** actually keeps it: the data directory still
+      holds the databases and volumes it did before, and the run says so only
+      when it is true
+- [ ] A service that ignores SIGTERM is stopped properly rather than reported
+      stopped early, and no unit is left `failed` behind the uninstall
 - [ ] `lerd uninstall --force` skips prompts on a second guest
 - [ ] Reinstall on top of the uninstalled machine and **https → 200** again on a
       re-linked existing project, with its data intact
@@ -492,11 +667,18 @@ after the last destructive step in it.
 | A — full pass | ubuntu26.04 | | | | |
 | B — upgrade/rollback | ubuntu26.04 | | | | |
 | C — DNS variants | omarchy | | | | |
-| D — apt | ubuntu-24 | | | | |
 | D — dnf | fedora COPR | | | | |
 | D — brew | fedora43-2-clone | | | | |
 | E — Silverblue | silverblue | | | | |
-| E — NixOS | nixos | | | | |
+| E — Bazzite | bazzite | | | | |
+
+## What this matrix cannot reach
+
+Three surfaces have no guest here and are signed off by hand on real hardware,
+or knowingly skipped and recorded as skipped rather than quietly passed:
+`lerd machine` and the macOS app on a Mac, `lerd wsl:setup` on Windows, and any
+tray or spawned-terminal behaviour on a desktop other than omarchy's, which is
+the only guest with a graphical session.
 
 Anything that failed gets an issue before the tag goes out. A release ships only
 when lane A is green and every mandatory lane for that release type is green.


### PR DESCRIPTION
The pre-release pass across the VM guests, and the two bugs it turned up.

A stop returned before the service had stopped. Every stop enqueued the job and waited a fixed thirty seconds for systemd to report its result, so a service declaring a longer graceful window was guaranteed to outlast the wait. mysql declares sixty seconds, which reaches the unit as TimeoutStopSec=75, while the caller gave up at thirty and returned as though the service had come down. The uninstall is where it left a mark: it deleted the unit files and reset their failed state, and podman killed mysql a minute later, so the unit was recorded as failed after the reset that would have cleared it and stayed behind on a machine that no longer had a lerd to clear it with. The wait now comes from the unit itself, floored at the old thirty seconds so nothing that declares less changes. Reproduced with a container that ignores SIGTERM, where the stop used to return at thirty seconds with the unit still deactivating.

The installer overrode a DNS mode it was supposed to be reading. lerd install settles the question once and honours the saved choice on every later run, and the docs say so, but install.sh asked again on every run and always passed the answer on as an explicit flag, which is the one input that wins ahead of the saved choice. With no terminal the question was not even shown and the answer silently resolved to managed, so a machine deliberately on *.localhost was converted, dnsmasq came up, the sudoers grant was written and every site domain was rewritten. Only a first install asks now, and a machine that already carries lerd has its mode read back from config instead of forced.

Three UI store tests failed on a full run and passed in isolation, timing out on the transform cost of a module reset while the rest of the suite was transforming too. They get a timeout that fits what they do. The reason nobody noticed is that CI never ran them, so the build job runs them now alongside the Go checks.

The release test plan had drifted from the app. Twenty six of the commands lerd ships appeared nowhere in it, and this release's features were not covered at all. What 1.34.0 added now sits in the phase it belongs to, with an index at the top saying where it went and what to drop once the next release makes it ordinary. The guest matrix loses two domains that no longer exist, gains the guest deliberately kept on .localhost, and corrects the redirect code the HTTPS toggle actually returns.

Closes #1510
Closes #1647
