### PR TITLE
feat: let the store declare the console commands that must leave the container

### DIFF
--- a/docs/getting-started/nativephp.md
+++ b/docs/getting-started/nativephp.md
@@ -39,6 +39,8 @@ lerd run native:install
 
 `native:install` is doing more than the artisan command of the same name. lerd runs every framework command on your host, but `php` on the host is lerd's shim, which routes straight back into the container, and the container has no display for Electron to draw into. So the command installs Electron's JavaScript dependencies on the host, unpacks the PHP binary NativePHP ships for your platform, and then runs `artisan native:install` through *that* binary. From there the platform-specific parts of NativePHP behave exactly as they do outside lerd.
 
+You can still type the commands the NativePHP documentation gives you. The framework definition declares that the `native:` commands have to leave the container and which binary runs them, so `lerd artisan native:run` and `php artisan native:run` both reach that binary on your host rather than the shim, under the Node version your site is on. If the runtime is not installed yet they say so and name `native:install` instead of failing somewhere inside a container.
+
 Start the app:
 
 ```bash

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -48,6 +48,19 @@ func runConsole(_ *cobra.Command, args []string) error {
 		return err
 	}
 
+	// `lerd artisan native:run` has to reach the same host binary `lerd php
+	// artisan native:run` does, so the console name is put back in front of the
+	// arguments and the declaration is matched on the command as typed.
+	if code, took, err := runDeclaredHostCommand(cwd, append([]string{consoleCmd}, args...), nil); took {
+		if err != nil {
+			return err
+		}
+		if code != 0 {
+			os.Exit(code)
+		}
+		return nil
+	}
+
 	version, err := phpVersionForDir(cwd)
 	if err != nil {
 		return err

--- a/internal/cli/host_command.go
+++ b/internal/cli/host_command.go
@@ -68,13 +68,15 @@ func frameworkForDir(dir string) *config.Framework {
 
 // hostCommandNodeVersion resolves the Node a re-routed command runs under, with
 // the same fallbacks a host worker uses: the project's own version, then the
-// machine default.
+// machine default. Empty is the version manager's own default alias, which is
+// the right answer for a machine that has expressed no preference and keeps
+// this off the platform-specific constants the worker units carry.
 func hostCommandNodeVersion(cwd string) string {
 	if v, err := nodeDet.DetectVersion(cwd); err == nil && v != "" {
 		return v
 	}
-	if cfg, _ := config.LoadGlobal(); cfg != nil && cfg.Node.DefaultVersion != "" {
+	if cfg, _ := config.LoadGlobal(); cfg != nil {
 		return cfg.Node.DefaultVersion
 	}
-	return defaultNodeVersion
+	return ""
 }

--- a/internal/cli/host_command.go
+++ b/internal/cli/host_command.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/geodro/lerd/internal/config"
+	nodeDet "github.com/geodro/lerd/internal/node"
+)
+
+// runDeclaredHostCommand runs argv on the host when the project's framework
+// says these arguments cannot work in the container, and reports whether it
+// took the call. The case it exists for is a desktop runtime: native:run opens
+// a window, and `php` on a lerd machine is the shim into the FPM container,
+// where there is no Electron and no display. The declaration names the binary,
+// so no framework or package is known here by name.
+//
+// A declared binary that is not there yet is an error rather than a fall back
+// into the container, which is the failure the declaration exists to prevent.
+func runDeclaredHostCommand(cwd string, argv []string, extraEnv []string) (int, bool, error) {
+	fw := frameworkForDir(cwd)
+	rel, ok := config.MatchHostCommand(fw, argv)
+	if !ok {
+		return 0, false, nil
+	}
+	bin := rel
+	if !filepath.IsAbs(bin) {
+		bin = filepath.Join(cwd, rel)
+	}
+	if _, err := os.Stat(bin); err != nil {
+		return 0, true, fmt.Errorf("%s runs on the host and needs %s, which is not installed yet.\nInstall the runtime first: lerd run native:install", argv[0], rel)
+	}
+	// The command shells out to npm, so it needs the project's Node the same way
+	// a host worker does. Unmanaged Node is left to the caller's PATH, which is
+	// a real login shell here rather than a unit that inherits nothing.
+	cmd := exec.Command(bin, argv...)
+	if lerdManagesNode() {
+		cmd = nodeDet.Active().Command(hostCommandNodeVersion(cwd), bin, argv)
+	}
+	cmd.Dir = cwd
+	cmd.Env = append(os.Environ(), extraEnv...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return ee.ExitCode(), true, nil
+		}
+		return 0, true, err
+	}
+	return 0, true, nil
+}
+
+// frameworkForDir resolves the framework a directory's commands run under,
+// package layer merged, or nil when the directory is not a project lerd knows.
+func frameworkForDir(dir string) *config.Framework {
+	if name, ok := config.DetectFrameworkForDir(dir); ok {
+		if fw, ok := config.GetFrameworkForDir(name, dir); ok {
+			return fw
+		}
+	}
+	return nil
+}
+
+// hostCommandNodeVersion resolves the Node a re-routed command runs under, with
+// the same fallbacks a host worker uses: the project's own version, then the
+// machine default.
+func hostCommandNodeVersion(cwd string) string {
+	if v, err := nodeDet.DetectVersion(cwd); err == nil && v != "" {
+		return v
+	}
+	if cfg, _ := config.LoadGlobal(); cfg != nil && cfg.Node.DefaultVersion != "" {
+		return cfg.Node.DefaultVersion
+	}
+	return defaultNodeVersion
+}

--- a/internal/cli/php_exec.go
+++ b/internal/cli/php_exec.go
@@ -122,6 +122,11 @@ func RunPHPCaptureEnv(cwd string, args []string, extraEnv []string) (int, error)
 // framework supports, since the empty parent directory would otherwise resolve
 // to the machine default and break composer's platform check.
 func RunPHPVersionCaptureEnv(cwd, version string, args []string, extraEnv []string) (int, error) {
+	// Some console commands cannot work in the container at all, and the
+	// framework says which. Checked before anything starts a container for them.
+	if code, took, err := runDeclaredHostCommand(cwd, args, extraEnv); took {
+		return code, err
+	}
 	recordCwdActivity(cwd) // keep the site awake under idle-suspend while you work in the terminal
 	// The CLI SAPI ignores a project's .user.ini, so a framework declaring
 	// php.cli_ini gets it as -d on every PHP process lerd starts for it.

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -68,6 +68,9 @@ type Framework struct {
 	// dropdown. See FrameworkCommand for the schema. Projects extend or
 	// override this list in .lerd.yaml; use ResolveCommands to merge.
 	Commands []FrameworkCommand `yaml:"commands,omitempty"`
+	// HostCommands names the console commands that must run on the host rather
+	// than in the container, and the binary that runs them. See HostCommand.
+	HostCommands []HostCommand `yaml:"host_commands,omitempty"`
 	// CacheCommand is the console subcommand that clears the framework's
 	// compiled caches, run through Console the way key generation is. lerd runs it after rewriting a project's connection: a
 	// framework caches the container definitions built from that configuration,
@@ -318,6 +321,48 @@ type FrameworkSetupCmd struct {
 // ships canonical defaults; projects extend or override them by name in
 // .lerd.yaml. Distinct from FrameworkWorker (long-running) and
 // FrameworkSetupCmd (install-time only).
+// HostCommand declares that some of a framework's console commands cannot run
+// in the PHP-FPM container and names the binary that must run them instead.
+// The case it exists for is a desktop runtime: `php artisan native:run` opens a
+// window, and on a lerd machine `php` is the shim into the container, where
+// there is no Electron and no display. Args is a space-separated glob matched
+// against the leading arguments as typed, so `artisan native:*` catches the
+// whole namespace whether it arrives via `lerd php artisan ...` or `lerd
+// artisan ...`. Binary is relative to the project root.
+type HostCommand struct {
+	Args   string `yaml:"args" json:"args"`
+	Binary string `yaml:"binary" json:"binary"`
+}
+
+// MatchHostCommand reports the binary a framework declares for these arguments,
+// if any. The first declaration that matches wins, so a package merged over a
+// framework file is not shadowed by the pattern it replaces.
+func MatchHostCommand(fw *Framework, argv []string) (string, bool) {
+	if fw == nil || len(argv) == 0 {
+		return "", false
+	}
+	for _, hc := range fw.HostCommands {
+		if hc.Binary == "" {
+			continue
+		}
+		pattern := strings.Fields(hc.Args)
+		if len(pattern) == 0 || len(pattern) > len(argv) {
+			continue
+		}
+		matched := true
+		for i, tok := range pattern {
+			if ok, err := filepath.Match(tok, argv[i]); err != nil || !ok {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return hc.Binary, true
+		}
+	}
+	return "", false
+}
+
 type FrameworkCommand struct {
 	Name        string         `yaml:"name" json:"name"`                                   // stable identifier, also the `lerd run` argument
 	Label       string         `yaml:"label" json:"label"`                                 // human label shown in the UI

--- a/internal/config/framework_hostcommand_test.go
+++ b/internal/config/framework_hostcommand_test.go
@@ -1,0 +1,66 @@
+package config
+
+import "testing"
+
+// A package whose command has to escape the container declares which arguments
+// mean that and the binary to use. Without it `php artisan native:run` reaches
+// lerd's shim, runs in the FPM container, and looks there for the Electron
+// runtime and a display that only exist on the host (#1651).
+func TestMatchHostCommand(t *testing.T) {
+	fw := &Framework{HostCommands: []HostCommand{
+		{Args: "artisan native:*", Binary: "vendor/nativephp/desktop/resources/build/php/php"},
+	}}
+
+	cases := []struct {
+		name string
+		argv []string
+		want string
+	}{
+		{"the console command it declares", []string{"artisan", "native:run"}, "vendor/nativephp/desktop/resources/build/php/php"},
+		{"trailing flags do not stop it matching", []string{"artisan", "native:build", "--no-interaction"}, "vendor/nativephp/desktop/resources/build/php/php"},
+		{"another console command is left in the container", []string{"artisan", "migrate"}, ""},
+		{"a bare script is left in the container", []string{"-v"}, ""},
+		{"too few arguments to match the pattern", []string{"artisan"}, ""},
+		{"nothing at all", nil, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := MatchHostCommand(fw, tc.argv)
+			if tc.want == "" {
+				if ok {
+					t.Fatalf("matched %q, want no match", got)
+				}
+				return
+			}
+			if !ok || got != tc.want {
+				t.Fatalf("got (%q, %v), want %q", got, ok, tc.want)
+			}
+		})
+	}
+}
+
+// A framework that declares nothing must never be asked to escape the
+// container, and a nil one must not panic the passthrough.
+func TestMatchHostCommand_NothingDeclared(t *testing.T) {
+	if _, ok := MatchHostCommand(nil, []string{"artisan", "native:run"}); ok {
+		t.Error("a nil framework declared nothing and must not match")
+	}
+	if _, ok := MatchHostCommand(&Framework{}, []string{"artisan", "native:run"}); ok {
+		t.Error("a framework with no host_commands must not match")
+	}
+}
+
+// The first declaration wins, so a package can be merged over a framework file
+// without the older pattern shadowing it.
+func TestMatchHostCommand_FirstMatchWins(t *testing.T) {
+	fw := &Framework{HostCommands: []HostCommand{
+		{Args: "artisan native:run", Binary: "first"},
+		{Args: "artisan native:*", Binary: "second"},
+	}}
+	if got, _ := MatchHostCommand(fw, []string{"artisan", "native:run"}); got != "first" {
+		t.Errorf("binary = %q, want first", got)
+	}
+	if got, _ := MatchHostCommand(fw, []string{"artisan", "native:build"}); got != "second" {
+		t.Errorf("binary = %q, want second", got)
+	}
+}

--- a/internal/config/framework_package.go
+++ b/internal/config/framework_package.go
@@ -46,8 +46,11 @@ type FrameworkPackage struct {
 	Frameworks []FrameworkPackageScope    `yaml:"frameworks,omitempty"`
 	Workers    map[string]FrameworkWorker `yaml:"workers,omitempty"`
 	Commands   []FrameworkCommand         `yaml:"commands,omitempty"`
-	Setup      []FrameworkSetupCmd        `yaml:"setup,omitempty"`
-	Doctor     *FrameworkDoctor           `yaml:"doctor,omitempty"`
+	// HostCommands are the console commands this package's runtime cannot run
+	// inside the container, and the binary that runs them instead.
+	HostCommands []HostCommand       `yaml:"host_commands,omitempty"`
+	Setup        []FrameworkSetupCmd `yaml:"setup,omitempty"`
+	Doctor       *FrameworkDoctor    `yaml:"doctor,omitempty"`
 	// Removes takes entries away from the resolved framework, for a major of the
 	// package that dropped a command or a worker. Declaring an entry is how a
 	// package replaces one, and this is how it deletes one, which it cannot do by
@@ -193,6 +196,9 @@ func applyPackage(fw *Framework, pkg *FrameworkPackage) {
 	for _, cmd := range pkg.Commands {
 		fw.Commands = upsertCommand(fw.Commands, cmd)
 	}
+	// Prepended, so a package's routing is consulted before a framework file's
+	// and the first match still wins.
+	fw.HostCommands = append(append([]HostCommand(nil), pkg.HostCommands...), fw.HostCommands...)
 	// A setup step has no name to key on, so the command it runs is its identity:
 	// the framework files still carry the copies this package was lifted out of,
 	// and matching on the command is what keeps a project from being offered the


### PR DESCRIPTION
A console command that opens a desktop window cannot run where lerd runs every other one. NativePHP's native:run is the case: it starts Electron and shows a window, and the PHP-FPM container has neither. What makes it worse than a plain failure is that nobody can see it coming. Upstream documents `php artisan native:run`, and on a lerd machine `php` is the shim sitting on PATH ahead of /usr/bin, so the documented command quietly re-enters the container, npm runs in there, and it dies a couple of seconds later saying only that the dev script failed. `lerd artisan native:run` lands in the same place by a shorter route.

A framework or a package can now say which commands have to leave, and what runs them. host_commands is a list of an argument pattern and a binary, merged from the package layer the way workers and commands already are, matched against the arguments as typed so a single declaration covers both entry points: the console path puts its own console name back in front of the arguments before matching. The first declaration that matches wins, so a package merged over a framework file is not shadowed by the pattern it replaces.

A declared binary that is not installed yet is an error naming the install command rather than a fall back into the container, since falling back is exactly the failure the declaration exists to prevent. The re-routed command runs under the project's Node through the version manager, the same way a host worker does, because the command it fronts shells out to npm.

Nothing here names a framework or a package. The pattern and the binary are store data, which is what keeps this from being one package's special case: anything whose runtime cannot live in a container gets the same treatment by declaring it. The declarations themselves are in lerd-env/frameworks#60.

Closes #1651
