### PR TITLE
fix: take the host command install hint from the declaration that matched

### DIFF
--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -304,10 +304,14 @@ console: bin/console
 # `lerd artisan native:run` alike; `binary` is relative to the project root. The
 # first match wins, so a package declaration is never shadowed by the framework
 # file it merges over, and a binary that is not installed is an error rather than
-# a fall back into the container.
+# a fall back into the container. `install_command` names the `lerd run` command
+# that puts that binary on disk, and belongs to the entry rather than to the
+# package, since a project can carry two packages installed by differently named
+# commands. An entry declaring none says so rather than naming another's.
 host_commands:
   - args: artisan native:*
     binary: vendor/nativephp/electron/resources/js/resources/php/php
+    install_command: native:install
 
 # Background workers
 workers:

--- a/internal/cli/host_command.go
+++ b/internal/cli/host_command.go
@@ -20,18 +20,22 @@ import (
 //
 // A declared binary that is not there yet is an error rather than a fall back
 // into the container, which is the failure the declaration exists to prevent.
+//
+// The project-supplied host command consent gate is deliberately not consulted:
+// this declaration is store data, like the vite host worker, and a runtime that
+// cannot live in a container does not work at all when it is refused.
 func runDeclaredHostCommand(cwd string, argv []string, extraEnv []string) (int, bool, error) {
 	fw := frameworkForDir(cwd)
-	rel, ok := config.MatchHostCommand(fw, argv)
+	hc, ok := config.MatchHostCommand(fw, argv)
 	if !ok {
 		return 0, false, nil
 	}
-	bin := rel
+	bin := hc.Binary
 	if !filepath.IsAbs(bin) {
-		bin = filepath.Join(cwd, rel)
+		bin = filepath.Join(cwd, hc.Binary)
 	}
 	if _, err := os.Stat(bin); err != nil {
-		return 0, true, fmt.Errorf("%s runs on the host and needs %s, which is not installed yet.\nInstall the runtime first: lerd run native:install", argv[0], rel)
+		return 0, true, errors.New(hostCommandMissingMsg(argv[0], hc))
 	}
 	// The command shells out to npm, so it needs the project's Node the same way
 	// a host worker does. Unmanaged Node is left to the caller's PATH, which is
@@ -53,6 +57,20 @@ func runDeclaredHostCommand(cwd string, argv []string, extraEnv []string) (int, 
 		return 0, true, err
 	}
 	return 0, true, nil
+}
+
+// hostCommandMissingMsg reports what to do about a declared host binary the
+// project has not installed yet. The command that installs it comes off the
+// declaration rather than being written here, because two packages that both
+// escape the container do not install the same way: nativephp/mobile installs
+// through native:install-mobile precisely because the desktop package already
+// owns native:install. A declaration naming none is not guessed at.
+func hostCommandMissingMsg(argv0 string, hc config.HostCommand) string {
+	msg := fmt.Sprintf("%s runs on the host and needs %s, which is not installed yet.", argv0, hc.Binary)
+	if hc.InstallCommand == "" {
+		return msg + "\nInstall the runtime it needs, then run it again."
+	}
+	return msg + "\nInstall the runtime first: lerd run " + hc.InstallCommand
 }
 
 // frameworkForDir resolves the framework a directory's commands run under,

--- a/internal/cli/host_command_test.go
+++ b/internal/cli/host_command_test.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// The runtime a re-routed command needs is installed by a command the
+// declaration names, because two packages that both escape the container do not
+// install the same way: nativephp/mobile installs through native:install-mobile
+// precisely because the desktop package already owns native:install (#1651).
+func TestHostCommandMissingMsg_namesTheDeclaredInstallCommand(t *testing.T) {
+	hc := config.HostCommand{
+		Args:           "artisan native:*",
+		Binary:         "vendor/nativephp/php-bin/bin/host/php",
+		InstallCommand: "native:install-mobile",
+	}
+
+	msg := hostCommandMissingMsg("artisan", hc)
+	if !strings.Contains(msg, "vendor/nativephp/php-bin/bin/host/php") {
+		t.Errorf("message = %q, want it to name the missing binary", msg)
+	}
+	if !strings.Contains(msg, "lerd run native:install-mobile") {
+		t.Errorf("message = %q, want it to name the declared install command", msg)
+	}
+}
+
+// A declaration that names no install command is not guessed at, since guessing
+// is how a mobile project was told to run the desktop installer.
+func TestHostCommandMissingMsg_genericWhenNoneDeclared(t *testing.T) {
+	hc := config.HostCommand{Args: "artisan native:*", Binary: "vendor/bin/runtime"}
+
+	msg := hostCommandMissingMsg("artisan", hc)
+	if !strings.Contains(msg, "vendor/bin/runtime") {
+		t.Errorf("message = %q, want it to name the missing binary", msg)
+	}
+	if strings.Contains(msg, "native:install") {
+		t.Errorf("message = %q, must not name a command no declaration carries", msg)
+	}
+	if strings.Contains(msg, "lerd run ") {
+		t.Errorf("message = %q, must not point at a command it cannot name", msg)
+	}
+}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -329,17 +329,24 @@ type FrameworkSetupCmd struct {
 // against the leading arguments as typed, so `artisan native:*` catches the
 // whole namespace whether it arrives via `lerd php artisan ...` or `lerd
 // artisan ...`. Binary is relative to the project root.
+// InstallCommand is declared per entry rather than per package because a
+// project can carry two packages whose runtimes are installed by differently
+// named commands: nativephp/mobile installs through native:install-mobile
+// precisely because the desktop package already owns native:install.
 type HostCommand struct {
-	Args   string `yaml:"args" json:"args"`
-	Binary string `yaml:"binary" json:"binary"`
+	Args           string `yaml:"args" json:"args"`
+	Binary         string `yaml:"binary" json:"binary"`
+	InstallCommand string `yaml:"install_command,omitempty" json:"install_command,omitempty"`
 }
 
-// MatchHostCommand reports the binary a framework declares for these arguments,
-// if any. The first declaration that matches wins, so a package merged over a
-// framework file is not shadowed by the pattern it replaces.
-func MatchHostCommand(fw *Framework, argv []string) (string, bool) {
+// MatchHostCommand reports the declaration a framework carries for these
+// arguments, if any. The first declaration that matches wins, so a package
+// merged over a framework file is not shadowed by the pattern it replaces, and
+// the whole entry comes back so the binary and the command that installs it can
+// never be taken from two different declarations.
+func MatchHostCommand(fw *Framework, argv []string) (HostCommand, bool) {
 	if fw == nil || len(argv) == 0 {
-		return "", false
+		return HostCommand{}, false
 	}
 	for _, hc := range fw.HostCommands {
 		if hc.Binary == "" {
@@ -357,10 +364,10 @@ func MatchHostCommand(fw *Framework, argv []string) (string, bool) {
 			}
 		}
 		if matched {
-			return hc.Binary, true
+			return hc, true
 		}
 	}
-	return "", false
+	return HostCommand{}, false
 }
 
 type FrameworkCommand struct {

--- a/internal/config/framework_hostcommand_test.go
+++ b/internal/config/framework_hostcommand_test.go
@@ -28,12 +28,12 @@ func TestMatchHostCommand(t *testing.T) {
 			got, ok := MatchHostCommand(fw, tc.argv)
 			if tc.want == "" {
 				if ok {
-					t.Fatalf("matched %q, want no match", got)
+					t.Fatalf("matched %q, want no match", got.Binary)
 				}
 				return
 			}
-			if !ok || got != tc.want {
-				t.Fatalf("got (%q, %v), want %q", got, ok, tc.want)
+			if !ok || got.Binary != tc.want {
+				t.Fatalf("got (%q, %v), want %q", got.Binary, ok, tc.want)
 			}
 		})
 	}
@@ -57,10 +57,50 @@ func TestMatchHostCommand_FirstMatchWins(t *testing.T) {
 		{Args: "artisan native:run", Binary: "first"},
 		{Args: "artisan native:*", Binary: "second"},
 	}}
-	if got, _ := MatchHostCommand(fw, []string{"artisan", "native:run"}); got != "first" {
-		t.Errorf("binary = %q, want first", got)
+	if got, _ := MatchHostCommand(fw, []string{"artisan", "native:run"}); got.Binary != "first" {
+		t.Errorf("binary = %q, want first", got.Binary)
 	}
-	if got, _ := MatchHostCommand(fw, []string{"artisan", "native:build"}); got != "second" {
-		t.Errorf("binary = %q, want second", got)
+	if got, _ := MatchHostCommand(fw, []string{"artisan", "native:build"}); got.Binary != "second" {
+		t.Errorf("binary = %q, want second", got.Binary)
+	}
+}
+
+// The binary and the command that installs it have to come from the same entry.
+// A project carrying both nativephp packages merges two declarations, and the
+// desktop installer does not put the mobile runtime on disk, so taking the
+// binary from one and the hint from another sends the user to a command that
+// cannot fix what they are looking at (#1651).
+func TestMatchHostCommand_InstallCommandComesFromTheMatchedEntry(t *testing.T) {
+	fw := &Framework{HostCommands: []HostCommand{
+		{Args: "artisan native:jump", Binary: "vendor/nativephp/php-bin/bin/host/php", InstallCommand: "native:install-mobile"},
+		{Args: "artisan native:*", Binary: "vendor/nativephp/electron/resources/js/resources/php/php", InstallCommand: "native:install"},
+	}}
+
+	got, ok := MatchHostCommand(fw, []string{"artisan", "native:jump"})
+	if !ok || got.InstallCommand != "native:install-mobile" {
+		t.Errorf("install command = %q, want native:install-mobile", got.InstallCommand)
+	}
+	if got.Binary != "vendor/nativephp/php-bin/bin/host/php" {
+		t.Errorf("binary = %q, want the mobile runtime", got.Binary)
+	}
+
+	got, ok = MatchHostCommand(fw, []string{"artisan", "native:run"})
+	if !ok || got.InstallCommand != "native:install" {
+		t.Errorf("install command = %q, want native:install", got.InstallCommand)
+	}
+}
+
+// A declaration published before install_command existed still matches, and
+// carries no hint rather than a wrong one.
+func TestMatchHostCommand_NoInstallCommandDeclared(t *testing.T) {
+	fw := &Framework{HostCommands: []HostCommand{
+		{Args: "artisan native:*", Binary: "vendor/bin/runtime"},
+	}}
+	got, ok := MatchHostCommand(fw, []string{"artisan", "native:run"})
+	if !ok {
+		t.Fatal("want a match")
+	}
+	if got.InstallCommand != "" {
+		t.Errorf("install command = %q, want empty", got.InstallCommand)
 	}
 }


### PR DESCRIPTION
A console command declared as one that has to leave the container refuses when the binary is not on disk, and named `lerd run native:install` as the way to fix it, written into the binary rather than read from the declaration.

That is the desktop package's installer. `nativephp/mobile` names its own `native:install-mobile`, deliberately, since a project carrying both packages would otherwise have two commands with the same name. A project on mobile alone was sent to a command it does not have. A project carrying both was sent to one that exists, runs the desktop installer, succeeds, and leaves the mobile runtime exactly as absent as it was, so the same refusal came back and the loop only ended when someone noticed the other command in `lerd run`.

The declaration is the only thing that knows which command puts its binary on disk, so it carries it now, per entry rather than per package, and the whole entry comes back from the match so the binary and the hint can never be taken from two different declarations. An entry declaring none says to install the runtime without naming a command, because guessing at one is what this was. Nothing about a package is spelled in the binary any more, which the feature's own changelog entry already claimed.

The three nativephp packages declare theirs in a companion PR to the frameworks store. A store file published without the key keeps working and gets the unnamed form, and no released binary reads this block at all.

Closes #1654