### PR TITLE
fix(doctor): forget the cached database list once the fix has created one

### DIFF
--- a/internal/cli/site_doctor.go
+++ b/internal/cli/site_doctor.go
@@ -103,6 +103,9 @@ func createMissingDatabases(path string, quiet bool) (bool, error) {
 			return created, fmt.Errorf("creating %s on %s: %w", t.Database, t.Service, err)
 		}
 		created = true
+		// The re-check that follows runs inside the list cache's window, so
+		// without this it reads the engine's contents from before the create.
+		sitedoctor.ForgetDatabases(t.Service)
 		if !quiet {
 			fmt.Printf("  %s\n\n", feedback.Dim("created the "+t.Database+" database on "+t.Service))
 		}

--- a/internal/sitedoctor/server_database.go
+++ b/internal/sitedoctor/server_database.go
@@ -29,10 +29,10 @@ var listDatabases = func(service string) ([]string, error) {
 func stubDatabaseLister(fn func(string) ([]string, error)) func() {
 	prev := listDatabases
 	listDatabases = fn
-	forgetDatabases()
+	ForgetDatabases("")
 	return func() {
 		listDatabases = prev
-		forgetDatabases()
+		ForgetDatabases("")
 	}
 }
 
@@ -68,10 +68,20 @@ func cachedDatabases(service string) ([]string, error) {
 	return names, err
 }
 
-func forgetDatabases() {
+// ForgetDatabases drops one engine's cached list, or every engine's when
+// service is empty. Anything that creates or removes a database has to call it:
+// the cache exists so a sweep does not ask the same engine once per site, and
+// the re-check that follows a fix runs well inside that window, so without this
+// it reads the list from before the create and reports the database it just
+// made as still missing.
+func ForgetDatabases(service string) {
 	dbListCache.Lock()
 	defer dbListCache.Unlock()
-	dbListCache.entries = map[string]dbListEntry{}
+	if service == "" {
+		dbListCache.entries = map[string]dbListEntry{}
+		return
+	}
+	delete(dbListCache.entries, service)
 }
 
 // checkServerDatabase fails when the site's database does not exist on the

--- a/internal/sitedoctor/server_database_declared_test.go
+++ b/internal/sitedoctor/server_database_declared_test.go
@@ -84,3 +84,88 @@ func TestCachedDatabases_ReusesOneLookupPerEngine(t *testing.T) {
 		t.Errorf("a second engine must be its own lookup: calls=%d err=%v", calls, err)
 	}
 }
+
+// The cache that saves a sweep one lookup per site is the same cache the fix
+// has to get past. `site:doctor --fix` creates the database and re-runs the
+// checks in the same process, always inside the TTL, so without an explicit
+// forget the re-check reads the list from before the create and reports the
+// database it just made as missing (#1649).
+func TestForgetDatabases_LetsTheRecheckAfterAFixSeeTheNewDatabase(t *testing.T) {
+	held := []string{"other"}
+	calls := 0
+	restore := stubDatabaseLister(func(string) ([]string, error) {
+		calls++
+		return held, nil
+	})
+	defer restore()
+
+	if names, _ := cachedDatabases("mysql"); len(names) != 1 || names[0] != "other" {
+		t.Fatalf("first lookup = %v, want the engine's list", names)
+	}
+
+	// What a create does: the engine now holds the schema.
+	held = []string{"other", "shop"}
+
+	// Without the forget the cached answer stands and the re-check is wrong.
+	if names, _ := cachedDatabases("mysql"); len(names) != 1 {
+		t.Fatalf("the cache must still stand before the forget, got %v", names)
+	}
+
+	ForgetDatabases("mysql")
+	names, err := cachedDatabases("mysql")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(names) != 2 {
+		t.Errorf("after the forget the list is %v, want the schema the create added", names)
+	}
+	if calls != 2 {
+		t.Errorf("looked the engine up %d times, want 2: one cold, one after the forget, "+
+			"with the cached middle lookup costing nothing", calls)
+	}
+}
+
+// Forgetting one engine must not throw away another engine's list, or a sweep
+// across sites on different services pays for every create.
+func TestForgetDatabases_IsScopedToOneEngine(t *testing.T) {
+	calls := map[string]int{}
+	restore := stubDatabaseLister(func(service string) ([]string, error) {
+		calls[service]++
+		return []string{"shop"}, nil
+	})
+	defer restore()
+
+	cachedDatabases("mysql")    //nolint:errcheck
+	cachedDatabases("postgres") //nolint:errcheck
+	ForgetDatabases("mysql")
+	cachedDatabases("mysql")    //nolint:errcheck
+	cachedDatabases("postgres") //nolint:errcheck
+
+	if calls["mysql"] != 2 {
+		t.Errorf("mysql looked up %d times, want 2", calls["mysql"])
+	}
+	if calls["postgres"] != 1 {
+		t.Errorf("postgres looked up %d times, want 1 (it was not forgotten)", calls["postgres"])
+	}
+}
+
+// An empty service forgets everything, which is what a test helper swapping the
+// lister out from under the cache needs.
+func TestForgetDatabases_EmptyServiceForgetsEveryEngine(t *testing.T) {
+	calls := 0
+	restore := stubDatabaseLister(func(string) ([]string, error) {
+		calls++
+		return []string{"shop"}, nil
+	})
+	defer restore()
+
+	cachedDatabases("mysql")    //nolint:errcheck
+	cachedDatabases("postgres") //nolint:errcheck
+	ForgetDatabases("")
+	cachedDatabases("mysql")    //nolint:errcheck
+	cachedDatabases("postgres") //nolint:errcheck
+
+	if calls != 4 {
+		t.Errorf("looked up %d times, want 4 (both engines forgotten)", calls)
+	}
+}

--- a/internal/ui/site_doctor.go
+++ b/internal/ui/site_doctor.go
@@ -200,6 +200,9 @@ func handleDoctorDatabaseFix(w http.ResponseWriter, r *http.Request, site *confi
 			failed = fmt.Errorf("creating %s on %s: %w", t.Database, t.Service, err)
 			break
 		}
+		// lerd-ui outlives the request, so a stale list would answer the next
+		// check as well as this one's.
+		sitedoctor.ForgetDatabases(t.Service)
 		created = append(created, t.Database+" on "+t.Service)
 	}
 	streamHostAction(w, "created "+strings.Join(created, ", "), failed)


### PR DESCRIPTION
The database fix created the schema, said so, and then the re-check underneath it reported the same database as still missing with the same remedy attached. Read in order those two lines say the fix does not work, while a plain run a moment later passes.

The engine's contents come from a list memoised for five seconds, so a sweep across every linked site does not pay a container exec per site to ask the same engine the same question. The fix creates the database and re-runs the checks in the same process, always inside that window, so the re-check answered from the list taken before the create. The cache has had an invalidation function from the start, but nothing outside the test helper ever called it, and the only reason this was survivable at all is that the entry expires on its own before the next command runs.

Creating a database now drops that engine's entry. The forget is scoped to the engine that changed rather than emptying the cache, since a sweep across sites on different services should not pay for every create, and the whole-cache form the test helper wants stays available as the empty case. The dashboard carries its own copy of the same fix and gets the same call, where it matters more, because lerd-ui outlives the request and a stale entry would answer the next check as well as this one's.

Found during the pre-release pass on Fedora Silverblue, and verified there afterwards: dropping a site's database and running the fix now prints the create and a passing check together, leaving only the pending migrations the doctor is meant to report next.

Closes #1649
