### PR TITLE
Keep the progress popup test off the session bus

### DIFF
--- a/internal/desktopnotify/progress_linux_test.go
+++ b/internal/desktopnotify/progress_linux_test.go
@@ -7,16 +7,7 @@ import "testing"
 // A session with no notification daemon still runs the work; the progress popup
 // is what degrades, not the start behind it.
 func TestStartProgress_withoutABusIsANoop(t *testing.T) {
-	t.Setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=/nonexistent/lerd-test-bus")
-	busMu.Lock()
-	prev := busConn
-	busConn = nil
-	busMu.Unlock()
-	defer func() {
-		busMu.Lock()
-		busConn = prev
-		busMu.Unlock()
-	}()
+	withoutSessionBus(t)
 
 	p := StartProgress("Starting Lerd", "Preparing")
 	p.Step("lerd-mysql")
@@ -30,6 +21,10 @@ func TestStartProgress_withoutABusIsANoop(t *testing.T) {
 // The bar is a percentage of the units the run announced, capped so a run that
 // starts more than it counted cannot overshoot.
 func TestBusProgress_percentIsCappedAndIgnoresAnUnknownTotal(t *testing.T) {
+	// Percent pushes, and a bus left connected here posts a real popup on the
+	// desktop of whoever runs the suite, replacing an id that is not theirs.
+	withoutSessionBus(t)
+
 	p := &busProgress{id: 1}
 	p.Percent(1, 4)
 	if p.percent != 25 {
@@ -58,4 +53,21 @@ func TestBusProgress_closeIsIdempotent(t *testing.T) {
 	if p.body != "" {
 		t.Errorf("body = %q, want a closed popup to ignore updates", p.body)
 	}
+}
+
+// withoutSessionBus points the package at a bus that cannot be dialled, so a
+// test that reaches push() degrades instead of talking to the session running
+// the suite. The cached connection is cleared and put back afterwards.
+func withoutSessionBus(t *testing.T) {
+	t.Helper()
+	t.Setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=/nonexistent/lerd-test-bus")
+	busMu.Lock()
+	prev := busConn
+	busConn = nil
+	busMu.Unlock()
+	t.Cleanup(func() {
+		busMu.Lock()
+		busConn = prev
+		busMu.Unlock()
+	})
 }


### PR DESCRIPTION
The percent test in internal/desktopnotify builds a busProgress with a hardcoded id and calls Percent, which pushes, and push talks straight to org.freedesktop.Notifications with no seam in front of it. Running the suite on a Linux desktop posts a real notification under the name Lerd, empty because the struct literal carries no summary or body, and it asks the daemon to replace an id the daemon never handed out. KDE writes that off as a bug in the application and leaves an empty popup on screen that nothing closes, since the test never calls Close.

The bus removal that was written inline in the first test moves into a withoutSessionBus helper on t.Cleanup, and the percent test calls it too, so push degrades instead of reaching the session of whoever is running the tests. The close test needs nothing, its id is zero and it returns before the push.

Closes #1661