### PR TITLE
fix: keep the dev server flags when a worker unit is restored

### DIFF
--- a/internal/cli/devserver.go
+++ b/internal/cli/devserver.go
@@ -395,3 +395,26 @@ func rewriteDevServerWrapper(sitePath string, tool *config.DevServerTool, addr d
 	}
 	return true
 }
+
+// devServerCommand appends the dev server flags to a host worker's command, so
+// every path that writes a worker unit points the tool at the generated config
+// and the pinned port. Anything the mechanism cannot apply cleanly leaves the
+// command as it was.
+func devServerCommand(siteName, sitePath, command string, host bool) string {
+	if !host {
+		return command
+	}
+	tool := config.DevServerToolFor(sitePath, command)
+	if tool == nil {
+		return command
+	}
+	args, err := devServerSetup(siteName, sitePath, tool)
+	if err != nil {
+		feedback.Warn("dev server stays on its own port: %v", err)
+		return command
+	}
+	if args == "" {
+		return command
+	}
+	return command + " " + args
+}

--- a/internal/cli/restore_worker_linux_test.go
+++ b/internal/cli/restore_worker_linux_test.go
@@ -3,6 +3,8 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -121,5 +123,43 @@ func TestRestoreWorker_autostartEnabled_armsBoot(t *testing.T) {
 
 	if len(mgr.enabled) != 1 || mgr.enabled[0] != "lerd-horizon-ws" {
 		t.Errorf("enabled %v, want [lerd-horizon-ws]", mgr.enabled)
+	}
+}
+
+// TestRestoreWorker_devServer_keepsTheGeneratedConfig pins issue #1685: the
+// unit `lerd start` rewrites must carry the dev server flags, or the worker
+// comes back on its own port with no generated config and the site's page is
+// refused every asset it asks for.
+func TestRestoreWorker_devServer_keepsTheGeneratedConfig(t *testing.T) {
+	site := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(site, "node_modules", "vite"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, body := range map[string]string{
+		"vite.config.js": "export default {};\n",
+		"package.json":   `{"scripts":{"dev":"vite"}}`,
+	} {
+		if err := os.WriteFile(filepath.Join(site, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	registerSite(t, "ws", site)
+	mgr := &captureWriteMgr{writeChange: true}
+	swapServiceMgr(t, mgr)
+
+	w := config.FrameworkWorker{Command: "npm run dev", Host: true, Label: "Vite"}
+	restoreWorker("ws", site, "8.4", "vite", w)
+
+	if len(mgr.writes) == 0 {
+		t.Fatal("expected at least one WriteServiceUnitIfChanged call")
+	}
+	content := mgr.writes[0].content
+	for _, want := range []string{"--config node_modules/.lerd/vite.config.mjs", "--port ", "--strictPort"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("expected %q in unit content, got %q", want, content)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(site, "node_modules", ".lerd", "vite.config.mjs")); err != nil {
+		t.Errorf("expected the generated config on disk: %v", err)
 	}
 }

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -312,16 +312,7 @@ func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w con
 
 	// A host worker that starts a known dev server is pinned to a port and
 	// pointed at a generated config, so it answers on the site's own domain.
-	// Anything the mechanism cannot apply cleanly leaves the command as it was.
-	if w.Host {
-		if tool := config.DevServerToolFor(sitePath, command); tool != nil {
-			if args, err := devServerSetup(siteName, sitePath, tool); err != nil {
-				feedback.Warn("dev server stays on its own port: %v", err)
-			} else if args != "" {
-				command += " " + args
-			}
-		}
-	}
+	command = devServerCommand(siteName, sitePath, command, w.Host)
 
 	// Workers exec into the container that hosts the site's runtime —
 	// custom container, FrankenPHP, or shared FPM. resolveWorkerFPMUnit

--- a/internal/cli/worker_darwin.go
+++ b/internal/cli/worker_darwin.go
@@ -304,6 +304,11 @@ func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.F
 			return
 		}
 	}
+	// The unit is rewritten here on every `lerd start`, so the dev server flags
+	// have to be rebuilt with it or the worker comes back on its own port and
+	// the site's page is refused the assets it asks for.
+	command = devServerCommand(siteName, sitePath, command, w.Host)
+
 	fpmUnit := resolveWorkerFPMUnit(siteName, phpVersion)
 	unitName, displaySite := workerNames(siteName, sitePath, workerName)
 	restart := w.Restart

--- a/internal/cli/worker_linux.go
+++ b/internal/cli/worker_linux.go
@@ -238,6 +238,10 @@ func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.F
 		}
 		command = command + " --port=" + port
 	}
+	// The unit is rewritten here on every `lerd start`, so the dev server flags
+	// have to be rebuilt with it or the worker comes back on its own port and
+	// the site's page is refused the assets it asks for.
+	command = devServerCommand(siteName, sitePath, command, w.Host)
 
 	fpmUnit := resolveWorkerFPMUnit(siteName, phpVersion)
 	unitName, displaySite := workerNames(siteName, sitePath, workerName)


### PR DESCRIPTION
Starting lerd rewrites the worker units listed in a site config, and that path built the command without the dev server setup the normal worker start applies. A unit that is not armed for boot gets rewritten on every start, so the tool came back listening on its own port with no generated config, and the page then asked for its assets on an address the browser refuses to load from over https. Toggling the worker afterwards went through the full path and put the flags back, which is why it looked intermittent.

The setup now lives in one helper that both the worker start and the restore call, so a restored unit points at the same generated config and pinned port as one started by hand.

Checked on Fedora 44 and Ubuntu 26.04 guests as well as locally, against a build of main and a build carrying the fix, through a full start cycle with the worker actually restarted on the rewritten unit.

Refs #1685