### PR TITLE
fix: stop an install from reapplying itself through its own child

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -139,6 +139,7 @@ func ensurePortsAvailable() {
 }
 
 func runInstall(cmd *cobra.Command, _ []string) error {
+	markInstallInProgress()
 	feedback.Header("Installing Lerd")
 
 	noIPv6, _ := cmd.Flags().GetBool("no-ipv6")

--- a/internal/cli/post_upgrade.go
+++ b/internal/cli/post_upgrade.go
@@ -29,6 +29,17 @@ var upgradeSkipCommands = map[string]bool{
 	"dns-forwarder": true,
 }
 
+// installInProgressEnv marks the process tree of a running `lerd install`.
+// The version stamp is only written when the install finishes, so a helper the
+// install shells out to would otherwise read the install it belongs to as a
+// pending upgrade and reapply the whole environment from inside it.
+const installInProgressEnv = "LERD_INSTALL_IN_PROGRESS"
+
+// markInstallInProgress makes every process the install spawns skip the reapply.
+func markInstallInProgress() {
+	_ = os.Setenv(installInProgressEnv, "1")
+}
+
 // devVersion matches the `git describe` versions a build from a checkout
 // carries, which change with every commit.
 var devVersion = regexp.MustCompile(`-\d+-g[0-9a-f]+`)
@@ -60,6 +71,9 @@ func ApplyPendingUpgrade(cmd *cobra.Command) {
 // command at a terminal that can afford the wait.
 func shouldApplyUpgrade(command, running, installed string, setUp, interactive bool) bool {
 	if !isReleaseVersion(running) || !setUp || !interactive {
+		return false
+	}
+	if os.Getenv(installInProgressEnv) != "" {
 		return false
 	}
 	if upgradeSkipCommands[command] {

--- a/internal/cli/post_upgrade_test.go
+++ b/internal/cli/post_upgrade_test.go
@@ -135,3 +135,22 @@ func TestIsSetUpFollowsTheGlobalConfig(t *testing.T) {
 		t.Error("isSetUp() = false with a global config on disk")
 	}
 }
+
+// `lerd install` shells out to itself for php:rebuild, and the version stamp is
+// only written once the install finishes, so without this guard the child reads
+// the install it is part of as a pending upgrade and reapplies the whole
+// environment from inside it, rebuilding every PHP image twice over.
+func TestShouldApplyUpgradeSkipsAChildOfARunningInstall(t *testing.T) {
+	t.Setenv(installInProgressEnv, "1")
+	if shouldApplyUpgrade("php:rebuild", "1.32.0", "1.31.0", true, true) {
+		t.Error("a process spawned by a running install should not reapply the environment")
+	}
+}
+
+func TestMarkInstallInProgressIsInheritedByChildren(t *testing.T) {
+	t.Setenv(installInProgressEnv, "")
+	markInstallInProgress()
+	if os.Getenv(installInProgressEnv) == "" {
+		t.Error("the install should mark its process tree so children skip the reapply")
+	}
+}


### PR DESCRIPTION
`lerd install` spawns `lerd php:rebuild` when the FPM images need rebuilding, and the child took its own install for a pending upgrade. The version stamp that tells a binary whether its environment has been applied is written at the end of the install, so mid-install there is nothing to read, and on a first install or a reinstall the child concluded a package manager had swapped the binary underneath it. It then re-execed a complete `lerd install --from-update` before running the rebuild it was actually called for, which cost a second full install pass and two extra rounds of PHP image builds.

The install now marks its process tree with an environment variable, and the upgrade reapply bails when it sees it. That keeps the decision on the install itself rather than on the timing of the stamp file, and it holds for every helper the install shells out to, not just this one. Both upgrade paths are unchanged: `update` re-execs `install`, which was already exempt, and the package-manager path stamps the version before it re-execs. The daemons the install starts are exempt too, so nothing inherits a flag that would suppress a genuine upgrade later.

Refs #1668
