### PR TITLE
Keep the dev server port the site is already serving

### DIFF
--- a/internal/cli/devserver.go
+++ b/internal/cli/devserver.go
@@ -17,6 +17,7 @@ import (
 	"github.com/geodro/lerd/internal/nginx"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/services"
 )
 
 // A host dev server normally advertises its own address, so everything it
@@ -213,7 +214,7 @@ func regenSiteOrWorktreeVhost(site *config.Site, sitePath string) {
 // devServerEnsurePort pins the site's dev server to a stable host port and
 // saves it, so the vhost generated later proxies somewhere the tool will
 // actually be listening.
-func devServerEnsurePort(siteName, sitePath string, defaultPort int) (int, error) {
+func devServerEnsurePort(siteName, sitePath, workerName string, defaultPort int) (int, error) {
 	site, err := config.FindSite(siteName)
 	if err != nil {
 		return 0, err
@@ -225,8 +226,11 @@ func devServerEnsurePort(siteName, sitePath string, defaultPort int) (int, error
 		current = site.WorktreeDevPorts[key]
 	}
 	// A pinned port that something else has taken would make the tool refuse to
-	// start rather than drift, so an unusable pin is re-picked here.
-	if current != 0 && freeport.Bindable(current) {
+	// start rather than drift, so an unusable pin is re-picked here. The site's
+	// own dev server holding it is not something else: this runs on every start,
+	// and moving the vhost off the port the tool is already serving would leave
+	// the page asking for assets on one nothing answers on.
+	if current != 0 && (freeport.Bindable(current) || devServerHoldsPort(siteName, sitePath, workerName)) {
 		return current, nil
 	}
 	port := assignDevServerPort(siteName, key, defaultPort)
@@ -282,7 +286,7 @@ func assignDevServerPort(excludeSiteName, excludeWorktree string, defaultPort in
 // devServerSetup pins the port, writes the generated config and regenerates the
 // site's vhost so nginx proxies the prefix. It returns the arguments to append
 // to the worker command, empty when the project is not shaped for this.
-func devServerSetup(siteName, sitePath string, tool *config.DevServerTool) (string, error) {
+func devServerSetup(siteName, sitePath, workerName string, tool *config.DevServerTool) (string, error) {
 	site, err := config.FindSite(siteName)
 	if err != nil {
 		return "", err
@@ -297,7 +301,7 @@ func devServerSetup(siteName, sitePath string, tool *config.DevServerTool) (stri
 	if err != nil || wrapper == "" {
 		return "", err
 	}
-	port, err := devServerEnsurePort(siteName, sitePath, tool.DefaultPort)
+	port, err := devServerEnsurePort(siteName, sitePath, workerName, tool.DefaultPort)
 	if err != nil {
 		return "", err
 	}
@@ -400,7 +404,7 @@ func rewriteDevServerWrapper(sitePath string, tool *config.DevServerTool, addr d
 // every path that writes a worker unit points the tool at the generated config
 // and the pinned port. Anything the mechanism cannot apply cleanly leaves the
 // command as it was.
-func devServerCommand(siteName, sitePath, command string, host bool) string {
+func devServerCommand(siteName, sitePath, workerName, command string, host bool) string {
 	if !host {
 		return command
 	}
@@ -408,7 +412,7 @@ func devServerCommand(siteName, sitePath, command string, host bool) string {
 	if tool == nil {
 		return command
 	}
-	args, err := devServerSetup(siteName, sitePath, tool)
+	args, err := devServerSetup(siteName, sitePath, workerName, tool)
 	if err != nil {
 		feedback.Warn("dev server stays on its own port: %v", err)
 		return command
@@ -417,4 +421,14 @@ func devServerCommand(siteName, sitePath, command string, host bool) string {
 		return command
 	}
 	return command + " " + args
+}
+
+// devServerHoldsPort reports whether the site's own dev server worker is the
+// one sitting on its pinned port, which is the difference between a pin that
+// has drifted and a pin that is doing its job.
+func devServerHoldsPort(siteName, sitePath, workerName string) bool {
+	if workerName == "" || services.Mgr == nil {
+		return false
+	}
+	return services.Mgr.IsActive(WorkerUnitName(siteName, sitePath, workerName))
 }

--- a/internal/cli/devserver_port_test.go
+++ b/internal/cli/devserver_port_test.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/services"
+)
+
+// devPortMgr answers IsActive for the units named in active and nothing else.
+type devPortMgr struct {
+	services.ServiceManager
+	active map[string]bool
+}
+
+func (m devPortMgr) IsActive(name string) bool { return m.active[name] }
+
+func swapDevPortMgr(t *testing.T, m services.ServiceManager) {
+	t.Helper()
+	prev := services.Mgr
+	services.Mgr = m
+	t.Cleanup(func() { services.Mgr = prev })
+}
+
+// heldPort binds a port for the duration of the test and returns it, so the
+// pin under test is genuinely unbindable rather than merely claimed.
+func heldPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func siteWithPin(t *testing.T, dir string, port int) string {
+	t.Helper()
+	path := filepath.Join(dir, "myapp")
+	if err := config.AddSite(config.Site{
+		Name:          "myapp",
+		Path:          path,
+		Domains:       []string{"myapp.test"},
+		DevServerPort: port,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// A dev server running on its pinned port makes that port unbindable, which
+// used to read as taken by another process: the pin moved, the vhost followed
+// it, and the tool kept serving the port it started on until it was restarted.
+func TestDevServerEnsurePortKeepsAPinItsOwnDevServerHolds(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	pinned := heldPort(t)
+	path := siteWithPin(t, dir, pinned)
+	swapDevPortMgr(t, devPortMgr{active: map[string]bool{"lerd-vite-myapp": true}})
+
+	got, err := devServerEnsurePort("myapp", path, "vite", 5173)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != pinned {
+		t.Fatalf("devServerEnsurePort() = %d, want it to keep %d, the port its own dev server is serving", got, pinned)
+	}
+}
+
+// A pin held by anything other than the site's dev server still has to be
+// re-picked, or the tool is launched with strict-port against a port it cannot
+// bind and refuses to start at all.
+func TestDevServerEnsurePortRepicksAPinHeldByAnotherProcess(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	pinned := heldPort(t)
+	path := siteWithPin(t, dir, pinned)
+	swapDevPortMgr(t, devPortMgr{active: map[string]bool{}})
+
+	got, err := devServerEnsurePort("myapp", path, "vite", 5173)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == pinned {
+		t.Fatalf("devServerEnsurePort() kept %d, a port nothing of ours is holding and nothing can bind", pinned)
+	}
+}

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -312,7 +312,7 @@ func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w con
 
 	// A host worker that starts a known dev server is pinned to a port and
 	// pointed at a generated config, so it answers on the site's own domain.
-	command = devServerCommand(siteName, sitePath, command, w.Host)
+	command = devServerCommand(siteName, sitePath, workerName, command, w.Host)
 
 	// Workers exec into the container that hosts the site's runtime —
 	// custom container, FrankenPHP, or shared FPM. resolveWorkerFPMUnit

--- a/internal/cli/worker_darwin.go
+++ b/internal/cli/worker_darwin.go
@@ -307,7 +307,7 @@ func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.F
 	// The unit is rewritten here on every `lerd start`, so the dev server flags
 	// have to be rebuilt with it or the worker comes back on its own port and
 	// the site's page is refused the assets it asks for.
-	command = devServerCommand(siteName, sitePath, command, w.Host)
+	command = devServerCommand(siteName, sitePath, workerName, command, w.Host)
 
 	fpmUnit := resolveWorkerFPMUnit(siteName, phpVersion)
 	unitName, displaySite := workerNames(siteName, sitePath, workerName)

--- a/internal/cli/worker_linux.go
+++ b/internal/cli/worker_linux.go
@@ -241,7 +241,7 @@ func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.F
 	// The unit is rewritten here on every `lerd start`, so the dev server flags
 	// have to be rebuilt with it or the worker comes back on its own port and
 	// the site's page is refused the assets it asks for.
-	command = devServerCommand(siteName, sitePath, command, w.Host)
+	command = devServerCommand(siteName, sitePath, workerName, command, w.Host)
 
 	fpmUnit := resolveWorkerFPMUnit(siteName, phpVersion)
 	unitName, displaySite := workerNames(siteName, sitePath, workerName)


### PR DESCRIPTION
Starting lerd rewrites the worker units a site config lists, and since #1685 the dev server flags are restored on that path, which brought the port resolution along with them. The port is kept only when it can still be bound, on the reasoning that a pin something else has taken would make the tool refuse to start rather than drift, and a dev server holding its own pin reads exactly like that. So a start with the tool running moved the pin, rewrote the unit and the vhost to the new port, and left the tool answering on the old one, since nothing restarts it. Every asset the page asked for came back 502 while the page itself still answered 200, which reads as a broken asset build rather than a proxy pointing at nobody.

Until 1.34.1 it could not happen. The port was only ever resolved from the path that starts a worker, where the worker is by definition down, and the restore did not resolve it at all.

The check now asks whether the site's own dev server worker is the one sitting on the pin, and keeps it when it is. A pin lost to anything else is still re-picked, because the tool is launched with strict-port and would refuse to start on a port it cannot bind. The worker name travels with the command, so the start path, the restore and macOS all decide it the same way rather than drifting apart again.

Driving it against a real site with the dev server running and its unit not armed for boot, a build of main moves the unit and the vhost to a different port than the one the tool is listening on and the assets go 502; this one leaves all three on the same port and they stay 200, with the worker never restarted in between.

Closes #1689