### PR TITLE
fix: include each site's .lerd.yaml in the bug report

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -39,7 +39,7 @@ If you need help on the [issue tracker](https://github.com/lerd-env/lerd/issues)
 lerd bug-report
 ```
 
-This writes a single plain-text file (default: `./lerd-bug-report-<timestamp>.txt`) containing the full `lerd doctor` output, your `config.yaml` and `sites.yaml`, the state of every `lerd-*` systemd unit, recent journal and container logs for lerd's own infra units, listening sockets on the lerd ports, and a curated set of environment variables.
+This writes a single plain-text file (default: `./lerd-bug-report-<timestamp>.txt`) containing the full `lerd doctor` output, your `config.yaml`, `sites.yaml` and every linked site's `.lerd.yaml`, the state of every `lerd-*` systemd unit, recent journal and container logs for lerd's own infra units, listening sockets on the lerd ports, and a curated set of environment variables.
 
 What gets filtered before it lands on disk:
 

--- a/internal/cli/bug_report.go
+++ b/internal/cli/bug_report.go
@@ -172,16 +172,39 @@ func section(w io.Writer, title string) {
 
 func dumpConfigFiles(w io.Writer) {
 	for _, p := range []string{config.GlobalConfigFile(), config.SitesFile()} {
-		fmt.Fprintf(w, "── %s\n", p)
-		data, err := os.ReadFile(p)
-		if err != nil {
-			fmt.Fprintf(w, "(unreadable: %v)\n\n", err)
+		dumpConfigFile(w, p, "")
+	}
+	// The registry says a site exists; only its .lerd.yaml says which
+	// workers, options and services it declares, which is what tells a lost
+	// declaration apart from a worker that failed to start.
+	reg, err := config.LoadSites()
+	if err != nil || reg == nil {
+		return
+	}
+	for _, s := range reg.Sites {
+		if s.Path == "" {
 			continue
 		}
-		fmt.Fprintln(w, string(data))
-		if !bytes.HasSuffix(data, []byte("\n")) {
-			fmt.Fprintln(w)
+		dumpConfigFile(w, filepath.Join(s.Path, ".lerd.yaml"), "(no .lerd.yaml for this site)")
+	}
+}
+
+// dumpConfigFile writes one config file verbatim under its path. missing, when
+// set, replaces the error line for a file that simply is not there.
+func dumpConfigFile(w io.Writer, path, missing string) {
+	fmt.Fprintf(w, "── %s\n", path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if missing != "" && os.IsNotExist(err) {
+			fmt.Fprintf(w, "%s\n\n", missing)
+			return
 		}
+		fmt.Fprintf(w, "(unreadable: %v)\n\n", err)
+		return
+	}
+	fmt.Fprintln(w, string(data))
+	if !bytes.HasSuffix(data, []byte("\n")) {
+		fmt.Fprintln(w)
 	}
 }
 

--- a/internal/cli/bug_report_test.go
+++ b/internal/cli/bug_report_test.go
@@ -490,3 +490,32 @@ func TestEnvAllowlist_excludesSecrets(t *testing.T) {
 		}
 	}
 }
+
+func TestDumpConfigFiles_includesPerSiteProjectConfig(t *testing.T) {
+	linked := t.TempDir()
+	bare := t.TempDir()
+	setupAnonFixtures(t, "", `sites:
+  - name: alpha
+    domains: [alpha.test]
+    path: `+linked+`
+  - name: beta
+    domains: [beta.test]
+    path: `+bare+`
+`)
+	if err := os.WriteFile(filepath.Join(linked, ".lerd.yaml"), []byte("workers:\n  - queue\n  - horizon\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	dumpConfigFiles(&buf)
+	out := buf.String()
+
+	for _, want := range []string{filepath.Join(linked, ".lerd.yaml"), "workers:", "- horizon"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, filepath.Join(bare, ".lerd.yaml")+"\n(no .lerd.yaml for this site)") {
+		t.Errorf("site without a project file should say so:\n%s", out)
+	}
+}


### PR DESCRIPTION
The bug report carried the global config and the site registry but nothing a site declares for itself. The workers list, the custom worker definitions, the worker options a project has answered and the declared services all live in the per-site .lerd.yaml, so a report showing a worker unit sitting there with nothing running gave no way to tell a lost declaration from a start that failed, which is exactly where triage on #1531 stalled.

Each linked site's file now prints under the registry, framed and anonymized the same way the global config already is. Sites that never got one say so in a single line rather than print an empty block.

Closes #1629
