### PR TITLE
Run a host command with a fuller PHP when the one it names lacks an extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ Lerd stands on a set of excellent open-source projects it bundles or fetches to 
 - [php-spx](https://github.com/NoiseByNorthwest/php-spx) - the profiler behind the SPX flame graphs
 - [mkcert](https://github.com/FiloSottile/mkcert) - the local CA that backs `.test` HTTPS
 - [fnm](https://github.com/Schniz/fnm) - the per-project Node version manager
+- [static-php-cli](https://github.com/crazywhalecc/static-php-cli) - the prebuilt static PHP binaries lerd falls back to when a project's own bundled runtime is missing an extension a command needs
 - [Composer](https://getcomposer.org) - fetched on the host for dependency operations
 - [Starship](https://starship.rs) - the prompt in the container shell drop-in
 - [Simple Icons](https://simpleicons.org) - the service marks in the dashboard, CC0

--- a/docs/getting-started/nativephp.md
+++ b/docs/getting-started/nativephp.md
@@ -128,6 +128,8 @@ lerd run native:jump
 
 It runs in a terminal rather than as a worker, and the QR code is why: a background unit has nowhere to draw one. It also asks which network interface to advertise when a machine has more than one, which podman and libvirt bridges make almost every development machine, and a unit has nobody to answer.
 
+This one command does not run on the PHP binary NativePHP bundles. Jump's websocket bridge is Workerman, which needs the posix and pcntl extensions, and neither the Linux nor the macOS build of `php-bin` carries them, so the bridge dies on its first line: the phone loads the landing page over HTTP and then drops the session a few seconds later with nothing to connect to. The binary is a static build with dynamic loading compiled out, so the extensions cannot be added to it either. lerd runs Jump with its own PHP instead, a pinned static build matching your project's PHP version, downloaded to `~/.local/share/lerd/bin` the first time a project needs it, and prints a line saying so. The toolchain commands are unaffected: `native:run` and the rest keep using the bundled binary, which has everything they need.
+
 The `.test` domain itself stays useful throughout, for hitting a route with curl and for the parts of the app that are still an ordinary web app. The native runtime serves its own copy on its own port, so the two never collide.
 
 ---

--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -308,10 +308,23 @@ console: bin/console
 # that puts that binary on disk, and belongs to the entry rather than to the
 # package, since a project can carry two packages installed by differently named
 # commands. An entry declaring none says so rather than naming another's.
+# `requires_extensions` names the PHP extensions that binary has to carry for the
+# command to work. Bundled runtimes are trimmed static builds with dynamic
+# loading compiled out, so a missing extension cannot be added to one. lerd asks
+# the binary itself, and when it is short an extension the command needs, runs
+# that command with lerd's own pinned PHP, downloaded to ~/.local/share/lerd/bin
+# the first time a project needs it. The build matches the project's own PHP
+# version, since the command runs project code against a composer.lock resolved
+# for it, and falls back to the nearest pinned minor when lerd pins none.
+# Everything else about the command is unchanged: same host, same working
+# directory, same environment.
 host_commands:
   - args: artisan native:*
     binary: vendor/nativephp/electron/resources/js/resources/php/php
     install_command: native:install
+  - args: artisan native:jump
+    binary: vendor/nativephp/php-bin/bin/host/php
+    requires_extensions: [posix, pcntl]
 
 # Background workers
 workers:

--- a/internal/cli/host_command.go
+++ b/internal/cli/host_command.go
@@ -6,8 +6,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	nodeDet "github.com/geodro/lerd/internal/node"
 )
 
@@ -36,6 +38,13 @@ func runDeclaredHostCommand(cwd string, argv []string, extraEnv []string) (int, 
 	}
 	if _, err := os.Stat(bin); err != nil {
 		return 0, true, errors.New(hostCommandMissingMsg(argv[0], hc))
+	}
+	if missing := missingPHPExtensions(bin, hc.RequiresExtensions); len(missing) > 0 {
+		full, err := managedHostPHP(cwd, hc.Binary, missing)
+		if err != nil {
+			return 0, true, err
+		}
+		bin = full
 	}
 	// The command shells out to npm, so it needs the project's Node the same way
 	// a host worker does. Unmanaged Node is left to the caller's PATH, which is
@@ -97,4 +106,69 @@ func hostCommandNodeVersion(cwd string) string {
 		return cfg.Node.DefaultVersion
 	}
 	return ""
+}
+
+// missingPHPExtensions reports which of the extensions a declaration requires
+// the binary does not have, asking the binary itself rather than trusting a
+// version number. A probe that cannot run reports nothing: a failed question is
+// no reason to move a command into a container the declaration never asked for,
+// and a binary that will not answer `php -m` fails loudly when it runs.
+func missingPHPExtensions(bin string, want []string) []string {
+	if len(want) == 0 {
+		return nil
+	}
+	out, err := exec.Command(bin, "-m").Output()
+	if err != nil {
+		return nil
+	}
+	loaded := map[string]bool{}
+	for _, line := range strings.Split(string(out), "\n") {
+		loaded[strings.ToLower(strings.TrimSpace(line))] = true
+	}
+	var missing []string
+	for _, ext := range want {
+		if !loaded[strings.ToLower(ext)] {
+			missing = append(missing, ext)
+		}
+	}
+	return missing
+}
+
+// managedHostPHP resolves a PHP that has what the declared binary is missing,
+// downloading lerd's own pinned build the first time a project needs it. The
+// runtimes projects bundle are trimmed static builds with dynamic loading
+// compiled out, so an extension one lacks cannot be added to it and the only
+// way to run the command is a fuller PHP.
+func managedHostPHP(cwd, declaredBin string, missing []string) (string, error) {
+	lacks := joinAnd(missing)
+	feedback.WarnOn(os.Stderr, "%s is missing %s, so lerd runs this command with its own PHP", declaredBin, lacks)
+	// The project's own PHP version, not the newest lerd pins: the command runs
+	// the project's code against a composer.lock resolved for that version.
+	version, err := phpVersionForDir(cwd)
+	if err != nil {
+		return "", err
+	}
+	php, err := ensureHostPHPBinary(os.Stderr, version)
+	if err != nil {
+		return "", fmt.Errorf("this command needs a PHP with %s and %s does not have it: %w", lacks, declaredBin, err)
+	}
+	// Fail here rather than inside the command: a pin that lost an extension
+	// would otherwise surface as whatever the command does when it is missing,
+	// which in Jump's case is a websocket bridge that dies in a log file.
+	if still := missingPHPExtensions(php, missing); len(still) > 0 {
+		return "", fmt.Errorf("lerd's PHP at %s is itself missing %s, so this command cannot run", php, strings.Join(still, ", "))
+	}
+	return php, nil
+}
+
+// joinAnd reads a short list the way the sentence around it does: "posix and
+// pcntl" rather than a bare comma list.
+func joinAnd(items []string) string {
+	switch len(items) {
+	case 0:
+		return ""
+	case 1:
+		return items[0]
+	}
+	return strings.Join(items[:len(items)-1], ", ") + " and " + items[len(items)-1]
 }

--- a/internal/cli/host_command_test.go
+++ b/internal/cli/host_command_test.go
@@ -1,10 +1,13 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/tools"
 )
 
 // The runtime a re-routed command needs is installed by a command the
@@ -41,5 +44,115 @@ func TestHostCommandMissingMsg_genericWhenNoneDeclared(t *testing.T) {
 	}
 	if strings.Contains(msg, "lerd run ") {
 		t.Errorf("message = %q, must not point at a command it cannot name", msg)
+	}
+}
+
+// The bundled runtime a project ships is not always a full PHP build: the Linux
+// php-bin NativePHP ships carries neither posix nor pcntl, and Jump's websocket
+// bridge is Workerman, which calls both unguarded and dies on the first line.
+func TestMissingPHPExtensions_reportsWhatTheDeclaredBinaryLacks(t *testing.T) {
+	bin := stubPHPModules(t, "[PHP Modules]\nCore\njson\nposix\nstandard\n")
+
+	got := missingPHPExtensions(bin, []string{"posix", "pcntl"})
+
+	if len(got) != 1 || got[0] != "pcntl" {
+		t.Errorf("missing = %v, want [pcntl]", got)
+	}
+}
+
+func TestMissingPHPExtensions_nothingMissingWhenTheBinaryHasThemAll(t *testing.T) {
+	bin := stubPHPModules(t, "[PHP Modules]\nPCNTL\nposix\n")
+
+	if got := missingPHPExtensions(bin, []string{"posix", "pcntl"}); len(got) != 0 {
+		t.Errorf("missing = %v, want none (the module list is not case sensitive)", got)
+	}
+}
+
+// A probe that cannot run says nothing about the binary, and rerouting a command
+// on a failed question would move work into a container the declaration never
+// asked for. The command runs where it was declared to run and fails there.
+func TestMissingPHPExtensions_silentWhenTheProbeFails(t *testing.T) {
+	if got := missingPHPExtensions(filepath.Join(t.TempDir(), "absent"), []string{"posix"}); got != nil {
+		t.Errorf("missing = %v, want nil when the binary cannot be asked", got)
+	}
+}
+
+func TestMissingPHPExtensions_noneDeclared(t *testing.T) {
+	if got := missingPHPExtensions("/nonexistent/php", nil); got != nil {
+		t.Errorf("missing = %v, want nil without a declaration to check", got)
+	}
+}
+
+// stubPHPModules writes an executable that answers `php -m` with the given list.
+func stubPHPModules(t *testing.T, modules string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "php")
+	script := "#!/bin/sh\ncat <<'MODS'\n" + modules + "MODS\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	return path
+}
+
+// The fallback PHP must never be installed as "php": that name in lerd's bin
+// directory is the shim into the container, and a static binary written over it
+// would take every `php` on the machine with it.
+func TestHostPHPPath_doesNotShadowTheContainerShim(t *testing.T) {
+	path := hostPHPPath("php-host-8.3")
+	if base := filepath.Base(path); base == "php" {
+		t.Errorf("host php installs as %q, which is lerd's php shim", base)
+	}
+	if filepath.Dir(path) != config.BinDir() {
+		t.Errorf("host php at %q, want it in lerd's bin directory", path)
+	}
+}
+
+// A host command runs the project's own code, and its composer.lock was
+// resolved against the project's PHP version, so the build that replaces the
+// incomplete one has to be that version rather than the newest lerd pins.
+func TestHostPHPTool_picksTheProjectsVersionThenTheNearest(t *testing.T) {
+	m := &tools.Manifest{Tools: map[string]tools.Tool{
+		"php-host-8.3": {Version: "8.3.32"},
+		"php-host-8.4": {Version: "8.4.23"},
+		"php-host-8.5": {Version: "8.5.8"},
+		"mkcert":       {Version: "v1.4.4"},
+	}}
+
+	cases := map[string]string{
+		"8.4": "php-host-8.4",
+		"8.5": "php-host-8.5",
+		"8.1": "php-host-8.3", // nothing pinned that low, nearest wins
+		"9.0": "php-host-8.5",
+	}
+	for version, want := range cases {
+		if got, ok := hostPHPTool(m, version); !ok || got != want {
+			t.Errorf("hostPHPTool(%s) = %q, want %q", version, got, want)
+		}
+	}
+}
+
+func TestHostPHPTool_nothingPinned(t *testing.T) {
+	if _, ok := hostPHPTool(&tools.Manifest{Tools: map[string]tools.Tool{"mkcert": {}}}, "8.4"); ok {
+		t.Error("want no tool when the manifest pins no PHP")
+	}
+}
+
+// The missing extensions are read inside a sentence, so they are joined like
+// one rather than printed as a bare comma list.
+func TestJoinAnd(t *testing.T) {
+	cases := map[string]string{
+		"":            "",
+		"posix":       "posix",
+		"posix|pcntl": "posix and pcntl",
+		"a|b|c":       "a, b and c",
+	}
+	for input, want := range cases {
+		var items []string
+		if input != "" {
+			items = strings.Split(input, "|")
+		}
+		if got := joinAnd(items); got != want {
+			t.Errorf("joinAnd(%v) = %q, want %q", items, got, want)
+		}
 	}
 }

--- a/internal/cli/host_command_test.go
+++ b/internal/cli/host_command_test.go
@@ -190,3 +190,17 @@ func TestHostPHPFallback_failsWhenNothingIsInstalled(t *testing.T) {
 		t.Errorf("err = %v, want it to carry the download failure", err)
 	}
 }
+
+// Nothing lerd fetches starts before the user has seen how big it is, the same
+// promise the image pull disclosure makes. A manifest that pins no size for a
+// platform still announces the download rather than saying nothing.
+func TestHostPHPDownloadLabel_disclosesTheSize(t *testing.T) {
+	with := hostPHPDownloadLabel("8.5.8", 12931817)
+	if !strings.Contains(with, "8.5.8") || !strings.Contains(with, "MiB") {
+		t.Errorf("label = %q, want the version and a human size", with)
+	}
+	without := hostPHPDownloadLabel("8.5.8", 0)
+	if !strings.Contains(without, "8.5.8") || strings.Contains(without, "(") {
+		t.Errorf("label = %q, want no size when the manifest pins none", without)
+	}
+}

--- a/internal/cli/host_command_test.go
+++ b/internal/cli/host_command_test.go
@@ -1,6 +1,9 @@
 package cli
 
 import (
+	"bytes"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -154,5 +157,36 @@ func TestJoinAnd(t *testing.T) {
 		if got := joinAnd(items); got != want {
 			t.Errorf("joinAnd(%v) = %q, want %q", items, got, want)
 		}
+	}
+}
+
+// A pin that moved is not worth failing the command over: the build installed
+// last time carries the extensions the command needs just as much, so a fetch
+// that fails falls back to it and says which version is actually running.
+func TestHostPHPFallback_usesTheCopyOnDiskAndSaysSo(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "php-host-8.4")
+	if err := os.WriteFile(dest, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+
+	got, err := hostPHPFallback(dest, "8.4.20", &out, errors.New("dial tcp: timeout"))
+
+	if err != nil || got != dest {
+		t.Fatalf("fallback = (%q, %v), want the installed binary", got, err)
+	}
+	if !strings.Contains(out.String(), "8.4.20") || !strings.Contains(out.String(), "timeout") {
+		t.Errorf("warning = %q, want the version it fell back to and why", out.String())
+	}
+}
+
+// With nothing on disk there is nothing to fall back to, and the command cannot
+// run at all, so the failure names what could not be fetched rather than
+// surfacing three layers away as a missing extension.
+func TestHostPHPFallback_failsWhenNothingIsInstalled(t *testing.T) {
+	_, err := hostPHPFallback(filepath.Join(t.TempDir(), "absent"), "", io.Discard, errors.New("HTTP 503"))
+
+	if err == nil || !strings.Contains(err.Error(), "503") {
+		t.Errorf("err = %v, want it to carry the download failure", err)
 	}
 }

--- a/internal/cli/tools_download.go
+++ b/internal/cli/tools_download.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/download"
@@ -23,15 +24,22 @@ import (
 type pinnedTools struct{ m *tools.Manifest }
 
 func (p *pinnedTools) download(name, dest string, mode os.FileMode, w io.Writer) (string, error) {
+	return p.downloadCtx(context.Background(), name, dest, mode, w)
+}
+
+// downloadCtx is download under a caller's context, so a fetch that would
+// otherwise sit inside the retry loop for as long as the server keeps trickling
+// bytes has an end.
+func (p *pinnedTools) downloadCtx(ctx context.Context, name, dest string, mode os.FileMode, w io.Writer) (string, error) {
 	if p.m == nil {
-		p.m = tools.Load(context.Background())
+		p.m = tools.Load(ctx)
 	}
 	url, err := p.m.URL(name, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		return "", err
 	}
 	digest := p.m.Digest(name, runtime.GOOS, runtime.GOARCH)
-	if err := download.Verified(context.Background(), url, dest, mode, digest, w); err != nil {
+	if err := download.Verified(ctx, url, dest, mode, digest, w); err != nil {
 		return "", err
 	}
 	return p.m.Tools[name].Version, nil
@@ -156,9 +164,11 @@ func ensureHostPHPBinary(w io.Writer, phpVersion string) (string, error) {
 	defer os.RemoveAll(stage)
 
 	archive := filepath.Join(stage, "php.tar.gz")
-	v, err := pins.download(tool, archive, 0644, w)
+	ctx, cancel := context.WithTimeout(context.Background(), hostPHPFetchTimeout)
+	defer cancel()
+	v, err := pins.downloadCtx(ctx, tool, archive, 0644, w)
 	if err != nil {
-		return "", fmt.Errorf("php download: %w", err)
+		return hostPHPFallback(dest, tools.InstalledVersion(tool), w, err)
 	}
 	extract := exec.Command("tar", "-xzf", archive, "-C", stage, "php")
 	extract.Stdout = w
@@ -171,5 +181,26 @@ func ensureHostPHPBinary(w io.Writer, phpVersion string) (string, error) {
 	}
 	os.Chmod(dest, 0755) //nolint:errcheck
 	_ = tools.WriteStamp(tool, v)
+	return dest, nil
+}
+
+// hostPHPFetchTimeout bounds the whole fetch. download.Verified already retries
+// a stalled attempt three times against a 60s idle watchdog, which on a server
+// that keeps trickling bytes is a wait with no end; a command a user is
+// watching needs one.
+const hostPHPFetchTimeout = 10 * time.Minute
+
+// hostPHPFallback answers a failed fetch with the copy already on disk when
+// there is one. A pin that moved is not worth failing a command over: the build
+// installed last time has the extensions the command needs just as much, and it
+// says so rather than running a version the user was not told about.
+func hostPHPFallback(dest, installed string, w io.Writer, cause error) (string, error) {
+	if _, err := os.Stat(dest); err != nil {
+		return "", fmt.Errorf("could not download the PHP this command needs: %w", cause)
+	}
+	if installed == "" {
+		installed = "the copy already installed"
+	}
+	feedback.WarnOn(w, "could not download the pinned PHP (%v), running with %s instead", cause, installed)
 	return dest, nil
 }

--- a/internal/cli/tools_download.go
+++ b/internal/cli/tools_download.go
@@ -8,9 +8,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/download"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/tools"
 )
 
@@ -79,4 +82,94 @@ func replaceTool(pins *pinnedTools, name, dest string, w io.Writer) error {
 	}
 	_ = tools.WriteStamp(name, v)
 	return nil
+}
+
+// hostPHPPath is where lerd keeps the full PHP it runs a host command with.
+// Deliberately not "php": that name in BinDir is the shim into the container,
+// and writing a static binary over it would send every `php` on the machine to
+// a PHP with no lerd behind it. Suffixed with the minor it is, since a project
+// runs its own code and its composer.lock was resolved against one version.
+func hostPHPPath(tool string) string { return filepath.Join(config.BinDir(), tool) }
+
+// hostPHPTool picks the pinned build for a project's PHP version: the matching
+// minor, or the nearest pinned one when a project runs a PHP lerd pins no build
+// for. Nearest rather than newest, because a project on 8.1 is closer to 8.3
+// than to whatever the newest line has deprecated since.
+func hostPHPTool(m *tools.Manifest, phpVersion string) (string, bool) {
+	want := "php-host-" + phpVersion
+	if _, ok := m.Tools[want]; ok {
+		return want, true
+	}
+	best, bestGap := "", 0
+	for name := range m.Tools {
+		minor, ok := strings.CutPrefix(name, "php-host-")
+		if !ok {
+			continue
+		}
+		gap := versionGap(phpVersion, minor)
+		if best == "" || gap < bestGap || (gap == bestGap && minor < strings.TrimPrefix(best, "php-host-")) {
+			best, bestGap = name, gap
+		}
+	}
+	return best, best != ""
+}
+
+// versionGap measures how far two "8.3"-shaped versions are apart in minors, so
+// the nearest pinned build can be picked without ordering rules spread around.
+func versionGap(a, b string) int {
+	n := func(v string) int {
+		major, minor, _ := strings.Cut(v, ".")
+		maj, _ := strconv.Atoi(major)
+		min, _ := strconv.Atoi(minor)
+		return maj*100 + min
+	}
+	gap := n(a) - n(b)
+	if gap < 0 {
+		return -gap
+	}
+	return gap
+}
+
+// ensureHostPHPBinary installs the pinned static PHP for a project's PHP version
+// when it is missing or behind the pin, and answers where it is. Downloaded on
+// demand rather than at install time, because only a project whose bundled
+// runtime is short an extension ever needs it.
+func ensureHostPHPBinary(w io.Writer, phpVersion string) (string, error) {
+	pins := &pinnedTools{m: tools.Load(context.Background())}
+	tool, ok := hostPHPTool(pins.m, phpVersion)
+	if !ok {
+		return "", fmt.Errorf("lerd pins no PHP build to fall back to")
+	}
+	dest := hostPHPPath(tool)
+	if _, err := os.Stat(dest); err == nil && tools.InstalledVersion(tool) == pins.m.Tools[tool].Version {
+		return dest, nil
+	}
+	on := feedback.ColorFor(w)
+	fmt.Fprintf(w, "%s%s lerd downloads PHP %s for this command\n", feedback.Prefix,
+		feedback.DimIf(on, feedback.GlyphDownload), pins.m.Tools[tool].Version)
+	// Extracted through a directory of its own: the archive's member is called
+	// "php", and unpacking that straight into BinDir would land on the shim.
+	stage, err := os.MkdirTemp(config.BinDir(), "php-host-")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(stage)
+
+	archive := filepath.Join(stage, "php.tar.gz")
+	v, err := pins.download(tool, archive, 0644, w)
+	if err != nil {
+		return "", fmt.Errorf("php download: %w", err)
+	}
+	extract := exec.Command("tar", "-xzf", archive, "-C", stage, "php")
+	extract.Stdout = w
+	extract.Stderr = w
+	if err := extract.Run(); err != nil {
+		return "", fmt.Errorf("php extract: %w", err)
+	}
+	if err := os.Rename(filepath.Join(stage, "php"), dest); err != nil {
+		return "", err
+	}
+	os.Chmod(dest, 0755) //nolint:errcheck
+	_ = tools.WriteStamp(tool, v)
+	return dest, nil
 }

--- a/internal/cli/tools_download.go
+++ b/internal/cli/tools_download.go
@@ -15,6 +15,7 @@ import (
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/download"
 	"github.com/geodro/lerd/internal/feedback"
+	"github.com/geodro/lerd/internal/imagepull"
 	"github.com/geodro/lerd/internal/tools"
 )
 
@@ -152,9 +153,10 @@ func ensureHostPHPBinary(w io.Writer, phpVersion string) (string, error) {
 	if _, err := os.Stat(dest); err == nil && tools.InstalledVersion(tool) == pins.m.Tools[tool].Version {
 		return dest, nil
 	}
+	version := pins.m.Tools[tool].Version
 	on := feedback.ColorFor(w)
-	fmt.Fprintf(w, "%s%s lerd downloads PHP %s for this command\n", feedback.Prefix,
-		feedback.DimIf(on, feedback.GlyphDownload), pins.m.Tools[tool].Version)
+	fmt.Fprintf(w, "%s%s %s\n", feedback.Prefix, feedback.DimIf(on, feedback.GlyphDownload),
+		hostPHPDownloadLabel(version, pins.m.Size(tool, runtime.GOOS, runtime.GOARCH)))
 	// Extracted through a directory of its own: the archive's member is called
 	// "php", and unpacking that straight into BinDir would land on the shim.
 	stage, err := os.MkdirTemp(config.BinDir(), "php-host-")
@@ -166,10 +168,16 @@ func ensureHostPHPBinary(w io.Writer, phpVersion string) (string, error) {
 	archive := filepath.Join(stage, "php.tar.gz")
 	ctx, cancel := context.WithTimeout(context.Background(), hostPHPFetchTimeout)
 	defer cancel()
-	v, err := pins.downloadCtx(ctx, tool, archive, 0644, w)
+	// The downloader draws its own bar, which is a stream of frames anywhere
+	// that is not a terminal. The step spinner is the one lerd uses everywhere
+	// else and stays a single line either way, so the bar goes to the bin.
+	step := feedback.StartOn(w, "fetching php "+version)
+	v, err := pins.downloadCtx(ctx, tool, archive, 0644, io.Discard)
 	if err != nil {
+		step.Fail(err)
 		return hostPHPFallback(dest, tools.InstalledVersion(tool), w, err)
 	}
+	step.OK("downloaded")
 	extract := exec.Command("tar", "-xzf", archive, "-C", stage, "php")
 	extract.Stdout = w
 	extract.Stderr = w
@@ -203,4 +211,15 @@ func hostPHPFallback(dest, installed string, w io.Writer, cause error) (string, 
 	}
 	feedback.WarnOn(w, "could not download the pinned PHP (%v), running with %s instead", cause, installed)
 	return dest, nil
+}
+
+// hostPHPDownloadLabel says what is about to be fetched and how big it is, so a
+// command that pauses to download tens of megabytes discloses that first, the
+// way an image pull does.
+func hostPHPDownloadLabel(version string, size int64) string {
+	label := "lerd downloads PHP " + version + " for this command"
+	if size > 0 {
+		label += " (" + imagepull.Human(size) + ")"
+	}
+	return label
 }

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -337,6 +337,11 @@ type HostCommand struct {
 	Args           string `yaml:"args" json:"args"`
 	Binary         string `yaml:"binary" json:"binary"`
 	InstallCommand string `yaml:"install_command,omitempty" json:"install_command,omitempty"`
+	// RequiresExtensions names the PHP extensions the declared binary must carry
+	// for the command to work at all. The runtimes projects bundle are trimmed
+	// builds, so a binary short one of them cannot run the command and lerd runs
+	// it in the PHP container on the host's network instead.
+	RequiresExtensions []string `yaml:"requires_extensions,omitempty" json:"requires_extensions,omitempty"`
 }
 
 // MatchHostCommand reports the declaration a framework carries for these

--- a/internal/config/framework_hostcommand_test.go
+++ b/internal/config/framework_hostcommand_test.go
@@ -1,6 +1,10 @@
 package config
 
-import "testing"
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
 
 // A package whose command has to escape the container declares which arguments
 // mean that and the binary to use. Without it `php artisan native:run` reaches
@@ -102,5 +106,32 @@ func TestMatchHostCommand_NoInstallCommandDeclared(t *testing.T) {
 	}
 	if got.InstallCommand != "" {
 		t.Errorf("install command = %q, want empty", got.InstallCommand)
+	}
+}
+
+// A declaration can say which extensions the binary it names has to have. The
+// runtimes projects bundle are trimmed builds, and one that is short an
+// extension the command needs cannot run it, so lerd needs the requirement in
+// the store rather than a guess in Go.
+func TestHostCommand_RequiresExtensionsParseAndTravelWithTheEntry(t *testing.T) {
+	var fw Framework
+	if err := yaml.Unmarshal([]byte(`
+host_commands:
+  - args: "artisan native:jump"
+    binary: vendor/nativephp/php-bin/bin/host/php
+    requires_extensions: [posix, pcntl]
+  - args: "artisan native:*"
+    binary: vendor/nativephp/php-bin/bin/host/php
+`), &fw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got, ok := MatchHostCommand(&fw, []string{"artisan", "native:jump"})
+	if !ok || len(got.RequiresExtensions) != 2 || got.RequiresExtensions[0] != "posix" {
+		t.Fatalf("requires_extensions = %v, want [posix pcntl]", got.RequiresExtensions)
+	}
+
+	if got, _ := MatchHostCommand(&fw, []string{"artisan", "native:run"}); len(got.RequiresExtensions) != 0 {
+		t.Errorf("requires_extensions = %v, want none on the entry that declares none", got.RequiresExtensions)
 	}
 }

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -63,6 +63,7 @@ var (
 // what every host downloads and marks executable. Extendable through
 // LERD_TOOLS_HOSTS for the same reason LERD_TOOLS_URL exists.
 var downloadHosts = []string{
+	"dl.static-php.dev",
 	"getcomposer.org",
 	"github.com",
 	"objects.githubusercontent.com",

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -45,6 +45,9 @@ type Tool struct {
 	URL     string            `yaml:"url"`
 	Assets  map[string]string `yaml:"assets"`
 	Digests map[string]string `yaml:"digests,omitempty"`
+	// Sizes is the asset's byte count per GOOS/GOARCH, so a command can say what
+	// it is about to fetch before it starts. Optional, like Digests.
+	Sizes map[string]int64 `yaml:"sizes,omitempty"`
 }
 
 // Manifest is the parsed tools.yaml.
@@ -100,6 +103,11 @@ func (t Tool) valid() bool {
 			return false
 		}
 	}
+	for _, n := range t.Sizes {
+		if n < 0 {
+			return false
+		}
+	}
 	return true
 }
 
@@ -107,6 +115,12 @@ func (t Tool) valid() bool {
 // pins none for this platform.
 func (m *Manifest) Digest(name, goos, goarch string) string {
 	return m.Tools[name].Digests[goos+"/"+goarch]
+}
+
+// Size returns the published byte count for an asset, zero when the manifest
+// pins none for this platform.
+func (m *Manifest) Size(name, goos, goarch string) int64 {
+	return m.Tools[name].Sizes[goos+"/"+goarch]
 }
 
 // Load returns the pinned tool manifest: the embedded copy, overlaid with

--- a/internal/tools/tools.yaml
+++ b/internal/tools/tools.yaml
@@ -13,6 +13,50 @@ tools:
       linux/arm64: fnm-arm64.zip
       darwin/amd64: fnm-macos.zip
       darwin/arm64: fnm-macos.zip
+  # The PHP a host command falls back to when the runtime a project bundles is
+  # short an extension it needs. Full static builds rather than trimmed ones, one
+  # per PHP minor because the command runs a project's own code and its
+  # composer.lock was resolved against that version. Kept out of Names() because
+  # only a project that asks for one ever downloads it.
+  php-host-8.3:
+    version: "8.3.32"
+    url: https://dl.static-php.dev/static-php-cli/common/{asset}
+    assets:
+      linux/amd64: php-{version}-cli-linux-x86_64.tar.gz
+      linux/arm64: php-{version}-cli-linux-aarch64.tar.gz
+      darwin/amd64: php-{version}-cli-macos-x86_64.tar.gz
+      darwin/arm64: php-{version}-cli-macos-aarch64.tar.gz
+    digests:
+      linux/amd64: d7ff2bc40846f4efed2757e5929f7469c96f672fbf33eb4bb80cd695534750fe
+      linux/arm64: e7644c646a62c44627d00e3deff498eeb943814adcc948b3de42a8ebfe07aaf2
+      darwin/amd64: aad1365eb29a6788c59494d39bc71ef5f72a8a384495b0d6004007a768449f8b
+      darwin/arm64: 1cc8148750bd1722031daba1618825a8b7d0a3830bb92c50d8dd844a1dcfb306
+  php-host-8.4:
+    version: "8.4.23"
+    url: https://dl.static-php.dev/static-php-cli/common/{asset}
+    assets:
+      linux/amd64: php-{version}-cli-linux-x86_64.tar.gz
+      linux/arm64: php-{version}-cli-linux-aarch64.tar.gz
+      darwin/amd64: php-{version}-cli-macos-x86_64.tar.gz
+      darwin/arm64: php-{version}-cli-macos-aarch64.tar.gz
+    digests:
+      linux/amd64: 1aeed5bc7967977ca5b1da7163acd91bf9ba3ac56037045d4e91ee2ff2712bb7
+      linux/arm64: 0978d89157292bcc9268a34a73a4d5d2793f8dff1403b5138a94d2af6b7a09b0
+      darwin/amd64: bd1c20f355e73a9f807b24ba62fd98f3a57bc08d063ebb3aa6393909e01ce89e
+      darwin/arm64: bba286e442796dbd420d778a016e2817b31d5036d11b3ba316d19a60de912cdc
+  php-host-8.5:
+    version: "8.5.8"
+    url: https://dl.static-php.dev/static-php-cli/common/{asset}
+    assets:
+      linux/amd64: php-{version}-cli-linux-x86_64.tar.gz
+      linux/arm64: php-{version}-cli-linux-aarch64.tar.gz
+      darwin/amd64: php-{version}-cli-macos-x86_64.tar.gz
+      darwin/arm64: php-{version}-cli-macos-aarch64.tar.gz
+    digests:
+      linux/amd64: 517a18e0f0874de35669fe134eb3c52508e128a6d1da5bf890760cb800ada410
+      linux/arm64: af995ef6b3187b39932a00714dfb97e44bfa40a9243c4c29f61f19d583950753
+      darwin/amd64: 05751000c6643f82e8377ed19d55bc159f84bbed46ace1fcc6f62be9866c787c
+      darwin/arm64: cba9bd8b38b51ef2c7cebf02af689e4481bbd07f65edc0b63d3a43b04e0c9db7
   mkcert:
     version: v1.4.4
     url: https://github.com/FiloSottile/mkcert/releases/download/{version}/{asset}

--- a/internal/tools/tools.yaml
+++ b/internal/tools/tools.yaml
@@ -31,6 +31,11 @@ tools:
       linux/arm64: e7644c646a62c44627d00e3deff498eeb943814adcc948b3de42a8ebfe07aaf2
       darwin/amd64: aad1365eb29a6788c59494d39bc71ef5f72a8a384495b0d6004007a768449f8b
       darwin/arm64: 1cc8148750bd1722031daba1618825a8b7d0a3830bb92c50d8dd844a1dcfb306
+    sizes:
+      linux/amd64: 11744291
+      linux/arm64: 12151982
+      darwin/amd64: 14110296
+      darwin/arm64: 13688227
   php-host-8.4:
     version: "8.4.23"
     url: https://dl.static-php.dev/static-php-cli/common/{asset}
@@ -44,6 +49,11 @@ tools:
       linux/arm64: 0978d89157292bcc9268a34a73a4d5d2793f8dff1403b5138a94d2af6b7a09b0
       darwin/amd64: bd1c20f355e73a9f807b24ba62fd98f3a57bc08d063ebb3aa6393909e01ce89e
       darwin/arm64: bba286e442796dbd420d778a016e2817b31d5036d11b3ba316d19a60de912cdc
+    sizes:
+      linux/amd64: 12375301
+      linux/arm64: 12768307
+      darwin/amd64: 14862400
+      darwin/arm64: 14435029
   php-host-8.5:
     version: "8.5.8"
     url: https://dl.static-php.dev/static-php-cli/common/{asset}
@@ -57,6 +67,11 @@ tools:
       linux/arm64: af995ef6b3187b39932a00714dfb97e44bfa40a9243c4c29f61f19d583950753
       darwin/amd64: 05751000c6643f82e8377ed19d55bc159f84bbed46ace1fcc6f62be9866c787c
       darwin/arm64: cba9bd8b38b51ef2c7cebf02af689e4481bbd07f65edc0b63d3a43b04e0c9db7
+    sizes:
+      linux/amd64: 12931817
+      linux/arm64: 13570407
+      darwin/amd64: 15606882
+      darwin/arm64: 15106458
   mkcert:
     version: v1.4.4
     url: https://github.com/FiloSottile/mkcert/releases/download/{version}/{asset}

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -31,7 +31,7 @@ var platforms = []struct{ goos, goarch string }{
 func TestEmbedded_ResolvesEveryToolOnEveryPlatform(t *testing.T) {
 	offline(t)
 	m := Load(context.Background())
-	for _, name := range []string{"composer", "fnm", "mkcert"} {
+	for _, name := range []string{"composer", "fnm", "mkcert", "php-host-8.3", "php-host-8.4", "php-host-8.5"} {
 		tool, ok := m.Tools[name]
 		if !ok {
 			t.Fatalf("embedded manifest is missing %s", name)
@@ -481,5 +481,32 @@ func TestInstalledVersion_ComposerPrefersTheStamp(t *testing.T) {
 	}
 	if v := InstalledVersion("composer"); v != "2.9.9" {
 		t.Errorf("InstalledVersion = %q, want the stamped 2.9.9", v)
+	}
+}
+
+// The fallback PHP is pinned for every platform lerd runs on, with a digest for
+// each: it is the one tool downloaded from outside GitHub, and it is fetched
+// only when a project's own runtime has already turned out to be incomplete.
+func TestEmbeddedManifest_hostPHPIsPinnedAndDigestedEverywhere(t *testing.T) {
+	m := embeddedManifest()
+	for _, name := range []string{"php-host-8.3", "php-host-8.4", "php-host-8.5"} {
+		for _, p := range []struct{ goos, goarch string }{
+			{"linux", "amd64"}, {"linux", "arm64"}, {"darwin", "amd64"}, {"darwin", "arm64"},
+		} {
+			url, err := m.URL(name, p.goos, p.goarch)
+			if err != nil {
+				t.Errorf("URL(%s, %s/%s): %v", name, p.goos, p.goarch, err)
+				continue
+			}
+			if !strings.HasPrefix(url, "https://dl.static-php.dev/") {
+				t.Errorf("%s %s/%s URL = %q", name, p.goos, p.goarch, url)
+			}
+			if d := m.Digest(name, p.goos, p.goarch); !sha256Re.MatchString(d) {
+				t.Errorf("%s %s/%s digest = %q, want a sha256", name, p.goos, p.goarch, d)
+			}
+		}
+		if v := m.Tools[name].Version; !strings.HasPrefix(v, strings.TrimPrefix(name, "php-host-")+".") {
+			t.Errorf("%s pins version %q, want a patch of that minor", name, v)
+		}
 	}
 }

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -504,6 +504,9 @@ func TestEmbeddedManifest_hostPHPIsPinnedAndDigestedEverywhere(t *testing.T) {
 			if d := m.Digest(name, p.goos, p.goarch); !sha256Re.MatchString(d) {
 				t.Errorf("%s %s/%s digest = %q, want a sha256", name, p.goos, p.goarch, d)
 			}
+			if n := m.Size(name, p.goos, p.goarch); n <= 0 {
+				t.Errorf("%s %s/%s size = %d, want the byte count the download discloses", name, p.goos, p.goarch, n)
+			}
 		}
 		if v := m.Tools[name].Version; !strings.HasPrefix(v, strings.TrimPrefix(name, "php-host-")+".") {
 			t.Errorf("%s pins version %q, want a patch of that minor", name, v)

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -241,7 +241,7 @@ func handleCommandRun(w http.ResponseWriter, r *http.Request, site *config.Site,
 	// running inside, then return immediately. The UI handles this by
 	// skipping the modal and showing a toast.
 	if target.Output == config.CommandOutputTerminal {
-		script := "cd " + podman.ShellQuote(cwd) + " && " + target.Command + "\nprintf '\\n[press any key to close]'\nread -n 1 -s -r 2>/dev/null || read"
+		script := terminalCommandScript(cwd, target.Command)
 		if err := openTerminalCommand(script); err != nil {
 			writeJSON(w, map[string]any{"error": err.Error()})
 			return
@@ -395,4 +395,19 @@ func streamHostAction(w http.ResponseWriter, line string, actionErr error) {
 	}
 	body, _ := json.Marshal(map[string]any{"exit": exit, "durationMs": 0})
 	send("done", string(body))
+}
+
+// terminalCommandScript is what the spawned terminal runs: the command in the
+// project directory, then a pause so the window holds its output.
+//
+// The trap is what keeps ctrl+c usable. A non-interactive shell dies on SIGINT
+// with the command it is waiting on, so interrupting a long-running one left
+// the terminal reporting a crashed shell instead of the command's own goodbye
+// and the pause below. It is a handler rather than an ignore on purpose: an
+// ignored SIGINT is inherited by every child, and the command would stop
+// answering ctrl+c at all.
+func terminalCommandScript(cwd, command string) string {
+	return "trap 'true' INT\n" +
+		"cd " + podman.ShellQuote(cwd) + " && " + command +
+		"\nprintf '\\n[press any key to close]'\nread -n 1 -s -r 2>/dev/null || read"
 }

--- a/internal/ui/commands_test.go
+++ b/internal/ui/commands_test.go
@@ -536,3 +536,25 @@ commands:
 		t.Errorf("three must stay unpinned: %v", got)
 	}
 }
+
+// Ctrl+c on a terminal command used to take the shell with it: a
+// non-interactive sh dies on SIGINT alongside the command it is waiting on, and
+// the window ended up reporting a crashed shell rather than showing the
+// command's own shutdown and the pause. The trap has to be a handler, since an
+// ignored SIGINT is inherited and the command itself would stop answering it.
+func TestTerminalCommandScript_survivesInterruptWithoutIgnoringIt(t *testing.T) {
+	script := terminalCommandScript("/home/u/my app", "php artisan native:jump")
+
+	if !strings.HasPrefix(script, "trap 'true' INT\n") {
+		t.Errorf("script = %q, want it to trap INT before running anything", script)
+	}
+	if strings.Contains(script, "trap '' INT") {
+		t.Error("script ignores INT, which children inherit and ctrl+c stops working")
+	}
+	if !strings.Contains(script, "cd '/home/u/my app' && php artisan native:jump") {
+		t.Errorf("script = %q, want the quoted directory and the command", script)
+	}
+	if !strings.Contains(script, "[press any key to close]") {
+		t.Errorf("script = %q, want the window to hold its output", script)
+	}
+}

--- a/internal/ui/commands_test.go
+++ b/internal/ui/commands_test.go
@@ -558,3 +558,23 @@ func TestTerminalCommandScript_survivesInterruptWithoutIgnoringIt(t *testing.T) 
 		t.Errorf("script = %q, want the window to hold its output", script)
 	}
 }
+
+// A declared command reaches `php` and `lerd` through lerd's own bin directory,
+// which `lerd run` and the dashboard runner both put on PATH. A terminal
+// command has to resolve them the same way rather than inheriting whatever the
+// service manager imported, or a store command fails as not found on one
+// machine and works on the next.
+func TestTerminalEnv_carriesLerdsBinDirOnPath(t *testing.T) {
+	var path string
+	for _, kv := range terminalEnv() {
+		if v, ok := strings.CutPrefix(kv, "PATH="); ok {
+			path = v
+		}
+	}
+	if path == "" {
+		t.Fatal("terminal env sets no PATH")
+	}
+	if !strings.Contains(path, config.BinDir()) {
+		t.Errorf("PATH = %q, want lerd's bin dir %q in it", path, config.BinDir())
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -5764,6 +5764,20 @@ func terminalScriptCandidates(script string) []terminalCmd {
 
 // openTerminalCommand opens the user's terminal emulator and runs the given
 // shell script in it.
+// terminalEnv is what a spawned terminal runs with: the graphical session keys
+// it needs to reach the display, and lerd's bin directory on PATH. A store
+// command that calls php or lerd has to resolve them the same way it does
+// through `lerd run` and the dashboard's own runner, both of which set this
+// PATH; without it the emulator inherits whatever the user's service manager
+// happened to import and a declared command can fail as not found.
+func terminalEnv() []string {
+	env := os.Environ()
+	if runtime.GOOS != "darwin" {
+		env = graphicalEnv()
+	}
+	return append(env, "PATH="+config.PathWithBinDir())
+}
+
 func openTerminalCommand(script string) error {
 	for _, t := range terminalScriptCandidates(script) {
 		bin, err := exec.LookPath(t.bin)
@@ -5771,9 +5785,7 @@ func openTerminalCommand(script string) error {
 			continue
 		}
 		cmd := exec.Command(bin, t.args...)
-		if runtime.GOOS != "darwin" {
-			cmd.Env = graphicalEnv()
-		}
+		cmd.Env = terminalEnv()
 		if err := cmd.Start(); err != nil {
 			return err
 		}


### PR DESCRIPTION
A host command declaration can now name the PHP extensions the binary it points at has to carry. lerd asks that binary rather than assuming, and when it comes up short the command runs with lerd's own PHP instead, a pinned static build downloaded to the bin directory the first time a project needs one. Everything else about the run is unchanged, same host, same working directory, same environment.

The case it exists for is NativePHP's Jump. Its websocket bridge is Workerman, which calls posix and pcntl unguarded, and the PHP that ships in nativephp/php-bin has neither, on Linux and macOS alike. The bridge dies on its first line inside a log file while the HTTP side keeps answering, so a phone loads the landing page, finds nothing to connect to, and drops the session a few seconds later. It reads like a network problem and is not one. The bundled binary is a static build with dynamic loading compiled out, so the extensions cannot be added to it on the machine either.

There is a build pinned per PHP minor rather than one for everyone, because the command runs the project's own code and its composer.lock was resolved against that version, the same way NativePHP picks the bundled binary that matches. A project on a version nothing is pinned for gets the nearest one and is told so. Every build carries a sha256 for each platform, and the fallback installs as php-host-<minor> rather than php, since php in that directory is the shim into the container and writing over it would take every php on the machine with it. Because lerd asks the binary rather than assuming, the day upstream ships a fuller build the command goes back to the bundled one on its own.

Two things came out of driving it on a real device. Interrupting a terminal command took the shell with it, since a non-interactive shell dies on the same SIGINT as the command it is waiting on, and the window ended up reporting a crashed shell instead of the command's own shutdown. And a terminal command was spawned without lerd's bin directory on PATH, which both `lerd run` and the dashboard's runner set, so a declaration naming php or lerd could work on one machine and fail as not found on the next.

Closes #1656