### PR TITLE
Answer a package check with what composer installed

### DIFF
--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -57,7 +57,9 @@ doctor:
 
 Workers, commands, post-link setup steps and doctor checks are the whole schema, because that is what the duplication was made of. A `removes:` block takes entries away again, which is what a new major of the package needs (see below). Env wiring, detection and services stay with the framework, which is where they belong.
 
-The layer is merged onto the resolved definition when the project requires the package in its `composer.json`, and only for the frameworks the `frameworks:` list names. An empty list means every framework, which is right for a queue driver and wrong for `nativephp/electron`; `min` and `max` bound the framework majors it applies to, and are compared against the project's own major, so a Laravel 14 project still gets a package that declares `min: "11"`. The package wins any name collision: it is where the entry is maintained now, so a copy left behind in a version file is replaced rather than shadowing it, and the replacement keeps the position the definition listed it in. Your user overlay and a project's `.lerd.yaml` are merged after the package layer and still sit above it.
+The layer is merged onto the resolved definition when the project has the package, and only for the frameworks the `frameworks:` list names. An empty list means every framework, which is right for a queue driver and wrong for `nativephp/electron`; `min` and `max` bound the framework majors it applies to, and are compared against the project's own major, so a Laravel 14 project still gets a package that declares `min: "11"`. The package wins any name collision: it is where the entry is maintained now, so a copy left behind in a version file is replaced rather than shadowing it, and the replacement keeps the position the definition listed it in. Your user overlay and a project's `.lerd.yaml` are merged after the package layer and still sit above it.
+
+Having the package means composer installed it, not that the project named it. The manifest is read first, and then `composer.lock`, which is the only place a dependency that arrived under a meta-package shows up, and the only place a package that another one `replace`s or `provide`s exists at all: `tempest/framework` stands in for `tempest/database`, so a stock Tempest project has that code installed while its `composer.json` names neither. A `check:` on a worker, command, setup step or doctor check is answered the same way, since what it is really asking is whether the thing it runs is there. Detection is the exception and reads the manifest alone: a library repo testing against Laravel has `laravel/framework` in its lock, and that must not make it a Laravel site.
 
 ### When a package major changes what lerd runs
 
@@ -365,7 +367,8 @@ workers:
                                   # `*:0/5`, `Mon..Fri *-*-* 02:00:00`). Linux only; on
                                   # macOS scheduled workers currently log a warning and skip.
     check:                        # only shown when check passes (optional)
-      composer: symfony/messenger
+      composer: symfony/messenger # matches a package composer installed, not
+                                  # only one composer.json names
     conflicts_with:               # workers to stop before starting (optional)
       - other-worker
     proxy:                        # nginx proxy config (optional)

--- a/internal/config/composer_lock.go
+++ b/internal/config/composer_lock.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// lockedPackage is the part of a composer.lock entry a check cares about: what
+// the package is called, which version resolved, and the names it stands in for.
+type lockedPackage struct {
+	Name    string            `json:"name"`
+	Version string            `json:"version"`
+	Replace map[string]string `json:"replace"`
+	Provide map[string]string `json:"provide"`
+}
+
+type composerLockEntry struct {
+	modTime  time.Time
+	size     int64
+	packages map[string]string
+}
+
+var (
+	composerLockMu    sync.Mutex
+	composerLockCache = map[string]composerLockEntry{}
+)
+
+// lockPackages returns what composer installed for a project, package name to
+// the version that resolved, and nil for a project with no lock. A name another
+// package replaces or provides is listed too, at the version of the package
+// standing in for it: that is the only place a name like tempest/database
+// appears, since composer writes one entry for the framework replacing it.
+func lockPackages(dir string) map[string]string {
+	path := filepath.Join(dir, "composer.lock")
+	st, err := os.Stat(path)
+	if err != nil {
+		return nil
+	}
+
+	composerLockMu.Lock()
+	defer composerLockMu.Unlock()
+	if e, ok := composerLockCache[path]; ok && e.modTime.Equal(st.ModTime()) && e.size == st.Size() {
+		return e.packages
+	}
+
+	data, err := composerReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var lock struct {
+		Packages    []lockedPackage `json:"packages"`
+		PackagesDev []lockedPackage `json:"packages-dev"`
+	}
+	if json.Unmarshal(data, &lock) != nil {
+		return nil
+	}
+
+	pkgs := make(map[string]string, len(lock.Packages)+len(lock.PackagesDev))
+	for _, entry := range append(lock.Packages, lock.PackagesDev...) {
+		if entry.Name == "" {
+			continue
+		}
+		pkgs[entry.Name] = entry.Version
+	}
+	// Second pass, so a package that is really installed keeps its own version
+	// rather than the one a later entry claims to replace it at.
+	for _, entry := range append(lock.Packages, lock.PackagesDev...) {
+		for _, stood := range []map[string]string{entry.Replace, entry.Provide} {
+			for name, version := range stood {
+				if _, real := pkgs[name]; real {
+					continue
+				}
+				if version == "self.version" {
+					version = entry.Version
+				}
+				pkgs[name] = version
+			}
+		}
+	}
+
+	composerLockCache[path] = composerLockEntry{modTime: st.ModTime(), size: st.Size(), packages: pkgs}
+	return pkgs
+}
+
+// ComposerHasInstalled reports whether a project has pkg available to run: named
+// in its composer.json, or installed underneath it. The manifest alone answers
+// what the project asked for, which misses a dependency it never named itself
+// and one that arrives under the package replacing it, and what a check is
+// really asking is whether the code is there.
+func ComposerHasInstalled(dir, pkg string, extraSections ...string) bool {
+	if ComposerHasPackage(dir, pkg, extraSections...) {
+		return true
+	}
+	_, ok := lockPackages(dir)[pkg]
+	return ok
+}
+
+// installedMajor is the major of pkg this project has, taken from the lock
+// composer resolved and falling back to the constraint the manifest declares,
+// which is all a project that has never been installed can offer.
+func installedMajor(dir, pkg string) string {
+	if v := lockPackages(dir)[pkg]; v != "" {
+		if major := extractMajorFromConstraint(v); major != "" {
+			return major
+		}
+	}
+	return detectVersionFromComposer(dir, []FrameworkRule{{Composer: pkg}})
+}

--- a/internal/config/composer_lock_test.go
+++ b/internal/config/composer_lock_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// composerProject writes a project with the manifest and, when body is not
+// empty, the lock composer would have resolved from it.
+func composerProject(t *testing.T, manifest, lock string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "composer.json"), []byte(manifest), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if lock != "" {
+		writeLock(t, dir, lock)
+	}
+	return dir
+}
+
+// writeLock gives a project the lock composer would have written for it.
+func writeLock(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "composer.lock"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A framework that stands in for its split packages is the only entry composer
+// writes, so the replaced name exists nowhere but under its replace map. This is
+// the Tempest case: tempest/app requires tempest/framework alone.
+func TestComposerHasInstalled_findsAReplacedPackage(t *testing.T) {
+	dir := composerProject(t,
+		`{"require": {"tempest/framework": "^3.0"}}`,
+		`{"packages": [{"name": "tempest/framework", "version": "v3.19.0",
+		  "replace": {"tempest/database": "self.version"}}]}`)
+
+	if !ComposerHasInstalled(dir, "tempest/database") {
+		t.Error("a replaced package is installed and must count as present")
+	}
+	if ComposerHasPackage(dir, "tempest/database") {
+		t.Error("the manifest lookup must stay manifest-only")
+	}
+}
+
+// A tool that arrived under a distribution rather than being asked for by name
+// is still there to run.
+func TestComposerHasInstalled_findsATransitiveDependency(t *testing.T) {
+	dir := composerProject(t,
+		`{"require": {"acme/distribution": "^1.0"}}`,
+		`{"packages": [{"name": "acme/distribution", "version": "1.2.0"}],
+		  "packages-dev": [{"name": "drush/drush", "version": "13.7.1"}]}`)
+
+	if !ComposerHasInstalled(dir, "drush/drush") {
+		t.Error("a package the lock installed must count as present")
+	}
+	if ComposerHasInstalled(dir, "acme/absent") {
+		t.Error("a package nothing installed must not count as present")
+	}
+}
+
+// A project that has never been installed has only its manifest to answer with.
+func TestComposerHasInstalled_withoutALockAnswersFromTheManifest(t *testing.T) {
+	dir := composerProject(t, `{"require": {"laravel/horizon": "^5.0"}}`, "")
+
+	if !ComposerHasInstalled(dir, "laravel/horizon") {
+		t.Error("a declared package must count with no lock on disk")
+	}
+	if ComposerHasInstalled(dir, "laravel/reverb") {
+		t.Error("a package neither file names must not count")
+	}
+}
+
+// Detection asks what the project is, and a library repo testing against Laravel
+// has laravel/framework in its lock without being a Laravel site.
+func TestMatchesDetectRule_readsTheManifestAlone(t *testing.T) {
+	dir := composerProject(t,
+		`{"require-dev": {"orchestra/testbench": "^9.0"}}`,
+		`{"packages-dev": [{"name": "laravel/framework", "version": "v11.9.0"},
+		  {"name": "orchestra/testbench", "version": "v9.0.0"}]}`)
+
+	rule := FrameworkRule{Composer: "laravel/framework"}
+	if MatchesDetectRule(dir, rule) {
+		t.Error("a framework in the lock alone must not detect the project as that framework")
+	}
+	if !MatchesRule(dir, rule) {
+		t.Error("a check asks what is installed, and it is")
+	}
+}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -2393,8 +2393,23 @@ func (fw *Framework) DetectProxy(dir string) (*WorkerProxy, string) {
 	return nil, ""
 }
 
-// MatchesRule returns true if the given rule matches the project directory.
+// MatchesRule returns true if the given rule matches the project directory. It
+// is the check gate: a worker, command, setup step or doctor check asking
+// whether what it runs is there, so a composer rule counts a package composer
+// installed as well as one the project declares.
 func MatchesRule(dir string, rule FrameworkRule) bool {
+	return matchesRule(dir, rule, ComposerHasInstalled)
+}
+
+// MatchesDetectRule is the same rule against the question detection asks, which
+// is what the project is rather than what is installed under it. A composer rule
+// reads the manifest alone here: a library repo testing against Laravel has
+// laravel/framework in its lock, and that must not make it a Laravel site.
+func MatchesDetectRule(dir string, rule FrameworkRule) bool {
+	return matchesRule(dir, rule, ComposerHasPackage)
+}
+
+func matchesRule(dir string, rule FrameworkRule, hasPackage func(string, string, ...string) bool) bool {
 	if rule.File != "" {
 		if _, err := os.Stat(filepath.Join(dir, rule.File)); err == nil {
 			return true
@@ -2409,7 +2424,7 @@ func MatchesRule(dir string, rule FrameworkRule) bool {
 		}
 	}
 	if rule.Composer != "" {
-		if ComposerHasPackage(dir, rule.Composer, rule.ComposerSections...) {
+		if hasPackage(dir, rule.Composer, rule.ComposerSections...) {
 			return true
 		}
 	}
@@ -2421,7 +2436,7 @@ func matchesFramework(dir string, fw *Framework) bool {
 		return false
 	}
 	for _, rule := range fw.Detect {
-		if MatchesRule(dir, rule) {
+		if MatchesDetectRule(dir, rule) {
 			return true
 		}
 	}

--- a/internal/config/framework_package.go
+++ b/internal/config/framework_package.go
@@ -128,7 +128,7 @@ func mergeStorePackages(fw *Framework, projectDir string) *Framework {
 		return fw
 	}
 	for _, entry := range cachedStorePackages() {
-		if !ComposerHasPackage(projectDir, entry.Name) {
+		if !ComposerHasInstalled(projectDir, entry.Name) {
 			continue
 		}
 		pkg := resolveStorePackage(entry, projectDir)
@@ -318,7 +318,7 @@ func pickPackageVersion(projectDir string, entry StorePackageEntry) string {
 	if len(entry.Versions) == 0 {
 		return ""
 	}
-	detected, err := strconv.Atoi(detectVersionFromComposer(projectDir, []FrameworkRule{{Composer: entry.Name}}))
+	detected, err := strconv.Atoi(installedMajor(projectDir, entry.Name))
 	if err != nil {
 		return entry.Latest
 	}
@@ -418,7 +418,7 @@ func ListStorePackages(projectDir string) []StorePackageInfo {
 	for _, entry := range entries {
 		info := StorePackageInfo{Name: entry.Name}
 		if projectDir != "" {
-			info.Required = ComposerHasPackage(projectDir, entry.Name)
+			info.Required = ComposerHasInstalled(projectDir, entry.Name)
 		}
 		info.Version = pickPackageVersion(projectDir, entry)
 		if pkg := loadPackageYAML(StorePackageFile(entry.Name, info.Version)); pkg != nil {

--- a/internal/config/framework_package_test.go
+++ b/internal/config/framework_package_test.go
@@ -391,3 +391,37 @@ func TestPackageAppliesTo_scopes(t *testing.T) {
 		})
 	}
 }
+
+// The package layer asks whether the project has the package, and a project can
+// have one it never named: a framework that replaces its own split packages is
+// the only entry composer writes, so the manifest alone shows nothing.
+func TestGetFrameworkForDir_packageMergedFromTheLock(t *testing.T) {
+	_, project := packageSandbox(t, []string{`{"name":"acme/electron"}`})
+	writePackage(t, "acme-electron", electronPackage)
+	writeLock(t, project, `{"packages": [{"name": "acme/framework", "version": "v11.2.0",
+	  "replace": {"acme/electron": "self.version"}}]}`)
+
+	fw, _ := GetFrameworkForDir("acme", project)
+	if _, has := fw.Workers["native"]; !has {
+		t.Error("a package the lock installed must contribute its worker")
+	}
+}
+
+// Which file serves the project follows the version composer resolved, not the
+// constraint, which a project tracking a branch does not have one of.
+func TestGetFrameworkForDir_packageVersionPrefersTheLock(t *testing.T) {
+	_, project := packageSandbox(t, []string{`{"name":"acme/electron","versions":["5","6"],"latest":"6"}`})
+	if err := os.WriteFile(filepath.Join(project, "composer.json"),
+		[]byte(`{"require": {"acme/framework": "^11.0", "acme/electron": "*"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeLock(t, project, `{"packages": [{"name": "acme/electron", "version": "5.4.0"}]}`)
+	writePackage(t, "acme-electron", packageAtVersion("", "php acme base"))
+	writePackage(t, "acme-electron@5", packageAtVersion("5", "php acme five"))
+	writePackage(t, "acme-electron@6", packageAtVersion("6", "php acme six"))
+
+	fw, _ := GetFrameworkForDir("acme", project)
+	if got := fw.Workers["native"].Command; got != "php acme five" {
+		t.Errorf("worker command = %q, want the file for the locked major", got)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -267,7 +267,7 @@ func (c *Client) DetectFromStore(dir string) (*IndexEntry, string, bool) {
 
 	for i, entry := range idx.Frameworks {
 		for _, rule := range entry.Detect {
-			if config.MatchesRule(dir, rule) {
+			if config.MatchesDetectRule(dir, rule) {
 				version := c.resolveVersion(dir, &entry)
 				return &idx.Frameworks[i], version, true
 			}


### PR DESCRIPTION
A check: composer: gate, and the package layer that grew out of those gates, went through a lookup reading the require and require-dev maps of composer.json and nothing else. A package the project never named itself read as absent while its code sat in vendor, and a package another one stands in for read as absent everywhere, since composer writes one entry for the package doing the replacing. tempest/framework replaces tempest/database and tempest/command-bus, so a stock Tempest project was offered neither the migration setup step nor the command monitor worker, and the same shape covers a distribution that ships drush or a skeleton that pulls messenger in underneath.

The lookup reads composer.lock as well now, cached by modification time and size the way the manifest already is, counting every name in packages and packages-dev together with the keys of each replace and provide map. A project with no lock answers from the manifest exactly as before, so a scaffold that has not been installed yet behaves as it did.

Detection keeps the manifest to itself, because it asks what the project is rather than what is installed under it. A library repo testing against Laravel carries laravel/framework in its lock without being a Laravel site, so matchesFramework and the store's own detection go through MatchesDetectRule while every check goes through MatchesRule.

Which file serves a project for a package publishing one per major follows the version composer resolved rather than the constraint the manifest declares, since a project tracking a branch has no constraint to read a major out of.

Driving the new binary against real sites, the Tempest one gains the command monitor worker and the migration step, the Symfony one gains the Messenger worker it has had installed all along, and the Drupal, Laravel and WordPress sites are unchanged.

Closes #1663