### PR TITLE
fix: run assistant commands in the site's own container

### DIFF
--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -470,7 +470,7 @@ container:
   containerfile: Containerfile.lerd
 ```
 
-Then `lerd link`. lerd builds `lerd-custom-myapp:local`, runs a dedicated FPM container `lerd-cfpm-myapp`, and points nginx fastcgi at it. The per-site container reuses every lerd mount, so xdebug, dumps, the debug bridge, the profiler, and `lerd shell` all work exactly as on a normal PHP site, and `lerd php`, `artisan`, `composer`, `tinker`, and queue/horizon workers all run inside it. Toggling xdebug for that PHP version restarts the per-site container too.
+Then `lerd link`. lerd builds `lerd-custom-myapp:local`, runs a dedicated FPM container `lerd-cfpm-myapp`, and points nginx fastcgi at it. The per-site container reuses every lerd mount, so xdebug, dumps, the debug bridge, the profiler, and `lerd shell` all work exactly as on a normal PHP site, and `lerd php`, `artisan`, `composer`, `tinker`, queue/horizon workers, and the commands an AI assistant runs through the MCP server all run inside it. Toggling xdebug for that PHP version restarts the per-site container too.
 
 The PHP version is fixed by the `FROM` line, not by `.php-version` or the dashboard, so the version selector is shown read-only for these sites. To change the version, edit the `FROM` and relink.
 

--- a/internal/cli/php_exec.go
+++ b/internal/cli/php_exec.go
@@ -68,19 +68,10 @@ func phpVersionForDir(dir string) (string, error) {
 	return phpDet.VersionForDir(dir)
 }
 
-// fpmContainerForDir resolves the FPM container an exec in dir should target:
-// the per-site container for custom-FPM sites, otherwise the shared
-// lerd-php<version>-fpm container. It resolves the site the same way version
-// detection does, so a worktree beside its project reaches the parent's custom
-// image rather than falling through to the shared container its vhost never uses.
+// fpmContainerForDir resolves the FPM container an exec in dir should target.
+// The rules live in internal/php so the CLI and the MCP server cannot drift.
 func fpmContainerForDir(dir, version string) string {
-	if _, parent, ok := phpDet.WorktreeRootFor(dir); ok {
-		return podman.FPMContainerName(*parent, version)
-	}
-	if site, _ := config.FindSiteByPath(phpDet.SiteRootFor(dir)); site != nil {
-		return podman.FPMContainerName(*site, version)
-	}
-	return "lerd-php" + strings.ReplaceAll(version, ".", "") + "-fpm"
+	return phpDet.FPMContainerForDir(dir, version)
 }
 
 // debugSiteEnvArgs returns the LERD_SITE exec flag for a CLI run in dir, so the

--- a/internal/mcp/profiler.go
+++ b/internal/mcp/profiler.go
@@ -76,16 +76,12 @@ func execProfilerReport(args map[string]any) (any, *rpcError) {
 		return toolErr(`args is required: the argv to run under php and profile, e.g. ["artisan","app:import"] or ["repro.php"]`), nil
 	}
 
-	phpVersion, err := phpDet.DetectVersion(projectPath)
+	phpVersion, err := phpDet.VersionForDir(projectPath)
 	if err != nil {
-		cfg, cfgErr := config.LoadGlobal()
-		if cfgErr != nil {
-			return toolErr("failed to detect PHP version: " + err.Error()), nil
-		}
-		phpVersion = cfg.PHP.DefaultVersion
+		return toolErr(err.Error()), nil
 	}
 	short := strings.ReplaceAll(phpVersion, ".", "")
-	container := "lerd-php" + short + "-fpm"
+	container := phpDet.FPMContainerForDir(projectPath, phpVersion)
 	if errBody := ensureFPMStartedMCP(phpVersion, short, container); errBody != nil {
 		return errBody, nil
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -327,17 +327,13 @@ func execArtisan(args map[string]any) (any, *rpcError) {
 		return toolErr("args is required and must be a non-empty array"), nil
 	}
 
-	phpVersion, err := phpDet.DetectVersion(projectPath)
+	phpVersion, err := phpDet.VersionForDir(projectPath)
 	if err != nil {
-		cfg, cfgErr := config.LoadGlobal()
-		if cfgErr != nil {
-			return toolErr("failed to detect PHP version: " + err.Error()), nil
-		}
-		phpVersion = cfg.PHP.DefaultVersion
+		return toolErr(err.Error()), nil
 	}
 
 	short := strings.ReplaceAll(phpVersion, ".", "")
-	container := "lerd-php" + short + "-fpm"
+	container := phpDet.FPMContainerForDir(projectPath, phpVersion)
 	if errBody := ensureFPMStartedMCP(phpVersion, short, container); errBody != nil {
 		return errBody, nil
 	}
@@ -575,9 +571,10 @@ func execReverbStart(args map[string]any) (any, *rpcError) {
 	if detected, err := phpDet.DetectVersion(site.Path); err == nil && detected != "" {
 		phpVersion = detected
 	}
-	versionShort := strings.ReplaceAll(phpVersion, ".", "")
-	fpmUnit := "lerd-php" + versionShort + "-fpm"
-	container := "lerd-php" + versionShort + "-fpm"
+	// A custom-FPM site runs its own image, so the unit binds to and execs into
+	// the per-site container rather than the shared one it is never served by.
+	fpmUnit := podman.FPMContainerName(*site, phpVersion)
+	container := fpmUnit
 	unitName := "lerd-reverb-" + siteName
 
 	unit := fmt.Sprintf(`[Unit]
@@ -642,9 +639,10 @@ func execHorizonStart(args map[string]any) (any, *rpcError) {
 	if detected, err := phpDet.DetectVersion(site.Path); err == nil && detected != "" {
 		phpVersion = detected
 	}
-	versionShort := strings.ReplaceAll(phpVersion, ".", "")
-	fpmUnit := "lerd-php" + versionShort + "-fpm"
-	container := "lerd-php" + versionShort + "-fpm"
+	// A custom-FPM site runs its own image, so the unit binds to and execs into
+	// the per-site container rather than the shared one it is never served by.
+	fpmUnit := podman.FPMContainerName(*site, phpVersion)
+	container := fpmUnit
 	unitName := "lerd-horizon-" + siteName
 
 	unit := fmt.Sprintf(`[Unit]
@@ -704,9 +702,10 @@ func execScheduleStart(args map[string]any) (any, *rpcError) {
 	if detected, err := phpDet.DetectVersion(site.Path); err == nil && detected != "" {
 		phpVersion = detected
 	}
-	versionShort := strings.ReplaceAll(phpVersion, ".", "")
-	fpmUnit := "lerd-php" + versionShort + "-fpm"
-	container := "lerd-php" + versionShort + "-fpm"
+	// A custom-FPM site runs its own image, so the unit binds to and execs into
+	// the per-site container rather than the shared one it is never served by.
+	fpmUnit := podman.FPMContainerName(*site, phpVersion)
+	container := fpmUnit
 	unitName := "lerd-schedule-" + siteName
 
 	unit := fmt.Sprintf(`[Unit]
@@ -884,17 +883,13 @@ func execComposer(args map[string]any) (any, *rpcError) {
 		return toolErr("args is required and must be a non-empty array"), nil
 	}
 
-	phpVersion, err := phpDet.DetectVersion(projectPath)
+	phpVersion, err := phpDet.VersionForDir(projectPath)
 	if err != nil {
-		cfg, cfgErr := config.LoadGlobal()
-		if cfgErr != nil {
-			return toolErr("failed to detect PHP version: " + err.Error()), nil
-		}
-		phpVersion = cfg.PHP.DefaultVersion
+		return toolErr(err.Error()), nil
 	}
 
 	short := strings.ReplaceAll(phpVersion, ".", "")
-	container := "lerd-php" + short + "-fpm"
+	container := phpDet.FPMContainerForDir(projectPath, phpVersion)
 	if errBody := ensureFPMStartedMCP(phpVersion, short, container); errBody != nil {
 		return errBody, nil
 	}
@@ -963,17 +958,13 @@ func execVendorRun(args map[string]any) (any, *rpcError) {
 	}
 	binArgs := strSliceArg(args, "args")
 
-	phpVersion, err := phpDet.DetectVersion(projectPath)
+	phpVersion, err := phpDet.VersionForDir(projectPath)
 	if err != nil {
-		cfg, cfgErr := config.LoadGlobal()
-		if cfgErr != nil {
-			return toolErr("failed to detect PHP version: " + err.Error()), nil
-		}
-		phpVersion = cfg.PHP.DefaultVersion
+		return toolErr(err.Error()), nil
 	}
 
 	short := strings.ReplaceAll(phpVersion, ".", "")
-	container := "lerd-php" + short + "-fpm"
+	container := phpDet.FPMContainerForDir(projectPath, phpVersion)
 	if errBody := ensureFPMStartedMCP(phpVersion, short, container); errBody != nil {
 		return errBody, nil
 	}
@@ -3793,15 +3784,11 @@ func runComposerInstallIfNeeded(projectPath string, out *bytes.Buffer) error {
 		return nil
 	}
 
-	phpVersion, err := phpDet.DetectVersion(projectPath)
+	phpVersion, err := phpDet.VersionForDir(projectPath)
 	if err != nil || phpVersion == "" {
-		cfg, cfgErr := config.LoadGlobal()
-		if cfgErr != nil || cfg == nil {
-			return fmt.Errorf("could not determine PHP version: %w", err)
-		}
-		phpVersion = cfg.PHP.DefaultVersion
+		return fmt.Errorf("could not determine PHP version: %w", err)
 	}
-	container := "lerd-php" + strings.ReplaceAll(phpVersion, ".", "") + "-fpm"
+	container := phpDet.FPMContainerForDir(projectPath, phpVersion)
 
 	out.WriteString("\n\n--- composer install ---\n")
 	cmd := podman.Cmd("exec", "-w", projectPath, "--env", composer.ProcessTimeoutEnv(), container, "composer", "install", "--no-interaction")
@@ -3836,15 +3823,11 @@ func execSetup(args map[string]any) (any, *rpcError) {
 		return toolErr(fmt.Sprintf("framework %q is not defined", fwName)), nil
 	}
 
-	phpVersion, phpErr := phpDet.DetectVersion(projectPath)
+	phpVersion, phpErr := phpDet.VersionForDir(projectPath)
 	if phpErr != nil || phpVersion == "" {
-		cfg, cfgErr := config.LoadGlobal()
-		if cfgErr != nil || cfg == nil {
-			return toolErr("could not determine PHP version"), nil
-		}
-		phpVersion = cfg.PHP.DefaultVersion
+		return toolErr("could not determine PHP version"), nil
 	}
-	container := "lerd-php" + strings.ReplaceAll(phpVersion, ".", "") + "-fpm"
+	container := phpDet.FPMContainerForDir(projectPath, phpVersion)
 	if errBody := ensureFPMStartedMCP(phpVersion, strings.ReplaceAll(phpVersion, ".", ""), container); errBody != nil {
 		return errBody, nil
 	}

--- a/internal/php/resolve.go
+++ b/internal/php/resolve.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
 )
 
 // VersionForDir resolves the PHP version a directory's commands must run on.
@@ -84,4 +85,21 @@ func SiteRootFor(dir string) string {
 		return best
 	}
 	return dir
+}
+
+// FPMContainerForDir resolves the FPM container an exec in dir must target: the
+// per-site container for custom-FPM sites, otherwise the shared
+// lerd-php<version>-fpm container. Like VersionForDir this is the single answer
+// the CLI and the MCP server share, so a command can never exec into a
+// different container than the one serving the same directory. A worktree
+// resolves through its parent site, so a checkout beside its project still
+// reaches the parent's custom image.
+func FPMContainerForDir(dir, version string) string {
+	if _, parent, ok := WorktreeRootFor(dir); ok {
+		return podman.FPMContainerName(*parent, version)
+	}
+	if site, _ := config.FindSiteByPath(SiteRootFor(dir)); site != nil {
+		return podman.FPMContainerName(*site, version)
+	}
+	return podman.SharedFPMContainerName(version)
 }

--- a/internal/php/resolve_test.go
+++ b/internal/php/resolve_test.go
@@ -1,0 +1,69 @@
+package php
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// tempRoot is t.TempDir() with symlinks resolved, so a path spelled the way the
+// registry stores it also matches by prefix. macOS hands out /var/folders
+// tempdirs, and /var is a symlink to /private/var there.
+func tempRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// A site served from its own image must be reached by every exec path, not just
+// nginx: resolving from the version alone lands in the shared container, which
+// has none of the site's custom layers (#1660).
+func TestFPMContainerForDir_CustomFPMSite(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	site := filepath.Join(tempRoot(t), "app")
+	sub := filepath.Join(site, "app", "Console")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.AddSite(config.Site{Name: "app", Path: site, PHPVersion: "8.4", Runtime: "fpm-custom"}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, dir := range []string{site, sub} {
+		if got, want := FPMContainerForDir(dir, "8.4"), "lerd-cfpm-app"; got != want {
+			t.Errorf("FPMContainerForDir(%q) = %q, want %q", dir, got, want)
+		}
+	}
+}
+
+// An ordinary site stays on the shared per-version container.
+func TestFPMContainerForDir_SharedFPMSite(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	site := filepath.Join(tempRoot(t), "app")
+	if err := os.MkdirAll(site, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.AddSite(config.Site{Name: "app", Path: site, PHPVersion: "8.4"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := FPMContainerForDir(site, "8.4"), "lerd-php84-fpm"; got != want {
+		t.Errorf("FPMContainerForDir = %q, want %q", got, want)
+	}
+}
+
+// A directory that belongs to no site has only the shared container to run in.
+func TestFPMContainerForDir_UnregisteredDir(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	if got, want := FPMContainerForDir(tempRoot(t), "8.3"), "lerd-php83-fpm"; got != want {
+		t.Errorf("FPMContainerForDir = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
A site with a Containerfile is served from an image built for it alone, and the CLI resolves that container before every exec. The MCP server built the container name from the PHP version, so artisan, console, composer, vendor/bin and the framework setup steps an assistant ran went to the shared per-version container instead, which has none of the layers the project added. A site whose image registers an ODBC driver or installs a binary the code shells out to fails on the first command that touches it, while the identical command from the shell works.

The container rule now lives next to the version rule in internal/php and both the CLI and the MCP server call it, so the two cannot drift apart again. The MCP paths pick up the CLI's version rule with it, preferring the version the site was registered with over a detection the framework clamp already overruled. The reverb, horizon and scheduler units an assistant writes bind to and exec into the per-site container too.

Refs #1660