### PR TITLE
fix: keep the node detection tests off the developer's own machine

### DIFF
--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/freeport"
+	"github.com/geodro/lerd/internal/hostbin"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/services"
 )
@@ -643,10 +644,22 @@ func TestDetectSystemNode_findsNvmDirEvenWhenPathIsEmpty(t *testing.T) {
 	}
 }
 
+// detectNvm resolves the nvm dir through the global config first and, on macOS,
+// through the Homebrew prefixes, so without this the assertions read whatever
+// the developer's own machine has installed.
+func isolateNvmLookup(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	prev := hostbin.ExtraDirs
+	hostbin.ExtraDirs = func() []string { return nil }
+	t.Cleanup(func() { hostbin.ExtraDirs = prev })
+}
+
 // An nvm with no Node versions in it is invisible to detectSystemNode, so
 // detectNvm is what makes the management question reach that user at all.
 func TestDetectNvm(t *testing.T) {
 	t.Run("empty nvm dir under NVM_DIR counts", func(t *testing.T) {
+		isolateNvmLookup(t)
 		tmp := t.TempDir()
 		t.Setenv("NVM_DIR", tmp)
 		if detectNvm() {
@@ -661,6 +674,7 @@ func TestDetectNvm(t *testing.T) {
 	})
 
 	t.Run("falls back to ~/.nvm", func(t *testing.T) {
+		isolateNvmLookup(t)
 		tmp := t.TempDir()
 		t.Setenv("NVM_DIR", "")
 		t.Setenv("HOME", tmp)

--- a/internal/node/system_hostbin_test.go
+++ b/internal/node/system_hostbin_test.go
@@ -5,6 +5,14 @@ import (
 	"testing"
 )
 
+// emptyPathDir stands in for a daemon PATH that carries no Node. A literal
+// /usr/bin:/bin would pick up a distro-packaged node and make the assertions
+// depend on what the machine running the tests has installed.
+func emptyPathDir(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "sysbin")
+}
+
 // withBrewPrefix points the unit PATH list at a fixture standing in for
 // /opt/homebrew/bin, which a launchd daemon never has on PATH.
 func withBrewPrefix(t *testing.T, dir string) {
@@ -36,7 +44,7 @@ func TestSystemNodeBinDirs_findsHomebrewUnderDaemonPATH(t *testing.T) {
 	writeExec(t, stale, "node")
 	writeExec(t, stale, "npm")
 
-	t.Setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+	t.Setenv("PATH", emptyPathDir(t))
 
 	dirs := SystemNodeBinDirs()
 	if len(dirs) != 1 || dirs[0] != brew {
@@ -59,7 +67,7 @@ func TestSystemNodeBinDirs_stillFallsBackToNvm(t *testing.T) {
 	writeExec(t, nvmBin, "node")
 	writeExec(t, nvmBin, "npm")
 
-	t.Setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+	t.Setenv("PATH", emptyPathDir(t))
 
 	dirs := SystemNodeBinDirs()
 	if len(dirs) != 1 || dirs[0] != nvmBin {


### PR DESCRIPTION
TestDetectNvm points NVM_DIR at an empty temp dir and asserts detection stays false, but nvmDir consults the global config before it ever looks at NVM_DIR, so a machine with a recorded node.nvm_dir resolves the real ~/.nvm and the assertion fails. It has been green on CI and on hosts without nvm and red on the test guests, where an install put the key there. The subtests now point XDG_CONFIG_HOME at a temp dir, and stub the extra bin dirs so a Homebrew nvm cannot answer for the fixture on macOS either.

The audit the issue asks for turned up one more of the same shape, the two SystemNodeBinDirs units that spell a daemon PATH out as /usr/bin:/bin. On a machine with a distro-packaged node the lookup finds /usr/bin too and the single-entry assertion fails. An empty fixture directory expresses the same thing without asking what the host has installed.

Closes #1515