### PR TITLE
Resolve a framework major from what composer installed

### DIFF
--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -99,9 +99,13 @@ Only the packages listed under `packages` in the store index are ever looked up,
 
 When loading a framework definition for a project, the version is resolved in order:
 
-1. `composer.lock`: the actual installed version (source of truth)
-2. `.lerd.yaml` `framework_version`: pinned version (fallback when no `composer.lock`)
-3. Latest available in store
+1. `composer.lock`: the version composer resolved for the framework's own package (source of truth)
+2. `composer.json`: the major read out of the declared constraint, for a project with no lock
+3. A `version_file` regex, for a framework that ships no composer package
+4. `.lerd.yaml` `framework_version`: the pinned version
+5. Latest available in store
+
+The lock leads because a constraint only says what would be installed: `"^11.0 || ^12.0"` carries two majors and is read as the older one, and `dev-main` carries none at all.
 
 When `composer.lock` shows a different version than `.lerd.yaml`, the pinned version is auto-updated.
 

--- a/internal/cli/framework.go
+++ b/internal/cli/framework.go
@@ -49,8 +49,8 @@ Use --check to compare local definitions against the store and show update statu
 func runFrameworkList(check bool) error {
 	frameworks := config.ListFrameworksDetailed()
 
-	// Try to resolve versions from composer.lock in cwd for frameworks
-	// that don't have a static version (e.g. built-in laravel).
+	// Try to resolve versions from the project in cwd for frameworks that don't
+	// have a static version (e.g. built-in laravel).
 	cwd, _ := os.Getwd()
 
 	// Fetch store index if --check is requested.

--- a/internal/config/composer_lock.go
+++ b/internal/config/composer_lock.go
@@ -98,14 +98,37 @@ func ComposerHasInstalled(dir, pkg string, extraSections ...string) bool {
 	return ok
 }
 
-// installedMajor is the major of pkg this project has, taken from the lock
-// composer resolved and falling back to the constraint the manifest declares,
-// which is all a project that has never been installed can offer.
-func installedMajor(dir, pkg string) string {
-	if v := lockPackages(dir)[pkg]; v != "" {
-		if major := extractMajorFromConstraint(v); major != "" {
-			return major
-		}
+// DetectPackageMajor is the major of a composer package a project has: the
+// version composer resolved for it, and failing that the constraint the manifest
+// declares, which is all a project that has never been installed can offer. A
+// constraint is a claim about what would be installed, and a poor one where it
+// spans two majors, so the lock answers first wherever there is one.
+//
+// versionKey and extraSections belong to the manifest fallback: a dot-path to
+// read when the constraint carries no digits, and the sections to look in beyond
+// require and require-dev.
+func DetectPackageMajor(dir, pkg, versionKey string, extraSections ...string) string {
+	if major := lockedMajor(dir, pkg); major != "" {
+		return major
 	}
-	return detectVersionFromComposer(dir, []FrameworkRule{{Composer: pkg}})
+	return detectVersionFromComposer(dir, []FrameworkRule{{
+		Composer:         pkg,
+		VersionKey:       versionKey,
+		ComposerSections: extraSections,
+	}})
+}
+
+// lockedMajor is the major composer resolved for pkg, empty when the project has
+// no lock or the lock does not carry the package.
+func lockedMajor(dir, pkg string) string {
+	if v := lockPackages(dir)[pkg]; v != "" {
+		return extractMajorFromConstraint(v)
+	}
+	return ""
+}
+
+// installedMajor is DetectPackageMajor for a package named plainly, which is how
+// the package layer's own files are named.
+func installedMajor(dir, pkg string) string {
+	return DetectPackageMajor(dir, pkg, "")
 }

--- a/internal/config/composer_lock_test.go
+++ b/internal/config/composer_lock_test.go
@@ -89,3 +89,27 @@ func TestMatchesDetectRule_readsTheManifestAlone(t *testing.T) {
 		t.Error("a check asks what is installed, and it is")
 	}
 }
+
+// A constraint spanning two majors reads as the older one, so the version the
+// project actually runs has to come from the lock.
+func TestDetectMajorVersion_prefersWhatComposerResolved(t *testing.T) {
+	setConfigDir(t)
+	dir := composerProject(t,
+		`{"require": {"laravel/framework": "^11.0 || ^12.0"}}`,
+		`{"packages": [{"name": "laravel/framework", "version": "v12.4.1"}]}`)
+
+	if v := DetectMajorVersion(dir, "laravel"); v != "12" {
+		t.Errorf("major = %q, want the 12 composer installed", v)
+	}
+}
+
+// A project that has never been installed has only its constraint, and that is
+// what it was served before.
+func TestDetectMajorVersion_withoutALockReadsTheConstraint(t *testing.T) {
+	setConfigDir(t)
+	dir := composerProject(t, `{"require": {"laravel/framework": "^11.0"}}`, "")
+
+	if v := DetectMajorVersion(dir, "laravel"); v != "11" {
+		t.Errorf("major = %q, want 11 from the constraint", v)
+	}
+}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -1279,7 +1279,7 @@ func mergeUserOverlay(base *Framework) *Framework {
 }
 
 // GetFrameworkForDir is like GetFramework but auto-detects the framework version
-// from composer.lock in projectDir. If a version-specific store definition exists
+// from projectDir, preferring what composer.lock resolved. If a version-specific store definition exists
 // it is preferred over an unversioned one. User overlay workers are always merged.
 // When a version is detected but no local definition exists, it attempts to fetch
 // the definition from the store automatically.
@@ -2476,7 +2476,19 @@ func DetectMajorVersion(projectDir, frameworkName string) string {
 		return ""
 	}
 
-	// Try composer.json-based detection first.
+	// What composer resolved comes first: a constraint is only a claim about
+	// what would be installed, and one spanning two majors ("^11.0 || ^12.0")
+	// reads as the older of them however new the project actually is.
+	for _, rule := range rules {
+		if rule.Composer == "" {
+			continue
+		}
+		if v := lockedMajor(projectDir, rule.Composer); v != "" {
+			return v
+		}
+	}
+
+	// Then the manifest, which is all a project with no lock has.
 	if v := detectVersionFromComposer(projectDir, rules); v != "" {
 		return v
 	}

--- a/internal/store/version.go
+++ b/internal/store/version.go
@@ -1,11 +1,12 @@
 package store
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/geodro/lerd/internal/config"
 )
 
 // DetectFrameworkVersion reads composer.json in dir and returns the major version
@@ -18,66 +19,11 @@ func DetectFrameworkVersion(dir string, composerPackageName string, extraSection
 
 // DetectFrameworkVersionWithKey is like DetectFrameworkVersion but also accepts a
 // versionKey (dot-path into composer.json) as a fallback when the constraint is "*".
+// The answer comes from config, which reads what composer resolved before what
+// the manifest asked for, so the store resolves a version the same way the rest
+// of lerd does rather than from a second copy of the manifest walk.
 func DetectFrameworkVersionWithKey(dir string, composerPackageName string, versionKey string, extraSections ...string) string {
-	data, err := os.ReadFile(filepath.Join(dir, "composer.json"))
-	if err != nil {
-		return ""
-	}
-
-	var raw map[string]json.RawMessage
-	if json.Unmarshal(data, &raw) != nil {
-		return ""
-	}
-
-	sections := append([]string{"require", "require-dev"}, extraSections...)
-	for _, section := range sections {
-		chunk, ok := raw[section]
-		if !ok {
-			continue
-		}
-		var m map[string]string
-		if json.Unmarshal(chunk, &m) != nil {
-			continue
-		}
-		constraint, found := m[composerPackageName]
-		if !found {
-			continue
-		}
-		if v := extractMajorFromConstraint(constraint); v != "" {
-			return v
-		}
-		if versionKey != "" {
-			if v := resolveJSONPath(raw, versionKey); v != "" {
-				return extractMajorFromConstraint(v)
-			}
-		}
-	}
-	return ""
-}
-
-// resolveJSONPath walks a dot-separated path through nested JSON objects.
-func resolveJSONPath(raw map[string]json.RawMessage, path string) string {
-	parts := strings.Split(path, ".")
-	current := raw
-	for i, part := range parts {
-		chunk, ok := current[part]
-		if !ok {
-			return ""
-		}
-		if i == len(parts)-1 {
-			var s string
-			if json.Unmarshal(chunk, &s) == nil {
-				return s
-			}
-			return ""
-		}
-		var next map[string]json.RawMessage
-		if json.Unmarshal(chunk, &next) != nil {
-			return ""
-		}
-		current = next
-	}
-	return ""
+	return config.DetectPackageMajor(dir, composerPackageName, versionKey, extraSections...)
 }
 
 // extractMajorFromConstraint extracts the major version from a composer constraint.

--- a/internal/store/version_test.go
+++ b/internal/store/version_test.go
@@ -123,3 +123,20 @@ func TestDetectFrameworkVersion_FlexRequire(t *testing.T) {
 		t.Errorf("DetectFrameworkVersionWithKey() = %q, want %q", got, "7")
 	}
 }
+
+// The store resolves a version the way the rest of lerd does, so a project whose
+// constraint spans two majors is placed on the one composer installed.
+func TestDetectFrameworkVersion_prefersTheLock(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "composer.json"),
+		[]byte(`{"require":{"laravel/framework":"^11.0 || ^12.0"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "composer.lock"),
+		[]byte(`{"packages":[{"name":"laravel/framework","version":"v12.4.1"}]}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectFrameworkVersion(dir, "laravel/framework"); got != "12" {
+		t.Errorf("DetectFrameworkVersion() = %q, want 12", got)
+	}
+}


### PR DESCRIPTION
Three places said the version came from composer.lock as the source of truth, and none of them opened it: the comment on GetFrameworkForDir, the ordered list under Version resolution in the docs, and the line above the resolver in lerd framework list. What ran was a walk of composer.json that read the major out of the declared constraint, and the store carried a second copy of the same walk.

A constraint says what would be installed rather than what is, and the major comes off the first run of digits in it, so a project written as ^11.0 || ^12.0 was served the Laravel 11 definition however new the release it runs, along with that definition's PHP range, workers and commands. A constraint of dev-main or * offered no digits at all and fell through to the version file and the pin.

The lock now answers first for the framework's own composer package, with the manifest as the fallback for a project that has never been installed, which behaves exactly as it did. store/version.go becomes a delegation to the config lookup rather than a second implementation, so lerd link, the framework list and the MCP paths all place a project on the same major. The docs list is rewritten to what the code does, and the two stale comments go with it.

On a linked throwaway site with ^11.0 || ^12.0 in composer.json and v12.4.1 in the lock, the binary from main lists it as Laravel 11 and this one as Laravel 12. Across the sites on this machine nothing moves, since each is on a single-major constraint that already agrees with its lock, and the site list is identical before and after.

Closes #1665