### PR TITLE
fix: keep autostart from re-arming a tray that was turned off

### DIFF
--- a/docs/features/system-tray.md
+++ b/docs/features/system-tray.md
@@ -108,6 +108,8 @@ The tray follows the global `lerd autostart` toggle: when autostart is on (the d
 
 The tray is also started automatically by `lerd start` if it isn't already running.
 
+The tray preference wins over the autostart one: with the tray off, `lerd autostart enable` arms everything else at login and leaves `lerd-tray.service` disabled, so turning autostart back on never brings back a tray you removed.
+
 The unit is wired to `graphical-session.target`, which is reached automatically by GNOME, KDE Plasma, and any Wayland compositor launched through `uwsm` (including Omarchy's Hyprland setup). On bare Hyprland / Sway / i3 launched without `uwsm`, `graphical-session.target` is never started, so the tray will not autostart. Either run the compositor under `uwsm` or replace `WantedBy=graphical-session.target` with `WantedBy=default.target` in `~/.config/systemd/user/lerd-tray.service`.
 
 ---

--- a/internal/cli/autostart.go
+++ b/internal/cli/autostart.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
@@ -118,6 +119,9 @@ func ApplyAutostart(disabled bool) error {
 	_ = exec.Command("systemctl", "--user", "daemon-reload").Run()
 
 	units := lerdSystemd.AutostartUserUnits()
+	if !disabled {
+		units = unitsToArm(units)
+	}
 	for _, u := range units {
 		name := strings.TrimSuffix(u, ".service")
 		if disabled {
@@ -127,6 +131,17 @@ func ApplyAutostart(disabled bool) error {
 		}
 	}
 	return nil
+}
+
+// unitsToArm drops the tray from the login set while the tray preference is
+// off. Autostart arms every lerd unit it finds on disk, and the tray is the one
+// the user can switch off on its own, so without this an autostart enable puts
+// back at the next boot a surface they removed.
+func unitsToArm(units []string) []string {
+	if trayEnabled() {
+		return units
+	}
+	return slices.DeleteFunc(slices.Clone(units), func(u string) bool { return u == "lerd-tray.service" })
 }
 
 // rewriteQuadletsForAutostart walks every lerd-*.container in the user's

--- a/internal/cli/autostart_tray_test.go
+++ b/internal/cli/autostart_tray_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestUnitsToArm_KeepsTrayWhenItIsOn(t *testing.T) {
+	withTempXDG(t)
+
+	got := unitsToArm([]string{"lerd-tray.service", "lerd-ui.service"})
+	if !slices.Contains(got, "lerd-tray.service") {
+		t.Error("enabling autostart with the tray on must arm lerd-tray at login")
+	}
+}
+
+func TestUnitsToArm_DropsTrayWhenItIsOff(t *testing.T) {
+	withTempXDG(t)
+
+	if _, err := setTrayPreference(false); err != nil {
+		t.Fatal(err)
+	}
+	got := unitsToArm([]string{"lerd-tray.service", "lerd-ui.service", "lerd-watcher.service"})
+	if slices.Contains(got, "lerd-tray.service") {
+		t.Error("enabling autostart must not bring back a tray the user turned off")
+	}
+	for _, want := range []string{"lerd-ui.service", "lerd-watcher.service"} {
+		if !slices.Contains(got, want) {
+			t.Errorf("%s must still be armed at login", want)
+		}
+	}
+}


### PR DESCRIPTION
Turning the system tray off disables lerd-tray.service so the applet stays gone at the next graphical login. Enabling autostart afterwards, from the CLI or from the dashboard toggle, armed every lerd unit found on disk and the tray unit was in that set regardless of the tray preference, so the wants symlink came back and the tray returned at the following login with nothing in the session having asked for it.

The login set now passes through a filter that drops the tray unit while the preference is off, so the tray switch wins over the autostart one. Disabling autostart still covers every unit, the tray included, and turning the tray back on re-enables it the way it always did.

Closes #1672
