### PR TITLE
feat: serve a service on a domain the app and the browser both resolve

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -242,7 +242,7 @@ Switch the PHP runtime for the current site between shared PHP-FPM and per-site 
 | `lerd service preset [name]` | List presets, or install one (use `--version` for multi-version presets); a store-only preset is fetched on demand |
 | `lerd service search [query]` | Browse the external service-preset store; filter by name, description, or family |
 | `lerd service remove <name> [--purge] [--no-snapshot]` | Stop and remove a service (custom or default). With `--purge`, snapshot every database on it, then rename the data dir aside (recoverable as `<name>.pre-remove-<ts>`). `--no-snapshot` skips the snapshot |
-| `lerd service domain <service> [domain] [--remove]` | Serve a service on its own HTTPS domain, resolvable from the app container and the browser alike. With no domain, show the current one |
+| `lerd service domain <service> [domain] [--port N] [--remove]` | Serve a service on its own HTTPS domain, resolvable from the app container and the browser alike. `--port` picks the container port for a service exposing several. With no domain, show the current one |
 | `lerd service reinstall <name> [--reset-data] [--no-snapshot]` | Stop, remove, and reinstall at the current version, then recreate any linked site's missing database or bucket on it. With `--reset-data`, snapshot every database on it and rename the data dir aside first. `--no-snapshot` skips the snapshot |
 | `lerd minio:migrate` | Migrate existing MinIO data to RustFS |
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -242,6 +242,7 @@ Switch the PHP runtime for the current site between shared PHP-FPM and per-site 
 | `lerd service preset [name]` | List presets, or install one (use `--version` for multi-version presets); a store-only preset is fetched on demand |
 | `lerd service search [query]` | Browse the external service-preset store; filter by name, description, or family |
 | `lerd service remove <name> [--purge] [--no-snapshot]` | Stop and remove a service (custom or default). With `--purge`, snapshot every database on it, then rename the data dir aside (recoverable as `<name>.pre-remove-<ts>`). `--no-snapshot` skips the snapshot |
+| `lerd service domain <service> [domain] [--remove]` | Serve a service on its own HTTPS domain, resolvable from the app container and the browser alike. With no domain, show the current one |
 | `lerd service reinstall <name> [--reset-data] [--no-snapshot]` | Stop, remove, and reinstall at the current version, then recreate any linked site's missing database or bucket on it. With `--reset-data`, snapshot every database on it and rename the data dir aside first. `--no-snapshot` skips the snapshot |
 | `lerd minio:migrate` | Migrate existing MinIO data to RustFS |
 

--- a/docs/usage/services.md
+++ b/docs/usage/services.md
@@ -216,6 +216,35 @@ If a historical `AWS_BUCKET` value with underscores (or other S3-invalid charact
 
 `AWS_URL` points to the public bucket URL (browser-reachable). `AWS_ENDPOINT` is the internal container address used by PHP.
 
+### Serving a service on its own domain
+
+An app reaches a service by container name, `lerd-rustfs`, which resolves only inside the podman network. That is fine until something hands the browser a URL built from it. An S3 presigned URL carries its host inside the signature, so rewriting the host afterwards produces `SignatureDoesNotMatch`; the app and the browser have to agree on one name *before* the URL is signed. `AWS_URL` cannot solve it either, because stock Laravel signs against the endpoint, not the public base.
+
+RustFS ships with one: its preset declares `domain: rustfs`, so an install that has it takes `rustfs.test` on the next start and the sites using it are repointed in the same pass. That is deliberate rather than opt-in, because a service whose URLs reach a browser is broken without a name both sides resolve, and a fix nobody runs is not a fix.
+
+```bash
+lerd service domain rustfs storage.test  # choose a different name
+lerd service domain rustfs               # show the current domain
+lerd service domain rustfs --remove      # stop serving it there
+```
+
+Removing it is recorded, so the preset's default is not handed back on the next start; naming one by hand clears that again. Any preset can declare a default the same way, which is why the value lives in the store and reaches every install without a release.
+
+The domain is a name both sides resolve: nginx serves it over HTTPS with a certificate from lerd's own CA, and the hosts file mounted into every PHP container points it at nginx, so the app signs for the same host the browser opens. A bare name is qualified with lerd's TLD, so `storage` means `storage.test`, and a domain outside that TLD is refused because nothing else resolves on both sides. The service stays reachable at `lerd-<name>` on the podman network throughout.
+
+A subdomain of a site works just as well if you prefer the storage to sit under the app it belongs to, `lerd service domain rustfs rustfs.myapp.test`. lerd runs one RustFS for every site, so the default is a name of its own rather than one borrowed from a project, and per-site subdomains share a namespace with grouped sites and worktree domains; but nothing stops you naming it that way.
+
+Setting or removing a domain sweeps the sites that use the service and rewrites their env files right away, so the change reaches the projects instead of waiting for each to run `lerd env` itself. That matters most on removal: without the sweep every project would be left pointing at a name that no longer resolves.
+
+Once a service has a domain, `lerd env` writes it into the sites that use the service: the container URL and the `localhost` published-port URL both become the domain, and the port the scheme now implies is dropped. Values that are not URLs are left alone, so a bare `REDIS_HOST=lerd-redis` keeps pointing at the container.
+
+```ini
+AWS_ENDPOINT=https://rustfs.test
+AWS_URL=https://rustfs.test/my-project
+```
+
+The vhost sends no CORS headers, so a browser fetching across origins (a direct-to-S3 upload from the site's own page) still needs them added; server-side uploads and plain `<img>` or download links are unaffected.
+
 If a bucket a site points at is not there, `lerd site:doctor` reports it under **Bucket** with a fix that creates it. Such a site serves every page fine and fails on the first upload, which is exactly the kind of thing that reads as an application bug. The check is driven by the service preset rather than by any framework: the preset names the `.env` key holding the entity a site owns (`owner_env: AWS_BUCKET` for RustFS), and only a project whose env also points at the lerd service is measured against it, so one configured for real AWS is left alone.
 
 `lerd env` writes the `.env` even when it could not create the database or bucket behind it, and then exits non-zero naming what is missing. It used to warn in passing and exit 0, which left a file claiming storage that was never created.

--- a/docs/usage/services.md
+++ b/docs/usage/services.md
@@ -242,6 +242,8 @@ A port the service does not expose is refused rather than written into a vhost t
 
 A subdomain of a site works just as well if you prefer the storage to sit under the app it belongs to, `lerd service domain rustfs rustfs.myapp.test`. lerd runs one RustFS for every site, so the default is a name of its own rather than one borrowed from a project, and per-site subdomains share a namespace with grouped sites and worktree domains; but nothing stops you naming it that way.
 
+The domain is taken during `lerd install` as well as at start, so an update reaches a machine that never sees a `lerd start` between releases.
+
 Setting or removing a domain sweeps the sites that use the service and rewrites their env files right away, so the change reaches the projects instead of waiting for each to run `lerd env` itself. That matters most on removal: without the sweep every project would be left pointing at a name that no longer resolves.
 
 Once a service has a domain, `lerd env` writes it into the sites that use the service: the container URL and the `localhost` published-port URL both become the domain, and the port the scheme now implies is dropped. Values that are not URLs are left alone, so a bare `REDIS_HOST=lerd-redis` keeps pointing at the container.

--- a/docs/usage/services.md
+++ b/docs/usage/services.md
@@ -232,6 +232,14 @@ Removing it is recorded, so the preset's default is not handed back on the next 
 
 The domain is a name both sides resolve: nginx serves it over HTTPS with a certificate from lerd's own CA, and the hosts file mounted into every PHP container points it at nginx, so the app signs for the same host the browser opens. A bare name is qualified with lerd's TLD, so `storage` means `storage.test`, and a domain outside that TLD is refused because nothing else resolves on both sides. The service stays reachable at `lerd-<name>` on the podman network throughout.
 
+A service exposing more than one port declares which one its domain serves, so Mailpit's `mailpit.test` would land on its web UI rather than on the SMTP port that happens to be listed first. Override it with `--port` when the preset says nothing:
+
+```bash
+lerd service domain rustfs console.rustfs.test --port 9001
+```
+
+A port the service does not expose is refused rather than written into a vhost that answers nothing.
+
 A subdomain of a site works just as well if you prefer the storage to sit under the app it belongs to, `lerd service domain rustfs rustfs.myapp.test`. lerd runs one RustFS for every site, so the default is a name of its own rather than one borrowed from a project, and per-site subdomains share a namespace with grouped sites and worktree domains; but nothing stops you naming it that way.
 
 Setting or removing a domain sweeps the sites that use the service and rewrites their env files right away, so the change reaches the projects instead of waiting for each to run `lerd env` itself. That matters most on removal: without the sweep every project would be left pointing at a name that no longer resolves.

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -56,6 +56,85 @@ func rewriteEnvForHostProxy(updates map[string]string, serviceNames []string) {
 	applyHostProxyEnv(updates, containerToHost)
 }
 
+// applyServiceDomainEnv repoints URL-shaped values at the domain a service is
+// served on. A service with a domain is one whose URLs leave the machine's own
+// processes and reach a browser, and the container name lerd otherwise writes
+// resolves nowhere out there. Only values carrying a scheme are touched, so a
+// bare connection host (REDIS_HOST=lerd-redis) is left where it belongs.
+func applyServiceDomainEnv(updates map[string]string, domains map[string]string, ports map[string]int) {
+	if len(domains) == 0 {
+		return
+	}
+	// Sorted so a value naming two services rewrites the same way every run.
+	names := make([]string, 0, len(domains))
+	for name := range domains {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for key, value := range updates {
+		if !strings.Contains(value, "://") {
+			continue
+		}
+		rewritten := value
+		for _, name := range names {
+			target := "https://" + domains[name]
+			rewritten = strings.ReplaceAll(rewritten, "http://lerd-"+name, target)
+			if port := ports[name]; port > 0 {
+				host := fmt.Sprintf(":%d", port)
+				rewritten = strings.ReplaceAll(rewritten, "http://localhost"+host, target)
+				rewritten = strings.ReplaceAll(rewritten, "http://127.0.0.1"+host, target)
+			}
+		}
+		// The container port survives the host swap ("https://rustfs.test:9000"),
+		// and nginx serves the domain on 443; strip what the scheme now implies.
+		rewritten = stripServiceDomainPorts(rewritten, domains)
+		if rewritten != value {
+			updates[key] = rewritten
+		}
+	}
+}
+
+// stripServiceDomainPorts removes an explicit port left on a service domain by
+// the rewrite above. Scoped to the domains lerd itself just substituted, so a
+// port on any other host in the value is untouched.
+func stripServiceDomainPorts(value string, domains map[string]string) string {
+	for _, domain := range domains {
+		prefix := "https://" + domain + ":"
+		for {
+			i := strings.Index(value, prefix)
+			if i < 0 {
+				break
+			}
+			rest := value[i+len(prefix):]
+			j := 0
+			for j < len(rest) && rest[j] >= '0' && rest[j] <= '9' {
+				j++
+			}
+			if j == 0 {
+				break
+			}
+			value = value[:i+len("https://"+domain)] + rest[j:]
+		}
+	}
+	return value
+}
+
+// serviceDomainPorts pairs each service that has a domain with the host port it
+// publishes, so a value written against localhost is recognised too.
+func serviceDomainPorts(domains map[string]string) map[string]int {
+	ports := map[string]int{}
+	for name := range domains {
+		sc := config.ServiceConfigFor(name)
+		if sc.PublishedPort > 0 {
+			ports[name] = sc.PublishedPort
+			continue
+		}
+		ports[name] = sc.Port
+	}
+	return ports
+}
+
 // hostProxyConnKey reports whether an env key names a service connection target
 // (a host, port, URL, DSN, or endpoint). The host-proxy rewrite only touches
 // these so an unrelated value that happens to contain a "lerd-" token (e.g.
@@ -1082,6 +1161,13 @@ func runEnv(_ *cobra.Command, _ []string) error {
 			names = append(names, n)
 		}
 		rewriteEnvForHostProxy(updates, names)
+	}
+
+	// 4d-bis. A service served on its own domain is reachable at that name from
+	// the app container and the browser alike, which is the only shape that
+	// works for a URL whose host is inside its signature.
+	if domains := config.ServiceDomains(); len(domains) > 0 {
+		applyServiceDomainEnv(updates, domains, serviceDomainPorts(domains))
 	}
 
 	// 4e. Apply personal .env.lerd_override values last so they win over lerd's

--- a/internal/cli/env_service_domain_test.go
+++ b/internal/cli/env_service_domain_test.go
@@ -1,0 +1,60 @@
+package cli
+
+import "testing"
+
+// The endpoint an app signs against and the URL the browser opens have to be
+// the same host, so both shapes lerd writes have to land on the domain.
+func TestApplyServiceDomainEnv_RepointsBothShapesAtTheDomain(t *testing.T) {
+	updates := map[string]string{
+		"AWS_ENDPOINT": "http://lerd-rustfs:9000",
+		"AWS_URL":      "http://localhost:9000/uploads",
+		"REDIS_HOST":   "lerd-redis",
+		"MAIL_HOST":    "lerd-mailpit",
+	}
+	applyServiceDomainEnv(updates,
+		map[string]string{"rustfs": "rustfs.test"},
+		map[string]int{"rustfs": 9000})
+
+	if got := updates["AWS_ENDPOINT"]; got != "https://rustfs.test" {
+		t.Errorf("AWS_ENDPOINT = %q, want https://rustfs.test", got)
+	}
+	if got := updates["AWS_URL"]; got != "https://rustfs.test/uploads" {
+		t.Errorf("AWS_URL = %q, want https://rustfs.test/uploads", got)
+	}
+	// A bare connection host is not a URL a browser ever sees, and rewriting it
+	// would point the app at nginx instead of the service.
+	if updates["REDIS_HOST"] != "lerd-redis" || updates["MAIL_HOST"] != "lerd-mailpit" {
+		t.Errorf("bare hosts were rewritten: redis=%q mail=%q", updates["REDIS_HOST"], updates["MAIL_HOST"])
+	}
+}
+
+// nginx serves the domain on 443, so the container port carried over from the
+// old value would point at a port nothing listens on.
+func TestApplyServiceDomainEnv_DropsThePortTheSchemeImplies(t *testing.T) {
+	updates := map[string]string{"AWS_ENDPOINT": "http://lerd-rustfs:9000/"}
+	applyServiceDomainEnv(updates,
+		map[string]string{"rustfs": "rustfs.test"},
+		map[string]int{"rustfs": 9000})
+	if got := updates["AWS_ENDPOINT"]; got != "https://rustfs.test/" {
+		t.Errorf("AWS_ENDPOINT = %q, want https://rustfs.test/", got)
+	}
+}
+
+func TestApplyServiceDomainEnv_NoDomainsLeavesEverythingAlone(t *testing.T) {
+	updates := map[string]string{"AWS_ENDPOINT": "http://lerd-rustfs:9000"}
+	applyServiceDomainEnv(updates, nil, nil)
+	if updates["AWS_ENDPOINT"] != "http://lerd-rustfs:9000" {
+		t.Errorf("value changed with no domains configured: %q", updates["AWS_ENDPOINT"])
+	}
+}
+
+// A value naming a host that only shares the port must keep its own port.
+func TestApplyServiceDomainEnv_LeavesOtherHostsPortsIntact(t *testing.T) {
+	updates := map[string]string{"OTHER_URL": "http://example.test:9000/thing"}
+	applyServiceDomainEnv(updates,
+		map[string]string{"rustfs": "rustfs.test"},
+		map[string]int{"rustfs": 9000})
+	if got := updates["OTHER_URL"]; got != "http://example.test:9000/thing" {
+		t.Errorf("OTHER_URL = %q, want it untouched", got)
+	}
+}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -1094,6 +1094,12 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	refreshGlobalMCPSkills()
 	refreshProjectMCPSkills()
 
+	// A service whose preset declares a domain takes it here as well as at start.
+	// An update runs this path, and plenty of machines never see a `lerd start`
+	// between one release and the next, so leaving it to start alone would mean
+	// the fix arrives for some users and not others.
+	adoptDefaultServiceDomains()
+
 	// Record which version this environment is set up for, so a binary a
 	// package manager swaps underneath it is recognised on the next command.
 	writeInstalledVersion(version.Version)

--- a/internal/cli/service_domain_sync_test.go
+++ b/internal/cli/service_domain_sync_test.go
@@ -34,7 +34,14 @@ func siteUsingRustfs(t *testing.T, name string) string {
 	if err := config.AddSite(config.Site{Name: name, Domains: []string{name + ".test"}, Path: dir}); err != nil {
 		t.Fatalf("AddSite: %v", err)
 	}
-	return dir
+	// The registry stores the resolved path, and on macOS the temp dir is a
+	// symlink (/var/folders -> /private/var/folders), so the raw path the test
+	// created would never match what comes back out.
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	return resolved
 }
 
 // A domain that never reaches the projects pointing at the service does

--- a/internal/cli/service_domain_sync_test.go
+++ b/internal/cli/service_domain_sync_test.go
@@ -94,3 +94,14 @@ func TestSyncServiceDomainSites_ContinuesPastAFailure(t *testing.T) {
 		t.Errorf("expected both attempted, got %v", *dirs)
 	}
 }
+
+// The tally is what the user reads instead of a list of site names, so it has
+// to say plainly when a site was left behind on the old address.
+func TestEnvSyncTally(t *testing.T) {
+	if got := envSyncTally(7, 0); got != "7 updated" {
+		t.Errorf("tally = %q, want %q", got, "7 updated")
+	}
+	if got := envSyncTally(5, 2); got != "5 updated, 2 failed" {
+		t.Errorf("tally = %q, want %q", got, "5 updated, 2 failed")
+	}
+}

--- a/internal/cli/service_domain_sync_test.go
+++ b/internal/cli/service_domain_sync_test.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
+)
+
+func stubDomainSync(t *testing.T, err error) *[]string {
+	t.Helper()
+	var dirs []string
+	prev := domainSyncEnvFn
+	domainSyncEnvFn = func(dir string, _ io.Writer) error {
+		dirs = append(dirs, dir)
+		return err
+	}
+	t.Cleanup(func() { domainSyncEnvFn = prev })
+	return &dirs
+}
+
+func siteUsingRustfs(t *testing.T, name string) string {
+	t.Helper()
+	dir := t.TempDir()
+	env := "FILESYSTEM_DISK=s3\nAWS_ENDPOINT=http://lerd-rustfs:9000\n"
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(env), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.AddSite(config.Site{Name: name, Domains: []string{name + ".test"}, Path: dir}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+	return dir
+}
+
+// A domain that never reaches the projects pointing at the service does
+// nothing, and removing one would strand every project on a name that resolves
+// nowhere. The sweep is what closes both.
+func TestSyncServiceDomainSites_RewritesEverySiteUsingTheService(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	var buf bytes.Buffer
+	defer feedback.SetTestWriter(&buf)()
+
+	a := siteUsingRustfs(t, "shop")
+	b := siteUsingRustfs(t, "blog")
+	dirs := stubDomainSync(t, nil)
+
+	syncServiceDomainSites("rustfs", config.SitesUsingService("rustfs"))
+
+	if len(*dirs) != 2 {
+		t.Fatalf("expected both sites swept, got %v", *dirs)
+	}
+	got := map[string]bool{(*dirs)[0]: true, (*dirs)[1]: true}
+	if !got[a] || !got[b] {
+		t.Errorf("expected %q and %q, got %v", a, b, *dirs)
+	}
+}
+
+func TestSyncServiceDomainSites_NoSitesIsSilent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	dirs := stubDomainSync(t, nil)
+
+	syncServiceDomainSites("rustfs", config.SitesUsingService("rustfs"))
+
+	if len(*dirs) != 0 {
+		t.Errorf("expected no sweep with no sites, got %v", *dirs)
+	}
+}
+
+// One project that cannot be written must not stop the rest: the others are
+// still pointing at the old address until they are swept.
+func TestSyncServiceDomainSites_ContinuesPastAFailure(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	var buf bytes.Buffer
+	defer feedback.SetTestWriter(&buf)()
+
+	siteUsingRustfs(t, "shop")
+	siteUsingRustfs(t, "blog")
+	dirs := stubDomainSync(t, errors.New("boom"))
+
+	syncServiceDomainSites("rustfs", config.SitesUsingService("rustfs"))
+
+	if len(*dirs) != 2 {
+		t.Errorf("expected both attempted, got %v", *dirs)
+	}
+}

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -84,8 +84,110 @@ func NewServiceCmd() *cobra.Command {
 	cmd.AddCommand(newServicePinCmd())
 	cmd.AddCommand(newServiceUnpinCmd())
 	cmd.AddCommand(newServicePortCmd())
+	cmd.AddCommand(newServiceDomainCmd())
 
 	return cmd
+}
+
+// newServiceDomainCmd returns the `service domain` command.
+func newServiceDomainCmd() *cobra.Command {
+	var remove bool
+	cmd := &cobra.Command{
+		Use:   "domain <service> [domain]",
+		Short: "Serve a service on its own domain, reachable from the app and the browser",
+		Long: `Give a service a hostname nginx serves it on, over HTTPS:
+
+    lerd service domain rustfs rustfs.test
+
+serves lerd-rustfs at https://rustfs.test. A bare name is qualified with lerd's
+TLD, so "storage" means storage.test.
+
+An app reaches a service by container name, which resolves nowhere outside the
+podman network. That is fine until something hands the browser a URL built from
+it: an S3 presigned URL carries its host inside the signature, so the app and
+the browser have to agree on one name before the URL is signed, and rewriting
+the host afterwards invalidates the signature. A service domain is that shared
+name, resolving to nginx from inside the app container and from the host alike.
+
+Run with no domain to show the current one, or --remove to stop serving it. The
+service stays reachable at lerd-<name> on the podman network either way.`,
+		Args: cobra.RangeArgs(1, 2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			name := args[0]
+			feedback.Begin()
+			// Resolved before the change: a site is recognised by whichever
+			// address its env currently names, so removing the domain first
+			// would lose every site the domain itself is what wired.
+			affected := config.SitesUsingService(name)
+			if remove {
+				if err := serviceops.RemoveServiceDomain(name); err != nil {
+					return err
+				}
+				feedback.Done("removed the domain for " + feedback.Val(name))
+				syncServiceDomainSites(name, affected)
+				return nil
+			}
+			if len(args) == 1 {
+				if current := config.ServiceDomain(name); current != "" {
+					fmt.Printf("%s is served at https://%s\n", name, current)
+					return nil
+				}
+				fmt.Printf("%s has no domain. Give it one with: lerd service domain %s %s\n",
+					name, name, serviceops.DefaultServiceDomain(name))
+				return nil
+			}
+			domain, err := serviceops.SetServiceDomain(name, args[1])
+			if err != nil {
+				return err
+			}
+			feedback.Done("serving " + feedback.Val(name) + " at https://" + domain)
+			syncServiceDomainSites(name, affected)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&remove, "remove", false, "Stop serving the service on its domain")
+	return cmd
+}
+
+// adoptDefaultServiceDomains takes the domain each preset declares for a service
+// that has none, then rewrites the env of the sites using it. Together those two
+// are what make the fix arrive with an update: the domain is provisioned and the
+// projects pointing at the service are repointed at it in the same pass.
+func adoptDefaultServiceDomains() {
+	for _, service := range serviceops.AdoptDefaultServiceDomains() {
+		// Resolved after the adoption on purpose: the sites still name the
+		// container at this point, which is what the lookup matches on.
+		sites := config.SitesUsingService(service)
+		fmt.Printf("  %s is now served at https://%s\n", service, config.ServiceDomain(service))
+		syncServiceDomainSites(service, sites)
+	}
+}
+
+// domainSyncEnvFn is the seam the domain sweep re-execs the env step through,
+// swapped in tests so the sweep can be driven without a real project to write.
+var domainSyncEnvFn = runLerdEnvTo
+
+// syncServiceDomainSites rewrites the env of every site that uses the service,
+// so a domain that just appeared or just went away reaches the projects pointing
+// at it. Without this a domain does nothing until each project runs `lerd env`
+// itself, and removing one leaves every project on a name that resolves nowhere.
+// It re-execs the env step rather than editing the values here, so both
+// directions are computed by the one path that owns them. The sites are resolved
+// by the caller before the domain changes, since a site wired to the domain
+// names the container nowhere and would vanish from the list the moment the
+// domain does.
+func syncServiceDomainSites(service string, sites []config.Site) {
+	if len(sites) == 0 {
+		return
+	}
+	fmt.Printf("Updating .env for %d site(s) that use %s:\n", len(sites), service)
+	for _, site := range sites {
+		if err := domainSyncEnvFn(site.Path, io.Discard); err != nil {
+			feedback.Warn("%s: %v", site.Name, err)
+			continue
+		}
+		fmt.Printf("  %s\n", site.Name)
+	}
 }
 
 func newServiceStartCmd() *cobra.Command {
@@ -602,6 +704,9 @@ stopped, removed, exposed, or pinned with the usual service subcommands.`,
 				return err
 			}
 			fmt.Printf("Installed preset %q. Start it with: lerd service start %s\n", svc.Name, svc.Name)
+			if domain := config.ServiceDomain(svc.Name); domain != "" {
+				fmt.Printf("Served at: https://%s\n", domain)
+			}
 			if svc.Dashboard != "" {
 				fmt.Printf("Dashboard: %s\n", svc.Dashboard)
 			}
@@ -897,6 +1002,8 @@ func newServiceReinstallCmd() *cobra.Command {
 					feedback.Note("reprovisioning skipped: " + e.Message)
 				case "reprovisioning_failed":
 					feedback.Warn("reprovisioning linked sites: %s", e.Message)
+				case "domain_adopted":
+					feedback.Note("serving on its own domain: " + e.Message)
 				}
 			}
 			opts := serviceops.ReinstallOptions{ResetData: resetData, SkipSnapshot: noSnapshot}

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -92,6 +92,7 @@ func NewServiceCmd() *cobra.Command {
 // newServiceDomainCmd returns the `service domain` command.
 func newServiceDomainCmd() *cobra.Command {
 	var remove bool
+	var port int
 	cmd := &cobra.Command{
 		Use:   "domain <service> [domain]",
 		Short: "Serve a service on its own domain, reachable from the app and the browser",
@@ -108,6 +109,12 @@ it: an S3 presigned URL carries its host inside the signature, so the app and
 the browser have to agree on one name before the URL is signed, and rewriting
 the host afterwards invalidates the signature. A service domain is that shared
 name, resolving to nginx from inside the app container and from the host alike.
+
+A service exposing more than one port declares which one its domain serves, and
+lerd falls back to the primary otherwise. Override it with --port when the
+service is yours or the preset says nothing:
+
+    lerd service domain rustfs console.rustfs.test --port 9001
 
 Run with no domain to show the current one, or --remove to stop serving it. The
 service stays reachable at lerd-<name> on the podman network either way.`,
@@ -129,14 +136,14 @@ service stays reachable at lerd-<name> on the podman network either way.`,
 			}
 			if len(args) == 1 {
 				if current := config.ServiceDomain(name); current != "" {
-					fmt.Printf("%s is served at https://%s\n", name, current)
+					fmt.Printf("%s is served at https://%s -> port %d\n", name, current, serviceops.ServiceDomainPort(name))
 					return nil
 				}
 				fmt.Printf("%s has no domain. Give it one with: lerd service domain %s %s\n",
 					name, name, serviceops.DefaultServiceDomain(name))
 				return nil
 			}
-			domain, err := serviceops.SetServiceDomain(name, args[1])
+			domain, err := serviceops.SetServiceDomain(name, args[1], port)
 			if err != nil {
 				return err
 			}
@@ -146,6 +153,7 @@ service stays reachable at lerd-<name> on the podman network either way.`,
 		},
 	}
 	cmd.Flags().BoolVar(&remove, "remove", false, "Stop serving the service on its domain")
+	cmd.Flags().IntVar(&port, "port", 0, "Container port the domain proxies to (default: the preset's, then the service's primary)")
 	return cmd
 }
 

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -166,7 +166,8 @@ func adoptDefaultServiceDomains() {
 		// Resolved after the adoption on purpose: the sites still name the
 		// container at this point, which is what the lookup matches on.
 		sites := config.SitesUsingService(service)
-		fmt.Printf("  %s is now served at https://%s\n", service, config.ServiceDomain(service))
+		step := feedback.Start("serving " + feedback.Val(service) + " at https://" + config.ServiceDomain(service))
+		step.OK("")
 		syncServiceDomainSites(service, sites)
 	}
 }
@@ -188,14 +189,27 @@ func syncServiceDomainSites(service string, sites []config.Site) {
 	if len(sites) == 0 {
 		return
 	}
-	fmt.Printf("Updating .env for %d site(s) that use %s:\n", len(sites), service)
+	bar := feedback.StartProgress(
+		fmt.Sprintf("rewriting .env for %d site%s using %s", len(sites), pluralS(len(sites)), service),
+		len(sites))
 	for _, site := range sites {
 		if err := domainSyncEnvFn(site.Path, io.Discard); err != nil {
-			feedback.Warn("%s: %v", site.Name, err)
+			bar.Failed(site.Name, err.Error())
 			continue
 		}
-		fmt.Printf("  %s\n", site.Name)
+		bar.Step(site.Name)
 	}
+	bar.Done(envSyncTally(bar.Completed(), bar.Failures()))
+}
+
+// envSyncTally summarises the sweep the way the store refresh does: the count
+// alone when every site took the change, and the failures named when some did
+// not, since a site left on the old address is the thing worth noticing.
+func envSyncTally(done, failed int) string {
+	if failed == 0 {
+		return fmt.Sprintf("%d updated", done)
+	}
+	return fmt.Sprintf("%d updated, %d failed", done, failed)
 }
 
 func newServiceStartCmd() *cobra.Command {

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -617,6 +617,13 @@ func startLerd(emit func(StartEvent), skip []string) error {
 		}
 	}
 
+	// A service domain is served by no site, so nothing else rebuilds its vhost
+	// or renews its certificate; do it before the repair sweep so a cert that
+	// aged out is reissued rather than found missing.
+	if err := serviceops.ApplyServiceDomains(); err != nil {
+		fmt.Printf("  WARN: %v\n", err)
+	}
+
 	// Pre-flight: repair SSL vhosts with missing cert files so nginx can start.
 	if repairs := nginx.RepairVhosts(); len(repairs) > 0 {
 		for _, r := range repairs {
@@ -733,6 +740,12 @@ func startLerd(emit func(StartEvent), skip []string) error {
 	if err := podman.WriteContainerHosts(); err != nil {
 		fmt.Printf("  WARN: browser hosts file: %v\n", err)
 	}
+
+	// A service whose URLs reach a browser is broken until it has a name both
+	// sides resolve, so the domain its preset declares is taken here rather than
+	// waiting for the user to find a command. Runs after the services are up
+	// because the env sweep that follows provisions against them.
+	adoptDefaultServiceDomains()
 
 	// Sync the pasta DNS proxy (169.254.1.1) as the aardvark-dns upstream for the lerd
 	// network. This address chains through systemd-resolved, which resolves both .test

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -34,7 +34,17 @@ type ServiceConfig struct {
 	// default. Keyed on the container port because that is the stable identity
 	// when the host side moves.
 	PublishedPorts map[int]int `yaml:"published_ports,omitempty" mapstructure:"published_ports"`
-	PreviousImage  string      `yaml:"previous_image,omitempty" mapstructure:"previous_image"`
+	// Domain is the hostname nginx serves this service on, empty when the
+	// service is only reachable at lerd-<name>:<port>. It exists because a
+	// presigned S3 URL carries its host inside the signature: the app and the
+	// browser have to agree on one name before the URL is signed, and no name
+	// they both resolve exists otherwise.
+	Domain string `yaml:"domain,omitempty" mapstructure:"domain"`
+	// DomainOptOut records that the user took the domain away deliberately, so
+	// the preset's default is not handed back on the next start. Without it
+	// `service domain --remove` would be undone by the very next reconcile.
+	DomainOptOut  bool   `yaml:"domain_opt_out,omitempty" mapstructure:"domain_opt_out"`
+	PreviousImage string `yaml:"previous_image,omitempty" mapstructure:"previous_image"`
 	// LastOp records the most recent mutation kind ("update" or "migrate") so
 	// the rollback flow can refuse a swap that would race the new image
 	// against the post-migrate (fresh) data dir. Empty means no recent op or a
@@ -537,6 +547,11 @@ func MappingHostPort(mapping string) int {
 	n, _ := strconv.Atoi(strings.TrimSpace(host))
 	return n
 }
+
+// MappingContainerPort is mappingContainerPort for callers outside this package:
+// the port a service listens on inside its container, which is what anything
+// reaching it across the podman network connects to.
+func MappingContainerPort(mapping string) int { return mappingContainerPort(mapping) }
 
 // mappingContainerPort extracts the container (internal) port from a podman port
 // mapping — the last numeric segment after stripping an optional "/proto" suffix.

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -43,7 +43,10 @@ type ServiceConfig struct {
 	// DomainOptOut records that the user took the domain away deliberately, so
 	// the preset's default is not handed back on the next start. Without it
 	// `service domain --remove` would be undone by the very next reconcile.
-	DomainOptOut  bool   `yaml:"domain_opt_out,omitempty" mapstructure:"domain_opt_out"`
+	DomainOptOut bool `yaml:"domain_opt_out,omitempty" mapstructure:"domain_opt_out"`
+	// DomainPort overrides the container port the domain proxies to. 0 = the
+	// preset's choice, then the service's primary port.
+	DomainPort    int    `yaml:"domain_port,omitempty" mapstructure:"domain_port"`
 	PreviousImage string `yaml:"previous_image,omitempty" mapstructure:"previous_image"`
 	// LastOp records the most recent mutation kind ("update" or "migrate") so
 	// the rollback flow can refuse a swap that would race the new image

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -89,6 +89,14 @@ type Preset struct {
 	// installs. Existing users with a saved image override are untouched —
 	// they progress through the Update / Upgrade buttons instead.
 	TrackLatest bool `yaml:"track_latest,omitempty"`
+	// Domain is the hostname label this service should be served on by default,
+	// qualified with the user's TLD (rustfs -> rustfs.test). A service declares
+	// it when its own URLs reach a browser: an S3 presigned URL carries its host
+	// inside the signature, so the app and the browser must agree on one name
+	// before the URL is signed, and the container name resolves in neither. A
+	// binary that predates this field ignores it and keeps behaving as it does
+	// today, which is why the default ships here rather than in Go.
+	Domain string `yaml:"domain,omitempty"`
 	// DataVersionFile names a file inside the service's data dir whose contents
 	// identify the version that wrote the data (postgres PG_VERSION, mariadb
 	// mariadb_upgrade_info). It is matched against Versions[].Tag so a data dir

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -97,6 +97,11 @@ type Preset struct {
 	// binary that predates this field ignores it and keeps behaving as it does
 	// today, which is why the default ships here rather than in Go.
 	Domain string `yaml:"domain,omitempty"`
+	// DomainPort is the container port the domain is served from, for a service
+	// exposing more than one. Without it the first mapping is assumed, which is
+	// the API for an object store but the SMTP port for a mail catcher whose web
+	// UI is the thing worth a hostname.
+	DomainPort int `yaml:"domain_port,omitempty"`
 	// DataVersionFile names a file inside the service's data dir whose contents
 	// identify the version that wrote the data (postgres PG_VERSION, mariadb
 	// mariadb_upgrade_info). It is matched against Versions[].Tag so a data dir

--- a/internal/config/presets/mailpit.yaml
+++ b/internal/config/presets/mailpit.yaml
@@ -22,3 +22,6 @@ env_vars:
 category: mail
 icon: mail
 color: "#00b786"
+
+# The web UI, not the SMTP port a domain would otherwise land on.
+domain_port: 8025

--- a/internal/config/presets/rustfs.yaml
+++ b/internal/config/presets/rustfs.yaml
@@ -76,3 +76,8 @@ introspect:
             - RCLONE_S3_ENDPOINT=http://lerd-rustfs:9000
             - RCLONE_S3_ACCESS_KEY_ID=lerd
             - RCLONE_S3_SECRET_ACCESS_KEY=lerdpassword
+
+# The app and the browser must agree on one hostname before a presigned URL is
+# signed, so this service is served on rustfs.test rather than only at its
+# container name. Remove it with: lerd service domain rustfs --remove
+domain: rustfs

--- a/internal/config/service_domain_match_test.go
+++ b/internal/config/service_domain_match_test.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A site whose env was rewritten to the service's domain names the container
+// nowhere. Without matching the domain it drops out of every sweep that keeps
+// it wired, including the one that would put the container name back when the
+// domain goes away.
+func TestSitesUsingService_MatchesASiteWiredToTheDomain(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	cfg, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if cfg.Services == nil {
+		cfg.Services = map[string]ServiceConfig{}
+	}
+	sc := cfg.Services["rustfs"]
+	sc.Domain = "rustfs.test"
+	cfg.Services["rustfs"] = sc
+	if err := SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	dir := t.TempDir()
+	env := "FILESYSTEM_DISK=s3\nAWS_ENDPOINT=https://rustfs.test\n"
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(env), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddSite(Site{Name: "shop", Domains: []string{"shop.test"}, Path: dir}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	sites := SitesUsingService("rustfs")
+	if len(sites) != 1 || sites[0].Name != "shop" {
+		t.Fatalf("expected the domain-wired site to be found, got %v", sites)
+	}
+}
+
+func TestSitesUsingService_StillMatchesTheContainerName(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	dir := t.TempDir()
+	env := "FILESYSTEM_DISK=s3\nAWS_ENDPOINT=http://lerd-rustfs:9000\n"
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(env), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddSite(Site{Name: "shop", Domains: []string{"shop.test"}, Path: dir}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+	if sites := SitesUsingService("rustfs"); len(sites) != 1 {
+		t.Fatalf("expected the container-wired site to be found, got %v", sites)
+	}
+}

--- a/internal/config/service_manual.go
+++ b/internal/config/service_manual.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/geodro/lerd/internal/envfile"
 )
@@ -68,6 +69,7 @@ func SitesUsingService(name string) []Site {
 	if err != nil {
 		return nil
 	}
+	domain := ServiceDomain(name)
 	var out []Site
 	for _, s := range reg.Sites {
 		if s.Ignored || s.Paused {
@@ -89,6 +91,15 @@ func SitesUsingService(name string) []Site {
 		envFile, _ := EnvFileFor(s.Path)
 		if data, err := os.ReadFile(filepath.Join(s.Path, envFile)); err == nil {
 			if envfile.ReferencesContainer(string(data), name) {
+				out = append(out, s)
+				continue
+			}
+			// A site whose env was rewritten to the service's domain no longer
+			// names the container at all, so without this it drops out of every
+			// sweep that keeps it wired: the one that would put the container
+			// name back when the domain goes away, and the provisioning that
+			// keeps its database or bucket there.
+			if domain != "" && strings.Contains(string(data), domain) {
 				out = append(out, s)
 			}
 		}
@@ -159,4 +170,32 @@ func ServiceExtraPorts(name string) []string {
 		return sc.ExtraPorts
 	}
 	return nil
+}
+
+// ServiceDomain returns the hostname a service is served on, empty when it has
+// none. Readers that hand a URL to a browser use it: the container name a
+// service is otherwise reached at resolves nowhere outside the podman network.
+func ServiceDomain(name string) string {
+	cfg, err := LoadGlobal()
+	if err != nil {
+		return ""
+	}
+	return cfg.Services[name].Domain
+}
+
+// ServiceDomains returns every configured service domain keyed by service name.
+// The hosts file and the vhost sweep both walk it, so neither has to know which
+// services opted in.
+func ServiceDomains() map[string]string {
+	cfg, err := LoadGlobal()
+	if err != nil {
+		return nil
+	}
+	out := map[string]string{}
+	for name, sc := range cfg.Services {
+		if sc.Domain != "" {
+			out[name] = sc.Domain
+		}
+	}
+	return out
 }

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -1019,6 +1019,39 @@ func GenerateProxyVhost(domain, upstreamHost string, upstreamPort int) error {
 	return os.WriteFile(confPath, rendered, 0644)
 }
 
+// GenerateServiceProxyVhost writes the vhost that serves a service on its own
+// domain: HTTP when ssl is false, HTTPS with an HTTP redirect in front when it
+// is. It is the plain proxy vhost with TLS, kept separate so the LAN proxy above
+// keeps its narrower shape.
+func GenerateServiceProxyVhost(domain, upstreamHost string, upstreamPort int, ssl bool) error {
+	if !ssl {
+		return GenerateProxyVhost(domain, upstreamHost, upstreamPort)
+	}
+	tmplData, err := GetTemplate("vhost-proxy-ssl.conf.tmpl")
+	if err != nil {
+		return err
+	}
+	tmpl, err := template.New("vhost-proxy-ssl").Parse(string(tmplData))
+	if err != nil {
+		return err
+	}
+	rendered, err := renderProxyVhost(tmpl, proxyVhostData{
+		Domain:         domain,
+		UpstreamHost:   upstreamHost,
+		UpstreamPort:   upstreamPort,
+		RequestTimeout: resolveRequestTimeout("", ""),
+	})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(config.NginxConfD(), 0755); err != nil {
+		return err
+	}
+	confPath := filepath.Join(config.NginxConfD(), domain+".conf")
+	config.GuardRealWrite(confPath)
+	return os.WriteFile(confPath, rendered, 0644)
+}
+
 // ErrNotRunning reports that lerd-nginx is down, so there is no process to
 // signal. The on-disk config is still authoritative: whoever starts nginx next
 // reads it. Callers that only need the config correct (the install reconcile,
@@ -1129,6 +1162,11 @@ func RepairVhosts() []VhostRepair {
 		return nil
 	}
 
+	serviceDomains := map[string]bool{}
+	for _, domain := range config.ServiceDomains() {
+		serviceDomains[domain] = true
+	}
+
 	var repairs []VhostRepair
 	dirty := false
 
@@ -1138,6 +1176,11 @@ func RepairVhosts() []VhostRepair {
 		}
 		// Skip internal configs (default catch-all and lerd dashboard proxy).
 		if entry.Name() == "_default.conf" || entry.Name() == "lerd.localhost.conf" {
+			continue
+		}
+		// A service domain is served by no site, so the orphan rule below would
+		// delete the vhost that makes it answer at all.
+		if serviceDomains[strings.TrimSuffix(entry.Name(), ".conf")] {
 			continue
 		}
 

--- a/internal/nginx/service_vhost_test.go
+++ b/internal/nginx/service_vhost_test.go
@@ -1,0 +1,91 @@
+package nginx
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// The upstream signs against the Host it is handed, so the proxy has to forward
+// the name the client signed for. Forwarding the container's would turn every
+// presigned URL into a signature mismatch.
+func TestGenerateServiceProxyVhost_ForwardsTheRequestedHostOverTLS(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	if err := GenerateServiceProxyVhost("rustfs.test", "lerd-rustfs", 9000, true); err != nil {
+		t.Fatalf("GenerateServiceProxyVhost: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(config.NginxConfD(), "rustfs.test.conf"))
+	if err != nil {
+		t.Fatalf("reading vhost: %v", err)
+	}
+	got := string(body)
+	for _, want := range []string{
+		"server_name rustfs.test;",
+		"ssl_certificate /etc/nginx/certs/rustfs.test.crt;",
+		`set $backend "lerd-rustfs";`,
+		"proxy_pass http://$backend:9000;",
+		"proxy_set_header Host $host;",
+		"return 301 https://$host$request_uri;",
+		"client_max_body_size 0;",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("vhost missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateServiceProxyVhost_PlainHTTPWhenNotSecured(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	if err := GenerateServiceProxyVhost("rustfs.test", "lerd-rustfs", 9000, false); err != nil {
+		t.Fatalf("GenerateServiceProxyVhost: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(config.NginxConfD(), "rustfs.test.conf"))
+	if err != nil {
+		t.Fatalf("reading vhost: %v", err)
+	}
+	if strings.Contains(string(body), "ssl_certificate") {
+		t.Errorf("plain vhost should carry no TLS directives:\n%s", body)
+	}
+}
+
+// A service domain belongs to no site, so the orphan rule in the repair sweep
+// would delete the vhost that makes it answer at all.
+func TestRepairVhosts_KeepsAServiceDomainVhost(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if cfg.Services == nil {
+		cfg.Services = map[string]config.ServiceConfig{}
+	}
+	sc := cfg.Services["rustfs"]
+	sc.Domain = "rustfs.test"
+	cfg.Services["rustfs"] = sc
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	if err := GenerateServiceProxyVhost("rustfs.test", "lerd-rustfs", 9000, true); err != nil {
+		t.Fatalf("GenerateServiceProxyVhost: %v", err)
+	}
+	conf := filepath.Join(config.NginxConfD(), "rustfs.test.conf")
+
+	RepairVhosts()
+
+	if _, err := os.Stat(conf); err != nil {
+		t.Fatalf("the service vhost was removed by the repair sweep: %v", err)
+	}
+}

--- a/internal/nginx/templates/vhost-proxy-ssl.conf.tmpl
+++ b/internal/nginx/templates/vhost-proxy-ssl.conf.tmpl
@@ -1,0 +1,40 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name {{.Domain}};
+
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name {{.Domain}};
+
+    ssl_certificate /etc/nginx/certs/{{.Domain}}.crt;
+    ssl_certificate_key /etc/nginx/certs/{{.Domain}}.key;
+
+    # An object store streams whole files both ways, so the body cap comes off
+    # and neither direction is spooled to disk on the way through.
+    client_max_body_size 0;
+    proxy_request_buffering off;
+    proxy_buffering off;
+
+    location / {
+        # Through a variable, the same way the custom-container vhosts do it: a
+        # literal upstream is resolved when the config loads, so a reload while
+        # the service container is absent is rejected outright and takes every
+        # other vhost in the file down with it.
+        set $backend "{{.UpstreamHost}}";
+        proxy_pass http://$backend:{{.UpstreamPort}};
+        # The upstream signs requests against the Host it is given, so this has
+        # to stay the name the client signed for, not the container's.
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_read_timeout {{.RequestTimeout}}s;
+        proxy_connect_timeout 5s;
+    }
+}

--- a/internal/podman/hosts.go
+++ b/internal/podman/hosts.go
@@ -77,7 +77,18 @@ func renderContainerHosts(reg *config.SiteRegistry, hostIP, nginxIP string) stri
 			fmt.Fprintf(&sb, "%s %s\n", nginxIP, domain)
 		}
 	}
+	writeServiceDomains(&sb, nginxIP)
 	return sb.String()
+}
+
+// writeServiceDomains adds the hostnames services are served on. An app reaches
+// a service by container name, but a hostname the browser will also be given
+// has to resolve to nginx from inside the app container too: a presigned URL
+// carries its host in the signature, so both sides have to use the same name.
+func writeServiceDomains(sb *strings.Builder, nginxIP string) {
+	for _, domain := range config.ServiceDomains() {
+		fmt.Fprintf(sb, "%s %s\n", nginxIP, domain)
+	}
 }
 
 // writeBrowserHosts writes the browser-testing hosts file, mapping all .test
@@ -94,6 +105,7 @@ func writeBrowserHosts(reg *config.SiteRegistry, nginxIP string) error {
 			fmt.Fprintf(&sb, "%s %s\n", nginxIP, domain)
 		}
 	}
+	writeServiceDomains(&sb, nginxIP)
 
 	browserPath := config.BrowserHostsFile()
 	if err := os.MkdirAll(filepath.Dir(browserPath), 0755); err != nil {

--- a/internal/podman/hosts.go
+++ b/internal/podman/hosts.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -48,7 +49,8 @@ func WriteContainerHostsWith(hostIP, nginxIP string) error {
 		return fmt.Errorf("loading sites: %w", err)
 	}
 
-	content := renderContainerHosts(reg, hostIP, nginxIP)
+	serviceDomains := config.ServiceDomains()
+	content := renderContainerHosts(reg, hostIP, nginxIP, serviceDomains)
 	hostsPath := config.ContainerHostsFile()
 	if err := os.MkdirAll(filepath.Dir(hostsPath), 0755); err != nil {
 		return err
@@ -60,13 +62,13 @@ func WriteContainerHostsWith(hostIP, nginxIP string) error {
 	// Write the browser-testing variant: same domains but resolved to
 	// lerd-nginx's IP on the Podman network so Chromium inside Selenium
 	// (or similar containers) can reach sites via HTTP/HTTPS.
-	return writeBrowserHosts(reg, nginxIP)
+	return writeBrowserHosts(reg, nginxIP, serviceDomains)
 }
 
 // renderContainerHosts builds the /etc/hosts contents for PHP-FPM containers.
 // .test domains go to nginxIP (direct bridge), host.containers.internal to
 // hostIP (host gateway for Xdebug and other host-side services).
-func renderContainerHosts(reg *config.SiteRegistry, hostIP, nginxIP string) string {
+func renderContainerHosts(reg *config.SiteRegistry, hostIP, nginxIP string, serviceDomains map[string]string) string {
 	var sb strings.Builder
 	sb.WriteString("127.0.0.1 localhost\n")
 	sb.WriteString("::1 localhost\n")
@@ -77,7 +79,7 @@ func renderContainerHosts(reg *config.SiteRegistry, hostIP, nginxIP string) stri
 			fmt.Fprintf(&sb, "%s %s\n", nginxIP, domain)
 		}
 	}
-	writeServiceDomains(&sb, nginxIP)
+	writeServiceDomains(&sb, nginxIP, serviceDomains)
 	return sb.String()
 }
 
@@ -85,9 +87,16 @@ func renderContainerHosts(reg *config.SiteRegistry, hostIP, nginxIP string) stri
 // a service by container name, but a hostname the browser will also be given
 // has to resolve to nginx from inside the app container too: a presigned URL
 // carries its host in the signature, so both sides have to use the same name.
-func writeServiceDomains(sb *strings.Builder, nginxIP string) {
-	for _, domain := range config.ServiceDomains() {
-		fmt.Fprintf(sb, "%s %s\n", nginxIP, domain)
+func writeServiceDomains(sb *strings.Builder, nginxIP string, serviceDomains map[string]string) {
+	// Sorted so two runs of the same configuration produce the same file and the
+	// diff that decides whether anything changed stays meaningful.
+	names := make([]string, 0, len(serviceDomains))
+	for name := range serviceDomains {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		fmt.Fprintf(sb, "%s %s\n", nginxIP, serviceDomains[name])
 	}
 }
 
@@ -95,7 +104,7 @@ func writeServiceDomains(sb *strings.Builder, nginxIP string) {
 // domains to nginxIP. When nginx isn't running the caller passes loopback and
 // the file stays well-formed (safe no-op — Selenium simply can't reach sites
 // until nginx starts).
-func writeBrowserHosts(reg *config.SiteRegistry, nginxIP string) error {
+func writeBrowserHosts(reg *config.SiteRegistry, nginxIP string, serviceDomains map[string]string) error {
 	var sb strings.Builder
 	sb.WriteString("127.0.0.1 localhost\n")
 	sb.WriteString("::1 localhost\n")
@@ -105,7 +114,7 @@ func writeBrowserHosts(reg *config.SiteRegistry, nginxIP string) error {
 			fmt.Fprintf(&sb, "%s %s\n", nginxIP, domain)
 		}
 	}
-	writeServiceDomains(&sb, nginxIP)
+	writeServiceDomains(&sb, nginxIP, serviceDomains)
 
 	browserPath := config.BrowserHostsFile()
 	if err := os.MkdirAll(filepath.Dir(browserPath), 0755); err != nil {

--- a/internal/podman/hosts_service_domain_test.go
+++ b/internal/podman/hosts_service_domain_test.go
@@ -1,0 +1,53 @@
+package podman
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// A presigned URL carries its host in the signature, so the app container has
+// to reach the service by the same name the browser will use. Without this the
+// name resolves only on the host and the app cannot sign for it at all.
+func TestRenderContainerHosts_ResolvesServiceDomainsToNginx(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if cfg.Services == nil {
+		cfg.Services = map[string]config.ServiceConfig{}
+	}
+	sc := cfg.Services["rustfs"]
+	sc.Domain = "rustfs.test"
+	cfg.Services["rustfs"] = sc
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	reg := &config.SiteRegistry{Sites: []config.Site{{Name: "shop", Domains: []string{"shop.test"}}}}
+	got := renderContainerHosts(reg, "169.254.1.2", "10.89.0.3")
+
+	if !strings.Contains(got, "10.89.0.3 rustfs.test\n") {
+		t.Errorf("service domain missing from the container hosts file:\n%s", got)
+	}
+	if !strings.Contains(got, "10.89.0.3 shop.test\n") {
+		t.Errorf("site domain missing from the container hosts file:\n%s", got)
+	}
+}
+
+func TestRenderContainerHosts_NoServiceDomainsAddsNothing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	reg := &config.SiteRegistry{Sites: []config.Site{{Name: "shop", Domains: []string{"shop.test"}}}}
+	got := renderContainerHosts(reg, "169.254.1.2", "10.89.0.3")
+	if strings.Count(got, "10.89.0.3") != 1 {
+		t.Errorf("expected only the site entry, got:\n%s", got)
+	}
+}

--- a/internal/podman/hosts_service_domain_test.go
+++ b/internal/podman/hosts_service_domain_test.go
@@ -11,26 +11,8 @@ import (
 // to reach the service by the same name the browser will use. Without this the
 // name resolves only on the host and the app cannot sign for it at all.
 func TestRenderContainerHosts_ResolvesServiceDomainsToNginx(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", tmp)
-	t.Setenv("XDG_DATA_HOME", tmp)
-
-	cfg, err := config.LoadGlobal()
-	if err != nil {
-		t.Fatalf("LoadGlobal: %v", err)
-	}
-	if cfg.Services == nil {
-		cfg.Services = map[string]config.ServiceConfig{}
-	}
-	sc := cfg.Services["rustfs"]
-	sc.Domain = "rustfs.test"
-	cfg.Services["rustfs"] = sc
-	if err := config.SaveGlobal(cfg); err != nil {
-		t.Fatalf("SaveGlobal: %v", err)
-	}
-
 	reg := &config.SiteRegistry{Sites: []config.Site{{Name: "shop", Domains: []string{"shop.test"}}}}
-	got := renderContainerHosts(reg, "169.254.1.2", "10.89.0.3")
+	got := renderContainerHosts(reg, "169.254.1.2", "10.89.0.3", map[string]string{"rustfs": "rustfs.test"})
 
 	if !strings.Contains(got, "10.89.0.3 rustfs.test\n") {
 		t.Errorf("service domain missing from the container hosts file:\n%s", got)
@@ -41,13 +23,22 @@ func TestRenderContainerHosts_ResolvesServiceDomainsToNginx(t *testing.T) {
 }
 
 func TestRenderContainerHosts_NoServiceDomainsAddsNothing(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", tmp)
-	t.Setenv("XDG_DATA_HOME", tmp)
-
 	reg := &config.SiteRegistry{Sites: []config.Site{{Name: "shop", Domains: []string{"shop.test"}}}}
-	got := renderContainerHosts(reg, "169.254.1.2", "10.89.0.3")
+	got := renderContainerHosts(reg, "169.254.1.2", "10.89.0.3", nil)
 	if strings.Count(got, "10.89.0.3") != 1 {
 		t.Errorf("expected only the site entry, got:\n%s", got)
+	}
+}
+
+// Two runs of the same configuration have to produce the same file, or the
+// change detection that decides whether to rewrite it fires on map order alone.
+func TestRenderContainerHosts_ServiceDomainsAreOrdered(t *testing.T) {
+	reg := &config.SiteRegistry{}
+	domains := map[string]string{"rustfs": "rustfs.test", "mailpit": "mail.test"}
+	first := renderContainerHosts(reg, "169.254.1.2", "10.89.0.3", domains)
+	for range 20 {
+		if got := renderContainerHosts(reg, "169.254.1.2", "10.89.0.3", domains); got != first {
+			t.Fatalf("output varies between runs:\n%s\n---\n%s", first, got)
+		}
 	}
 }

--- a/internal/podman/hosts_test.go
+++ b/internal/podman/hosts_test.go
@@ -73,7 +73,7 @@ func TestParseNginxIP(t *testing.T) {
 // it can never produce and rewrites the file on every tick.
 func TestParseNginxIP_RoundTripsRenderContainerHosts(t *testing.T) {
 	reg := &config.SiteRegistry{Sites: []config.Site{{Domains: []string{"blog.test"}}}}
-	rendered := renderContainerHosts(reg, "169.254.1.2", "10.89.7.11")
+	rendered := renderContainerHosts(reg, "169.254.1.2", "10.89.7.11", nil)
 	if got := parseNginxIP([]byte(rendered)); got != "10.89.7.11" {
 		t.Errorf("parseNginxIP(rendered) = %q, want %q", got, "10.89.7.11")
 	}
@@ -87,7 +87,7 @@ func TestReadNginxIPFromFile_MissingFile(t *testing.T) {
 }
 
 func TestRenderContainerHosts_EmptyRegistry(t *testing.T) {
-	got := renderContainerHosts(&config.SiteRegistry{}, "169.254.1.2", "10.89.0.2")
+	got := renderContainerHosts(&config.SiteRegistry{}, "169.254.1.2", "10.89.0.2", nil)
 	want := "127.0.0.1 localhost\n" +
 		"::1 localhost\n" +
 		"169.254.1.2 host.containers.internal host.docker.internal\n"
@@ -102,7 +102,7 @@ func TestRenderContainerHosts_SitesPointAtNginx(t *testing.T) {
 		{Name: "bar", Domains: []string{"bar.test", "admin-bar.test"}},
 	}}
 
-	got := renderContainerHosts(reg, "169.254.1.2", "10.89.0.2")
+	got := renderContainerHosts(reg, "169.254.1.2", "10.89.0.2", nil)
 
 	// host.containers.internal must use the host gateway, never nginx.
 	if !strings.Contains(got, "169.254.1.2 host.containers.internal host.docker.internal\n") {
@@ -125,7 +125,7 @@ func TestRenderContainerHosts_DistinctIPs(t *testing.T) {
 	reg := &config.SiteRegistry{Sites: []config.Site{
 		{Name: "x", Domains: []string{"x.test"}},
 	}}
-	got := renderContainerHosts(reg, "169.254.1.2", "10.89.0.2")
+	got := renderContainerHosts(reg, "169.254.1.2", "10.89.0.2", nil)
 
 	if strings.Contains(got, "169.254.1.2 x.test") {
 		t.Errorf("x.test must not resolve to host gateway:\n%s", got)
@@ -136,7 +136,7 @@ func TestRenderContainerHosts_DistinctIPs(t *testing.T) {
 }
 
 func TestRenderContainerHosts_PreservesLoopback(t *testing.T) {
-	got := renderContainerHosts(&config.SiteRegistry{}, "1.2.3.4", "5.6.7.8")
+	got := renderContainerHosts(&config.SiteRegistry{}, "1.2.3.4", "5.6.7.8", nil)
 	if !strings.HasPrefix(got, "127.0.0.1 localhost\n::1 localhost\n") {
 		t.Errorf("loopback entries missing or out of order:\n%s", got)
 	}

--- a/internal/serviceops/domain.go
+++ b/internal/serviceops/domain.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"path/filepath"
 	"regexp"
+	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -86,13 +88,23 @@ func ValidateServiceDomain(service, domain string) (string, error) {
 // SetServiceDomain gives a service a domain and serves it there: the vhost, its
 // certificate and the hosts entry the app containers resolve through all follow
 // from the one call, so the name works from both sides the moment it returns.
-func SetServiceDomain(service, domain string) (string, error) {
+// A port of 0 leaves the choice to the preset, then to the service's primary.
+func SetServiceDomain(service, domain string, port int) (string, error) {
 	if !config.IsDefaultPreset(service) && !ServiceInstalled(service) {
 		return "", fmt.Errorf("%q is not a built-in or installed service", service)
 	}
 	resolved, err := ValidateServiceDomain(service, domain)
 	if err != nil {
 		return "", err
+	}
+	// A port the service does not listen on writes a vhost that answers nothing,
+	// which is indistinguishable from the domain not working at all.
+	if port > 0 {
+		declared := serviceContainerPorts(service)
+		if len(declared) > 0 && !slices.Contains(declared, port) {
+			return "", fmt.Errorf("service %q does not expose port %d (it exposes %s)",
+				service, port, joinPorts(declared))
+		}
 	}
 	cfg, err := config.LoadGlobal()
 	if err != nil {
@@ -101,6 +113,7 @@ func SetServiceDomain(service, domain string) (string, error) {
 	svcCfg := cfg.Services[service]
 	previous := svcCfg.Domain
 	svcCfg.Domain = resolved
+	svcCfg.DomainPort = port
 	// Choosing a domain is the opposite of turning it off, so it clears the
 	// record that would keep the preset's default away.
 	svcCfg.DomainOptOut = false
@@ -180,7 +193,7 @@ func ApplyServiceDomain(service string) error {
 	if domain == "" {
 		return nil
 	}
-	port := servicePrimaryPort(service)
+	port := serviceDomainPort(service)
 	if port == 0 {
 		return fmt.Errorf("service %q declares no port to proxy to", service)
 	}
@@ -309,11 +322,28 @@ func ApplyServiceDomains() error {
 	return nil
 }
 
-// servicePrimaryPort is the container-internal port nginx proxies to. The
-// published host port is deliberately not used: nginx reaches the service
+// ServiceDomainPort is serviceDomainPort for callers outside this package: the
+// port a service's domain actually proxies to, so a surface can show it rather
+// than leave the user guessing which of a multi-port service answers.
+func ServiceDomainPort(service string) int { return serviceDomainPort(service) }
+
+// serviceDomainPort is the container-internal port nginx proxies the domain to.
+// The published host port is deliberately not used: nginx reaches the service
 // across the podman network, where the container port is what listens.
-func servicePrimaryPort(service string) int {
-	if sc := config.ServiceConfigFor(service); sc.Port > 0 {
+//
+// The user's own choice wins, then the preset's, then the service's primary
+// port. That last fallback is a guess and only right when the first mapping
+// happens to be the HTTP one, which is why a multi-port preset says so.
+func serviceDomainPort(service string) int {
+	sc := config.ServiceConfigFor(service)
+	if sc.DomainPort > 0 {
+		return sc.DomainPort
+	}
+	preset, perr := config.LoadPreset(service)
+	if perr == nil && preset != nil && preset.DomainPort > 0 {
+		return preset.DomainPort
+	}
+	if sc.Port > 0 {
 		return sc.Port
 	}
 	if svc, err := config.LoadCustomService(service); err == nil && svc != nil {
@@ -323,10 +353,57 @@ func servicePrimaryPort(service string) int {
 	}
 	// The global config entry is seeded later than the install that adopts the
 	// domain, so at that moment the only place the port exists is the preset.
-	if preset, err := config.LoadPreset(service); err == nil && preset != nil {
+	if perr == nil && preset != nil {
 		return config.MappingContainerPort(firstMapping(preset.Ports))
 	}
 	return 0
+}
+
+// serviceContainerPorts lists every container port a service declares, so a
+// requested one can be checked against what actually listens rather than being
+// written into a vhost that answers nothing.
+func serviceContainerPorts(service string) []int {
+	var ports []int
+	add := func(p int) {
+		if p <= 0 {
+			return
+		}
+		for _, seen := range ports {
+			if seen == p {
+				return
+			}
+		}
+		ports = append(ports, p)
+	}
+	if sc := config.ServiceConfigFor(service); sc.Port > 0 {
+		add(sc.Port)
+		for containerPort := range sc.PublishedPorts {
+			add(containerPort)
+		}
+		for _, mapping := range sc.ExtraPorts {
+			add(config.MappingContainerPort(mapping))
+		}
+	}
+	if svc, err := config.LoadCustomService(service); err == nil && svc != nil {
+		for _, mapping := range svc.Ports {
+			add(config.MappingContainerPort(mapping))
+		}
+	}
+	if preset, err := config.LoadPreset(service); err == nil && preset != nil {
+		for _, mapping := range preset.Ports {
+			add(config.MappingContainerPort(mapping))
+		}
+	}
+	return ports
+}
+
+// joinPorts renders a port list for an error the user has to act on.
+func joinPorts(ports []int) string {
+	out := make([]string, 0, len(ports))
+	for _, p := range ports {
+		out = append(out, strconv.Itoa(p))
+	}
+	return strings.Join(out, ", ")
 }
 
 func firstMapping(ports []string) string {

--- a/internal/serviceops/domain.go
+++ b/internal/serviceops/domain.go
@@ -1,0 +1,337 @@
+package serviceops
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/geodro/lerd/internal/certs"
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/nginx"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// The seams the domain flow talks to the rest of the machine through, swapped
+// in tests so the vhost, the certificate and the hosts file can be asserted
+// without an nginx to reload.
+var (
+	domainIssueCertFn = func(domain string) error {
+		return certs.IssueCert(domain, []string{domain}, filepath.Join(config.CertsDir(), "sites"))
+	}
+	domainVhostFn       = nginx.GenerateServiceProxyVhost
+	domainRemoveCertFn  = certs.RemoveSiteCerts
+	domainRemoveVhostFn = nginx.RemoveVhost
+	domainWriteHostsFn  = podman.WriteContainerHosts
+	domainReloadFn      = nginx.Reload
+	domainWaitServedFn  = waitDomainServed
+)
+
+// hostnameLabel is one label of a domain name: the shape nginx will accept as a
+// server_name and mkcert will sign.
+var hostnameLabel = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+// DefaultServiceDomain is the domain a service takes when the user names none:
+// the service's own name under the configured TLD.
+func DefaultServiceDomain(name string) string {
+	return name + "." + config.EffectiveTLD()
+}
+
+// ServiceDomainURL returns the https URL a service is reachable at from both
+// the app container and the browser, empty when the service has no domain.
+func ServiceDomainURL(name string) string {
+	if domain := config.ServiceDomain(name); domain != "" {
+		return "https://" + domain
+	}
+	return ""
+}
+
+// ValidateServiceDomain normalises a requested domain and rejects one that
+// nginx, mkcert or another site would refuse. A bare name is qualified with the
+// configured TLD, so `lerd service domain rustfs storage` means storage.test.
+func ValidateServiceDomain(service, domain string) (string, error) {
+	domain = strings.ToLower(strings.TrimSpace(strings.Trim(domain, ".")))
+	if domain == "" {
+		return "", fmt.Errorf("a domain is required")
+	}
+	tld := config.EffectiveTLD()
+	if !strings.Contains(domain, ".") {
+		domain += "." + tld
+	}
+	for _, label := range strings.Split(domain, ".") {
+		if !hostnameLabel.MatchString(label) {
+			return "", fmt.Errorf("invalid domain %q: use letters, digits and dashes", domain)
+		}
+	}
+	// Only the TLD lerd resolves can work: the name has to answer inside the app
+	// container and in the browser, and lerd owns no other suffix on either.
+	if !strings.HasSuffix(domain, "."+tld) {
+		return "", fmt.Errorf("domain %q must end in .%s, the TLD lerd resolves", domain, tld)
+	}
+	if site, err := config.IsDomainUsed(domain); err == nil && site != nil {
+		return "", fmt.Errorf("domain %q is already used by site %q", domain, site.Name)
+	}
+	for other, taken := range config.ServiceDomains() {
+		if taken == domain && other != service {
+			return "", fmt.Errorf("domain %q is already used by service %q", domain, other)
+		}
+	}
+	return domain, nil
+}
+
+// SetServiceDomain gives a service a domain and serves it there: the vhost, its
+// certificate and the hosts entry the app containers resolve through all follow
+// from the one call, so the name works from both sides the moment it returns.
+func SetServiceDomain(service, domain string) (string, error) {
+	if !config.IsDefaultPreset(service) && !ServiceInstalled(service) {
+		return "", fmt.Errorf("%q is not a built-in or installed service", service)
+	}
+	resolved, err := ValidateServiceDomain(service, domain)
+	if err != nil {
+		return "", err
+	}
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return "", err
+	}
+	svcCfg := cfg.Services[service]
+	previous := svcCfg.Domain
+	svcCfg.Domain = resolved
+	// Choosing a domain is the opposite of turning it off, so it clears the
+	// record that would keep the preset's default away.
+	svcCfg.DomainOptOut = false
+	cfg.Services[service] = svcCfg
+	if err := config.SaveGlobal(cfg); err != nil {
+		return "", err
+	}
+	// A renamed domain leaves its old vhost answering otherwise, and the stale
+	// server_name would keep winning for whoever still points at it.
+	if previous != "" && previous != resolved {
+		_ = domainRemoveVhostFn(previous)
+	}
+	if err := ApplyServiceDomain(service); err != nil {
+		return resolved, err
+	}
+	return resolved, nil
+}
+
+// RemoveServiceDomain takes the domain away and stops serving it. The service
+// itself is untouched: it stays reachable at lerd-<name> on the podman network.
+// The removal is recorded, not just applied: a preset that declares a default
+// domain would otherwise hand it straight back on the next reconcile.
+func RemoveServiceDomain(service string) error {
+	return removeServiceDomain(service, true)
+}
+
+// ClearServiceDomain stops serving the domain without recording a refusal. It is
+// what removing the service itself uses: the user said nothing about domains,
+// they removed a service, and a reinstall that came back without its default
+// would be the surprising outcome.
+func ClearServiceDomain(service string) error {
+	return removeServiceDomain(service, false)
+}
+
+func removeServiceDomain(service string, optOut bool) error {
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return err
+	}
+	svcCfg := cfg.Services[service]
+	if svcCfg.Domain == "" {
+		return fmt.Errorf("service %q has no domain", service)
+	}
+	domain := svcCfg.Domain
+	svcCfg.Domain = ""
+	svcCfg.DomainOptOut = optOut
+	cfg.Services[service] = svcCfg
+	if err := config.SaveGlobal(cfg); err != nil {
+		return err
+	}
+	if err := domainRemoveVhostFn(domain); err != nil {
+		return fmt.Errorf("removing vhost for %s: %w", domain, err)
+	}
+	// The certificate goes with the vhost, the way unlinking a site drops its
+	// own: nothing serves the name any more, so leaving it is a key on disk for
+	// a host that answers nowhere.
+	domainRemoveCertFn(domain)
+	_ = domainWriteHostsFn()
+	return reloadNginxIfRunning()
+}
+
+// reloadNginxIfRunning treats a stopped nginx as success. The config on disk is
+// what matters here; whoever starts nginx next reads it, and failing the command
+// would report a domain as unset when it is written and will serve on start.
+func reloadNginxIfRunning() error {
+	if err := domainReloadFn(); err != nil && !errors.Is(err, nginx.ErrNotRunning) {
+		return err
+	}
+	return nil
+}
+
+// ApplyServiceDomain writes everything a service's domain needs to answer:
+// its certificate, its vhost, and the hosts entry the app containers read. It
+// is idempotent, so the start and install reconciles can call it blindly.
+func ApplyServiceDomain(service string) error {
+	domain := config.ServiceDomain(service)
+	if domain == "" {
+		return nil
+	}
+	port := servicePrimaryPort(service)
+	if port == 0 {
+		return fmt.Errorf("service %q declares no port to proxy to", service)
+	}
+	if err := domainIssueCertFn(domain); err != nil {
+		return fmt.Errorf("issuing certificate for %s: %w", domain, err)
+	}
+	if err := domainVhostFn(domain, "lerd-"+service, port, true); err != nil {
+		return fmt.Errorf("writing vhost for %s: %w", domain, err)
+	}
+	if err := domainWriteHostsFn(); err != nil {
+		return fmt.Errorf("updating container hosts: %w", err)
+	}
+	if err := reloadNginxIfRunning(); err != nil {
+		return err
+	}
+	// An nginx reload is asynchronous: the old workers keep answering until they
+	// cycle. Returning here without waiting hands back a URL that the very next
+	// request cannot reach yet, which reads as the domain simply not working.
+	if domainWaitServedFn(domain, domainReadyTimeout) {
+		return nil
+	}
+	// The signal can be lost outright: an install regenerates units and restarts
+	// nginx around the same moment, and a reload that lands in that window is
+	// accepted by a process that is on its way out. One retry costs a signal and
+	// is the difference between a domain that works and one the user has to
+	// reload nginx for by hand.
+	if err := reloadNginxIfRunning(); err != nil {
+		return err
+	}
+	domainWaitServedFn(domain, domainReadyTimeout)
+	return nil
+}
+
+// domainReadyTimeout bounds the wait for nginx to start serving a new service
+// domain. A reload is quick; this only has to outlast one worker cycle, and a
+// vhost that never comes up must report rather than hang the command.
+const domainReadyTimeout = 5 * time.Second
+
+// waitDomainServed blocks until the domain answers over TLS, so the caller does
+// not return while the previous config is still being served. Any response is
+// enough: the service's own status says nothing about whether nginx picked the
+// vhost up, and requiring 200 would wait out a service that is merely empty.
+func waitDomainServed(domain string, timeout time.Duration) bool {
+	if domain == "" {
+		return true
+	}
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+		// The certificate is lerd's own and only the vhost being live is being
+		// measured, so it is neither verified nor followed here.
+		Transport:     &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}, //nolint:gosec
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := client.Get("https://" + domain + "/") //nolint:noctx
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		if err == nil && resp != nil {
+			return true
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return false
+}
+
+// AdoptDefaultServiceDomains gives every installed service the domain its preset
+// declares, unless the user already chose one or took it away. It is what makes
+// the domain arrive with an update rather than waiting for each user to find a
+// command: a service whose URLs reach a browser is broken without one, and the
+// preset is where that fact belongs. Returns the services that took a domain.
+//
+// Idempotent: once adopted the domain is an ordinary explicit value, so later
+// runs see it set and do nothing.
+func AdoptDefaultServiceDomains() []string {
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return nil
+	}
+	var adopted []string
+	for _, name := range config.DefaultPresetNames() {
+		svcCfg := cfg.Services[name]
+		if svcCfg.Domain != "" || svcCfg.DomainOptOut {
+			continue
+		}
+		if !UnitInstalledFn("lerd-" + name) {
+			continue
+		}
+		preset, perr := config.LoadPreset(name)
+		if perr != nil || preset.Domain == "" {
+			continue
+		}
+		// A default that collides with a site or another service is not worth
+		// failing a start over; the user can name a free one by hand.
+		resolved, verr := ValidateServiceDomain(name, preset.Domain)
+		if verr != nil {
+			continue
+		}
+		svcCfg.Domain = resolved
+		cfg.Services[name] = svcCfg
+		if err := config.SaveGlobal(cfg); err != nil {
+			return adopted
+		}
+		if err := ApplyServiceDomain(name); err != nil {
+			continue
+		}
+		adopted = append(adopted, name)
+	}
+	return adopted
+}
+
+// ApplyServiceDomains reapplies every configured service domain. Called from
+// the reconcile paths so a domain survives a machine that came up with no
+// vhosts, or a certificate that aged out.
+func ApplyServiceDomains() error {
+	var failed []string
+	for service := range config.ServiceDomains() {
+		if err := ApplyServiceDomain(service); err != nil {
+			failed = append(failed, fmt.Sprintf("%s: %v", service, err))
+		}
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("applying service domains: %s", strings.Join(failed, "; "))
+	}
+	return nil
+}
+
+// servicePrimaryPort is the container-internal port nginx proxies to. The
+// published host port is deliberately not used: nginx reaches the service
+// across the podman network, where the container port is what listens.
+func servicePrimaryPort(service string) int {
+	if sc := config.ServiceConfigFor(service); sc.Port > 0 {
+		return sc.Port
+	}
+	if svc, err := config.LoadCustomService(service); err == nil && svc != nil {
+		if port := config.MappingContainerPort(firstMapping(svc.Ports)); port > 0 {
+			return port
+		}
+	}
+	// The global config entry is seeded later than the install that adopts the
+	// domain, so at that moment the only place the port exists is the preset.
+	if preset, err := config.LoadPreset(service); err == nil && preset != nil {
+		return config.MappingContainerPort(firstMapping(preset.Ports))
+	}
+	return 0
+}
+
+func firstMapping(ports []string) string {
+	if len(ports) == 0 {
+		return ""
+	}
+	return ports[0]
+}

--- a/internal/serviceops/domain_test.go
+++ b/internal/serviceops/domain_test.go
@@ -104,7 +104,7 @@ func TestSetServiceDomain_PersistsAndServesIt(t *testing.T) {
 	domainTestConfig(t)
 	rec := stubDomainSeams(t)
 
-	domain, err := SetServiceDomain("rustfs", "rustfs")
+	domain, err := SetServiceDomain("rustfs", "rustfs", 0)
 	if err != nil {
 		t.Fatalf("SetServiceDomain: %v", err)
 	}
@@ -133,10 +133,10 @@ func TestSetServiceDomain_RenameDropsTheOldVhost(t *testing.T) {
 	domainTestConfig(t)
 	rec := stubDomainSeams(t)
 
-	if _, err := SetServiceDomain("rustfs", "rustfs"); err != nil {
+	if _, err := SetServiceDomain("rustfs", "rustfs", 0); err != nil {
 		t.Fatalf("first SetServiceDomain: %v", err)
 	}
-	if _, err := SetServiceDomain("rustfs", "storage"); err != nil {
+	if _, err := SetServiceDomain("rustfs", "storage", 0); err != nil {
 		t.Fatalf("second SetServiceDomain: %v", err)
 	}
 	if len(rec.removed) != 1 || rec.removed[0] != "rustfs.test" {
@@ -148,7 +148,7 @@ func TestRemoveServiceDomain_ClearsConfigAndVhost(t *testing.T) {
 	domainTestConfig(t)
 	rec := stubDomainSeams(t)
 
-	if _, err := SetServiceDomain("rustfs", "rustfs"); err != nil {
+	if _, err := SetServiceDomain("rustfs", "rustfs", 0); err != nil {
 		t.Fatalf("SetServiceDomain: %v", err)
 	}
 	if err := RemoveServiceDomain("rustfs"); err != nil {
@@ -217,7 +217,7 @@ func TestAdoptDefaultServiceDomains_RespectsAnExplicitRemoval(t *testing.T) {
 	UnitInstalledFn = func(string) bool { return true }
 	t.Cleanup(func() { UnitInstalledFn = prev })
 
-	if _, err := SetServiceDomain("rustfs", "rustfs"); err != nil {
+	if _, err := SetServiceDomain("rustfs", "rustfs", 0); err != nil {
 		t.Fatalf("SetServiceDomain: %v", err)
 	}
 	if err := RemoveServiceDomain("rustfs"); err != nil {
@@ -254,13 +254,13 @@ func TestSetServiceDomain_ClearsAnEarlierOptOut(t *testing.T) {
 	UnitInstalledFn = func(string) bool { return true }
 	t.Cleanup(func() { UnitInstalledFn = prev })
 
-	if _, err := SetServiceDomain("rustfs", "rustfs"); err != nil {
+	if _, err := SetServiceDomain("rustfs", "rustfs", 0); err != nil {
 		t.Fatalf("SetServiceDomain: %v", err)
 	}
 	if err := RemoveServiceDomain("rustfs"); err != nil {
 		t.Fatalf("RemoveServiceDomain: %v", err)
 	}
-	if _, err := SetServiceDomain("rustfs", "storage"); err != nil {
+	if _, err := SetServiceDomain("rustfs", "storage", 0); err != nil {
 		t.Fatalf("second SetServiceDomain: %v", err)
 	}
 	if config.ServiceConfigFor("rustfs").DomainOptOut {
@@ -277,7 +277,7 @@ func TestClearServiceDomain_DoesNotRecordARefusal(t *testing.T) {
 	UnitInstalledFn = func(string) bool { return true }
 	t.Cleanup(func() { UnitInstalledFn = prev })
 
-	if _, err := SetServiceDomain("rustfs", "rustfs"); err != nil {
+	if _, err := SetServiceDomain("rustfs", "rustfs", 0); err != nil {
 		t.Fatalf("SetServiceDomain: %v", err)
 	}
 	if err := ClearServiceDomain("rustfs"); err != nil {
@@ -294,7 +294,7 @@ func TestClearServiceDomain_DoesNotRecordARefusal(t *testing.T) {
 // The global config entry for a default preset is seeded later than the install
 // that adopts its domain, so resolving the port only from config left the vhost
 // unwritten and the domain answering nowhere until the user set it by hand.
-func TestServicePrimaryPort_FallsBackToThePreset(t *testing.T) {
+func TestServiceDomainPort_FallsBackToThePreset(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	t.Setenv("XDG_DATA_HOME", tmp)
@@ -311,7 +311,60 @@ func TestServicePrimaryPort_FallsBackToThePreset(t *testing.T) {
 		t.Fatalf("SaveGlobal: %v", err)
 	}
 
-	if got := servicePrimaryPort("rustfs"); got != 9000 {
+	if got := serviceDomainPort("rustfs"); got != 9000 {
 		t.Errorf("port = %d, want 9000 from the preset", got)
+	}
+}
+
+// A multi-port service says which port its domain serves, because guessing the
+// first mapping lands on SMTP for a mail catcher whose web UI is the point.
+func TestServiceDomainPort_PrefersThePresetDeclaration(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if cfg.Services == nil {
+		cfg.Services = map[string]config.ServiceConfig{}
+	}
+	// The primary port is the SMTP one, which is what the old resolver returned.
+	cfg.Services["mailpit"] = config.ServiceConfig{Port: 1025}
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+	if got := serviceDomainPort("mailpit"); got != 8025 {
+		t.Errorf("port = %d, want the preset's 8025", got)
+	}
+}
+
+// An explicit choice outranks the preset, for a service whose useful port only
+// the user knows.
+func TestServiceDomainPort_UserChoiceWins(t *testing.T) {
+	domainTestConfig(t)
+	stubDomainSeams(t)
+
+	if _, err := SetServiceDomain("rustfs", "console.rustfs.test", 9001); err != nil {
+		t.Fatalf("SetServiceDomain: %v", err)
+	}
+	if got := serviceDomainPort("rustfs"); got != 9001 {
+		t.Errorf("port = %d, want the requested 9001", got)
+	}
+}
+
+// A port nothing listens on writes a vhost that answers nothing, which reads as
+// the domain simply not working rather than as the typo it is.
+func TestSetServiceDomain_RejectsAPortTheServiceDoesNotExpose(t *testing.T) {
+	domainTestConfig(t)
+	stubDomainSeams(t)
+
+	_, err := SetServiceDomain("rustfs", "rustfs.test", 1234)
+	if err == nil {
+		t.Fatal("expected a port the service does not expose to be refused")
+	}
+	if !strings.Contains(err.Error(), "9000") {
+		t.Errorf("the error should name the ports it does expose, got %v", err)
 	}
 }

--- a/internal/serviceops/domain_test.go
+++ b/internal/serviceops/domain_test.go
@@ -1,0 +1,317 @@
+package serviceops
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+type domainCalls struct {
+	certs       []string
+	removedCert []string
+	vhosts      []string
+	removed     []string
+	hosts       int
+	reloads     int
+}
+
+func stubDomainSeams(t *testing.T) *domainCalls {
+	t.Helper()
+	rec := &domainCalls{}
+	prevCert, prevVhost, prevRemove, prevHosts, prevReload, prevRemoveCert :=
+		domainIssueCertFn, domainVhostFn, domainRemoveVhostFn, domainWriteHostsFn, domainReloadFn, domainRemoveCertFn
+	domainRemoveCertFn = func(domain string) { rec.removedCert = append(rec.removedCert, domain) }
+	domainIssueCertFn = func(domain string) error {
+		rec.certs = append(rec.certs, domain)
+		return nil
+	}
+	domainVhostFn = func(domain, upstreamHost string, upstreamPort int, ssl bool) error {
+		rec.vhosts = append(rec.vhosts, fmt.Sprint(domain, "|", upstreamHost, "|", upstreamPort, "|", ssl))
+		return nil
+	}
+	domainRemoveVhostFn = func(domain string) error {
+		rec.removed = append(rec.removed, domain)
+		return nil
+	}
+	domainWriteHostsFn = func() error { rec.hosts++; return nil }
+	prevWait := domainWaitServedFn
+	domainWaitServedFn = func(string, time.Duration) bool { return true }
+	domainReloadFn = func() error { rec.reloads++; return nil }
+	t.Cleanup(func() {
+		domainIssueCertFn, domainVhostFn, domainRemoveVhostFn, domainWriteHostsFn, domainReloadFn, domainRemoveCertFn =
+			prevCert, prevVhost, prevRemove, prevHosts, prevReload, prevRemoveCert
+		domainWaitServedFn = prevWait
+	})
+	return rec
+}
+
+func domainTestConfig(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if cfg.Services == nil {
+		cfg.Services = map[string]config.ServiceConfig{}
+	}
+	sc := cfg.Services["rustfs"]
+	sc.Port = 9000
+	cfg.Services["rustfs"] = sc
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+}
+
+// A bare name is the common way to type one, and lerd resolves exactly one TLD,
+// so the qualification has to happen here rather than becoming a name that
+// answers nowhere.
+func TestValidateServiceDomain_QualifiesABareName(t *testing.T) {
+	domainTestConfig(t)
+	got, err := ValidateServiceDomain("rustfs", "storage")
+	if err != nil {
+		t.Fatalf("ValidateServiceDomain: %v", err)
+	}
+	if got != "storage.test" {
+		t.Errorf("domain = %q, want storage.test", got)
+	}
+}
+
+func TestValidateServiceDomain_RejectsAForeignTLD(t *testing.T) {
+	domainTestConfig(t)
+	if _, err := ValidateServiceDomain("rustfs", "storage.local"); err == nil {
+		t.Fatal("expected a foreign TLD to be rejected")
+	}
+}
+
+func TestValidateServiceDomain_RejectsADomainASiteOwns(t *testing.T) {
+	domainTestConfig(t)
+	if err := config.AddSite(config.Site{Name: "shop", Domains: []string{"shop.test"}, Path: t.TempDir()}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+	_, err := ValidateServiceDomain("rustfs", "shop.test")
+	if err == nil || !strings.Contains(err.Error(), "shop") {
+		t.Fatalf("expected the site collision to be reported, got %v", err)
+	}
+}
+
+func TestSetServiceDomain_PersistsAndServesIt(t *testing.T) {
+	domainTestConfig(t)
+	rec := stubDomainSeams(t)
+
+	domain, err := SetServiceDomain("rustfs", "rustfs")
+	if err != nil {
+		t.Fatalf("SetServiceDomain: %v", err)
+	}
+	if domain != "rustfs.test" {
+		t.Errorf("domain = %q, want rustfs.test", domain)
+	}
+	if config.ServiceDomain("rustfs") != "rustfs.test" {
+		t.Errorf("domain not persisted, got %q", config.ServiceDomain("rustfs"))
+	}
+	if len(rec.certs) != 1 || rec.certs[0] != "rustfs.test" {
+		t.Errorf("expected a certificate for rustfs.test, got %v", rec.certs)
+	}
+	// nginx reaches the service across the podman network, so the vhost has to
+	// point at the container port rather than the published host one.
+	if len(rec.vhosts) != 1 || rec.vhosts[0] != "rustfs.test|lerd-rustfs|9000|true" {
+		t.Errorf("unexpected vhost: %v", rec.vhosts)
+	}
+	if rec.hosts == 0 || rec.reloads == 0 {
+		t.Errorf("expected the hosts file and nginx to be refreshed, got hosts=%d reloads=%d", rec.hosts, rec.reloads)
+	}
+}
+
+// A renamed domain leaves the old vhost answering otherwise, and whoever still
+// points at the old name keeps being served by it.
+func TestSetServiceDomain_RenameDropsTheOldVhost(t *testing.T) {
+	domainTestConfig(t)
+	rec := stubDomainSeams(t)
+
+	if _, err := SetServiceDomain("rustfs", "rustfs"); err != nil {
+		t.Fatalf("first SetServiceDomain: %v", err)
+	}
+	if _, err := SetServiceDomain("rustfs", "storage"); err != nil {
+		t.Fatalf("second SetServiceDomain: %v", err)
+	}
+	if len(rec.removed) != 1 || rec.removed[0] != "rustfs.test" {
+		t.Errorf("expected the old vhost to be removed, got %v", rec.removed)
+	}
+}
+
+func TestRemoveServiceDomain_ClearsConfigAndVhost(t *testing.T) {
+	domainTestConfig(t)
+	rec := stubDomainSeams(t)
+
+	if _, err := SetServiceDomain("rustfs", "rustfs"); err != nil {
+		t.Fatalf("SetServiceDomain: %v", err)
+	}
+	if err := RemoveServiceDomain("rustfs"); err != nil {
+		t.Fatalf("RemoveServiceDomain: %v", err)
+	}
+	if config.ServiceDomain("rustfs") != "" {
+		t.Errorf("domain still set: %q", config.ServiceDomain("rustfs"))
+	}
+	if len(rec.removed) != 1 || rec.removed[0] != "rustfs.test" {
+		t.Errorf("expected the vhost to be removed, got %v", rec.removed)
+	}
+	// A key left behind for a host nothing serves is the same wart unlinking a
+	// site avoids by dropping its certificate with it.
+	if len(rec.removedCert) != 1 || rec.removedCert[0] != "rustfs.test" {
+		t.Errorf("expected the certificate to be removed, got %v", rec.removedCert)
+	}
+}
+
+func TestApplyServiceDomain_NoDomainIsANoOp(t *testing.T) {
+	domainTestConfig(t)
+	rec := stubDomainSeams(t)
+
+	if err := ApplyServiceDomain("rustfs"); err != nil {
+		t.Fatalf("ApplyServiceDomain: %v", err)
+	}
+	if len(rec.certs) != 0 || len(rec.vhosts) != 0 {
+		t.Errorf("expected nothing to be written, got certs=%v vhosts=%v", rec.certs, rec.vhosts)
+	}
+}
+
+func TestDefaultServiceDomain_UsesTheConfiguredTLD(t *testing.T) {
+	domainTestConfig(t)
+	if got := DefaultServiceDomain("rustfs"); got != "rustfs.test" {
+		t.Errorf("DefaultServiceDomain = %q, want rustfs.test", got)
+	}
+}
+
+// The fix has to arrive with the update. A service whose preset declares a
+// domain and whose user never chose one takes it on the next reconcile.
+func TestAdoptDefaultServiceDomains_TakesThePresetDefault(t *testing.T) {
+	domainTestConfig(t)
+	rec := stubDomainSeams(t)
+	prev := UnitInstalledFn
+	UnitInstalledFn = func(string) bool { return true }
+	t.Cleanup(func() { UnitInstalledFn = prev })
+
+	adopted := AdoptDefaultServiceDomains()
+
+	if len(adopted) != 1 || adopted[0] != "rustfs" {
+		t.Fatalf("expected rustfs to adopt its preset domain, got %v", adopted)
+	}
+	if got := config.ServiceDomain("rustfs"); got != "rustfs.test" {
+		t.Errorf("domain = %q, want rustfs.test", got)
+	}
+	if len(rec.vhosts) != 1 {
+		t.Errorf("expected the domain to be served, got %v", rec.vhosts)
+	}
+}
+
+// Taking the domain away has to stick, or the next start hands it straight back
+// and the removal reads as broken.
+func TestAdoptDefaultServiceDomains_RespectsAnExplicitRemoval(t *testing.T) {
+	domainTestConfig(t)
+	stubDomainSeams(t)
+	prev := UnitInstalledFn
+	UnitInstalledFn = func(string) bool { return true }
+	t.Cleanup(func() { UnitInstalledFn = prev })
+
+	if _, err := SetServiceDomain("rustfs", "rustfs"); err != nil {
+		t.Fatalf("SetServiceDomain: %v", err)
+	}
+	if err := RemoveServiceDomain("rustfs"); err != nil {
+		t.Fatalf("RemoveServiceDomain: %v", err)
+	}
+
+	if adopted := AdoptDefaultServiceDomains(); len(adopted) != 0 {
+		t.Fatalf("a removed domain must not be handed back, got %v", adopted)
+	}
+	if got := config.ServiceDomain("rustfs"); got != "" {
+		t.Errorf("domain = %q, want it to stay removed", got)
+	}
+}
+
+// A service that is not installed has nothing to serve on the name.
+func TestAdoptDefaultServiceDomains_SkipsAnUninstalledService(t *testing.T) {
+	domainTestConfig(t)
+	stubDomainSeams(t)
+	prev := UnitInstalledFn
+	UnitInstalledFn = func(string) bool { return false }
+	t.Cleanup(func() { UnitInstalledFn = prev })
+
+	if adopted := AdoptDefaultServiceDomains(); len(adopted) != 0 {
+		t.Fatalf("expected nothing adopted for an uninstalled service, got %v", adopted)
+	}
+}
+
+// Choosing a domain by hand is the opposite of turning it off, so it has to
+// clear the record that keeps the default away.
+func TestSetServiceDomain_ClearsAnEarlierOptOut(t *testing.T) {
+	domainTestConfig(t)
+	stubDomainSeams(t)
+	prev := UnitInstalledFn
+	UnitInstalledFn = func(string) bool { return true }
+	t.Cleanup(func() { UnitInstalledFn = prev })
+
+	if _, err := SetServiceDomain("rustfs", "rustfs"); err != nil {
+		t.Fatalf("SetServiceDomain: %v", err)
+	}
+	if err := RemoveServiceDomain("rustfs"); err != nil {
+		t.Fatalf("RemoveServiceDomain: %v", err)
+	}
+	if _, err := SetServiceDomain("rustfs", "storage"); err != nil {
+		t.Fatalf("second SetServiceDomain: %v", err)
+	}
+	if config.ServiceConfigFor("rustfs").DomainOptOut {
+		t.Error("choosing a domain should clear the opt-out")
+	}
+}
+
+// Removing the service is not a statement about domains. Recording a refusal
+// there would leave a reinstall silently without the default its preset ships.
+func TestClearServiceDomain_DoesNotRecordARefusal(t *testing.T) {
+	domainTestConfig(t)
+	stubDomainSeams(t)
+	prev := UnitInstalledFn
+	UnitInstalledFn = func(string) bool { return true }
+	t.Cleanup(func() { UnitInstalledFn = prev })
+
+	if _, err := SetServiceDomain("rustfs", "rustfs"); err != nil {
+		t.Fatalf("SetServiceDomain: %v", err)
+	}
+	if err := ClearServiceDomain("rustfs"); err != nil {
+		t.Fatalf("ClearServiceDomain: %v", err)
+	}
+	if config.ServiceConfigFor("rustfs").DomainOptOut {
+		t.Fatal("removing the service must not count as refusing the domain")
+	}
+	if adopted := AdoptDefaultServiceDomains(); len(adopted) != 1 {
+		t.Errorf("expected the default to come back on reinstall, got %v", adopted)
+	}
+}
+
+// The global config entry for a default preset is seeded later than the install
+// that adopts its domain, so resolving the port only from config left the vhost
+// unwritten and the domain answering nowhere until the user set it by hand.
+func TestServicePrimaryPort_FallsBackToThePreset(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if cfg.Services == nil {
+		cfg.Services = map[string]config.ServiceConfig{}
+	}
+	cfg.Services["rustfs"] = config.ServiceConfig{}
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	if got := servicePrimaryPort("rustfs"); got != 9000 {
+		t.Errorf("port = %d, want 9000 from the preset", got)
+	}
+}

--- a/internal/serviceops/remove.go
+++ b/internal/serviceops/remove.go
@@ -159,6 +159,14 @@ func RemoveService(name string, opts RemoveOptions, emit func(PhaseEvent)) error
 		}
 	}
 
+	// A domain outlives nothing: its vhost would keep answering for a service
+	// that is gone, and the certificate would go on being renewed.
+	if config.ServiceDomain(name) != "" {
+		if err := ClearServiceDomain(name); err != nil {
+			emit(PhaseEvent{Phase: "removing_domain", Message: err.Error()})
+		}
+	}
+
 	emit(PhaseEvent{Phase: "removing_quadlet", Unit: unit})
 	if err := removeQuadletFn(unit); err != nil {
 		return fmt.Errorf("remove quadlet %s: %w", unit, err)

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -401,6 +401,13 @@ func InstallPresetStreaming(name, version string, emit func(PhaseEvent)) (*confi
 	if err := installReprovFn(svc.Name, emit); err != nil {
 		emit(PhaseEvent{Phase: "reprovisioning_failed", Message: err.Error()})
 	}
+	// A service that needs a domain needs it from the moment it exists, not from
+	// the next start: the first thing the user does with a fresh object store is
+	// point an app at it, and a URL signed before the name exists is already
+	// wrong.
+	for _, adopted := range AdoptDefaultServiceDomains() {
+		emit(PhaseEvent{Phase: "domain_adopted", Message: adopted + ": " + config.ServiceDomain(adopted)})
+	}
 	return svc, nil
 }
 
@@ -421,6 +428,9 @@ func InstallPresetByName(name, version string) (*config.CustomService, error) {
 	if err := registerPreset(svc); err != nil {
 		return nil, err
 	}
+	// Same reason as the streaming path: the name has to exist before anything
+	// signs a URL against it.
+	AdoptDefaultServiceDomains()
 	return svc, nil
 }
 

--- a/internal/sitedoctor/server_bucket.go
+++ b/internal/sitedoctor/server_bucket.go
@@ -135,7 +135,7 @@ func OwnedEntitiesFor(path string) []OwnedEntity {
 	}
 	var out []OwnedEntity
 	for _, service := range servicesDeclaringOwnedEntities() {
-		if !envReferencesService(vals, service) {
+		if !envReferencesService(vals, service, config.ServiceDomain(service)) {
 			continue
 		}
 		for _, spec := range serviceops.ServiceEntities(service) {
@@ -153,10 +153,16 @@ func OwnedEntitiesFor(path string) []OwnedEntity {
 }
 
 // envReferencesService reports whether any value in the env file points at the
-// service's container, the same test that links an entity row to its site.
-func envReferencesService(vals map[string]string, service string) bool {
+// service, by its container name or by the domain it is served on. A project
+// rewritten to the domain names the container nowhere, and checking only the
+// container name would quietly stop judging exactly the projects the domain was
+// turned on for.
+func envReferencesService(vals map[string]string, service, domain string) bool {
 	for _, v := range vals {
 		if strings.Contains(v, "lerd-"+service) {
+			return true
+		}
+		if domain != "" && strings.Contains(v, domain) {
 			return true
 		}
 	}

--- a/internal/sitedoctor/server_bucket_test.go
+++ b/internal/sitedoctor/server_bucket_test.go
@@ -126,3 +126,41 @@ func TestForgetEntities_DropsTheCachedList(t *testing.T) {
 		t.Fatalf("expected ok after the cache was dropped, got %+v", c)
 	}
 }
+
+// Once a project is wired to the service's domain its env names the container
+// nowhere, and a check that looked only for the container name would stop
+// judging exactly the projects the domain was turned on for.
+func TestCheckServerBucket_StillJudgesASiteWiredToTheDomain(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if cfg.Services == nil {
+		cfg.Services = map[string]config.ServiceConfig{}
+	}
+	sc := cfg.Services["rustfs"]
+	sc.Domain = "rustfs.test"
+	cfg.Services["rustfs"] = sc
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	dir := t.TempDir()
+	env := "FILESYSTEM_DISK=s3\nAWS_BUCKET=uploads\nAWS_ENDPOINT=https://rustfs.test\n"
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(env), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	restore := stubEntityLister(func(string, *config.EntitySpec) ([]string, error) {
+		return []string{"other"}, nil
+	})
+	defer restore()
+
+	c, produced := checkServerBucket(dir)
+	if !produced || c.Status != StatusFail {
+		t.Fatalf("check = %+v (produced=%v), want the missing bucket reported", c, produced)
+	}
+}

--- a/internal/ui/entities.go
+++ b/internal/ui/entities.go
@@ -46,6 +46,25 @@ type entityRowResponse struct {
 	Name   string   `json:"name"`
 	Values []string `json:"values"`
 	Site   string   `json:"site,omitempty"`
+	// URL is where the entity is addressable, empty when the service exposes no
+	// browsable base for it. It follows the service's domain when it has one, so
+	// the list shows the address an app and a browser actually share rather than
+	// a container name that resolves in neither.
+	URL string `json:"url,omitempty"`
+}
+
+// entityBaseURL is the address prefix an entity a site owns is reachable at:
+// the service's own domain when it has one, otherwise the published loopback
+// port. Empty when the service publishes nothing to reach it on.
+func entityBaseURL(service string) string {
+	if url := serviceops.ServiceDomainURL(service); url != "" {
+		return url
+	}
+	ports := config.ServiceConfigFor(service).HostPorts()
+	if len(ports) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("http://localhost:%d", ports[0])
 }
 
 // entityOwnerIndex maps entity names to the domain of the site whose .env
@@ -177,12 +196,22 @@ func entityOverview(service string, specs []config.EntitySpec) []entityKindRespo
 				kind.Error = err.Error()
 			} else {
 				owners := entityOwnerIndex(service, spec.OwnerEnv)
+				// Only an entity a site addresses by name has a URL to show; the
+				// declaration says which kinds those are.
+				base := ""
+				if spec.OwnerEnv != "" {
+					base = entityBaseURL(service)
+				}
 				for _, row := range rows {
 					values := row.Values
 					if values == nil {
 						values = []string{}
 					}
-					kind.Rows = append(kind.Rows, entityRowResponse{Name: row.Name, Values: values, Site: owners[row.Name]})
+					url := ""
+					if base != "" {
+						url = base + "/" + row.Name
+					}
+					kind.Rows = append(kind.Rows, entityRowResponse{Name: row.Name, Values: values, Site: owners[row.Name], URL: url})
 				}
 			}
 		}

--- a/internal/ui/entities_url_test.go
+++ b/internal/ui/entities_url_test.go
@@ -1,0 +1,51 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// A bucket row is only useful if it says where the bucket actually is, and the
+// answer changes the moment the service gets a domain: the container name it is
+// otherwise reached at resolves in no browser.
+func TestEntityBaseURL_FollowsTheServiceDomain(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if cfg.Services == nil {
+		cfg.Services = map[string]config.ServiceConfig{}
+	}
+	cfg.Services["rustfs"] = config.ServiceConfig{Port: 9000}
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+	if got := entityBaseURL("rustfs"); got != "http://localhost:9000" {
+		t.Errorf("base = %q, want the published loopback port", got)
+	}
+
+	sc := cfg.Services["rustfs"]
+	sc.Domain = "rustfs.test"
+	cfg.Services["rustfs"] = sc
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+	if got := entityBaseURL("rustfs"); got != "https://rustfs.test" {
+		t.Errorf("base = %q, want the service domain", got)
+	}
+}
+
+func TestEntityBaseURL_NoPortsNoURL(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	if got := entityBaseURL("not-a-service"); got != "" {
+		t.Errorf("base = %q, want empty for a service with nothing published", got)
+	}
+}

--- a/internal/ui/web/src/stores/entities.ts
+++ b/internal/ui/web/src/stores/entities.ts
@@ -25,6 +25,9 @@ export interface EntityRow {
   values?: string[];
   // Domain of the linked site that owns this entity, when one does.
   site?: string;
+  // Where the entity is addressable: the service's domain when it has one,
+  // otherwise its published loopback port.
+  url?: string;
 }
 
 export interface EntityKind {

--- a/internal/ui/web/src/stores/services.ts
+++ b/internal/ui/web/src/stores/services.ts
@@ -378,6 +378,8 @@ function phaseLabel(phase: string): string {
       return 'Reprovisioning skipped';
     case 'reprovisioning_failed':
       return 'Reprovisioning failed';
+    case 'domain_adopted':
+      return 'Serving on its own domain…';
     case 'starting_unit':
       return 'Starting…';
     case 'installing_config':

--- a/internal/ui/web/src/tabs/services/EntityCard.svelte
+++ b/internal/ui/web/src/tabs/services/EntityCard.svelte
@@ -106,7 +106,17 @@
   {#snippet header()}
     <Icon name="cube" class="w-4 h-4 mt-0.5 shrink-0 text-gray-300 dark:text-gray-600" />
     <div class="min-w-0 flex-1">
-      <p class="truncate text-sm font-semibold text-gray-800 dark:text-gray-100" title={row.name}>{row.name}</p>
+      {#if row.url}
+        <a
+          href={row.url}
+          target="_blank"
+          rel="noopener"
+          class="block truncate text-sm font-semibold text-gray-800 hover:underline dark:text-gray-100"
+          title={row.url}>{row.name}</a
+        >
+      {:else}
+        <p class="truncate text-sm font-semibold text-gray-800 dark:text-gray-100" title={row.name}>{row.name}</p>
+      {/if}
       <p class="flex flex-wrap items-center gap-x-1.5 text-xs text-gray-400 dark:text-gray-500">
         {#each kind.columns as col, i (col.key)}
           {#if i > 0}<span class="shrink-0" aria-hidden="true">·</span>{/if}

--- a/internal/ui/web/src/tabs/services/EntityCard.svelte
+++ b/internal/ui/web/src/tabs/services/EntityCard.svelte
@@ -106,17 +106,7 @@
   {#snippet header()}
     <Icon name="cube" class="w-4 h-4 mt-0.5 shrink-0 text-gray-300 dark:text-gray-600" />
     <div class="min-w-0 flex-1">
-      {#if row.url}
-        <a
-          href={row.url}
-          target="_blank"
-          rel="noopener"
-          class="block truncate text-sm font-semibold text-gray-800 hover:underline dark:text-gray-100"
-          title={row.url}>{row.name}</a
-        >
-      {:else}
-        <p class="truncate text-sm font-semibold text-gray-800 dark:text-gray-100" title={row.name}>{row.name}</p>
-      {/if}
+      <p class="truncate text-sm font-semibold text-gray-800 dark:text-gray-100" title={row.name}>{row.name}</p>
       <p class="flex flex-wrap items-center gap-x-1.5 text-xs text-gray-400 dark:text-gray-500">
         {#each kind.columns as col, i (col.key)}
           {#if i > 0}<span class="shrink-0" aria-hidden="true">·</span>{/if}
@@ -135,6 +125,21 @@
               class="min-w-0 truncate text-sky-600 dark:text-sky-400 hover:underline"
               title={row.site}
             >{row.site}</button>
+          </span>
+        {/if}
+        {#if row.url}
+          <!-- The address itself, not the name: the name is what the entity is
+               called, the link is where it answers, and they are not the same
+               once the service is served on its own domain. -->
+          <span class="inline-flex min-w-0 max-w-full items-center gap-1.5">
+            <span class="shrink-0" aria-hidden="true">·</span>
+            <a
+              href={row.url}
+              target="_blank"
+              rel="noopener"
+              class="min-w-0 truncate text-sky-600 dark:text-sky-400 hover:underline"
+              title={row.url}>{row.url}</a
+            >
           </span>
         {/if}
       </p>


### PR DESCRIPTION
An app reaches a service by container name, which resolves nowhere outside the podman network. That is fine until something hands the browser a URL built from it. An S3 presigned URL carries its host inside the signature, so rewriting the host afterwards returns `SignatureDoesNotMatch`, and the app and the browser have to agree on one name before the URL is signed. There was no such name, which is what makes a private bucket unusable in the browser.

A service can now be served on its own hostname over HTTPS, `lerd service domain rustfs rustfs.test`. nginx proxies it with a certificate from lerd's own CA, and the name goes into the hosts file mounted into every PHP container, so the app signs for the same host the browser opens. The upstream is reached through a variable rather than a literal, the way the custom container vhosts already do it: a literal is resolved when the config loads, so a reload while the service container is absent is rejected outright and takes every other vhost in the file down with it.

RustFS ships with one. The default is declared in its preset rather than in Go, so it reaches every install without a release and any other service can declare one the same way. A service that needs a domain is broken without it, so the domain is taken on install and on the next start rather than waiting for each user to find a command, and the sites using the service have their env rewritten in the same pass. Taking a domain away is recorded so the default is not handed back on the next start; removing the service itself is not treated as a refusal, so a reinstall comes back with it.

A site is recognised by whichever address its env currently names, the container or the domain, so it stays wired through the change in both directions. The bucket list in the dashboard now shows where each bucket actually is, following the domain when there is one.

A subdomain of a site works too if you prefer the storage under the app it belongs to. lerd runs one RustFS for every site, and per-site subdomains share a namespace with grouped sites and worktree domains, so the default is a name of its own.

The vhost sends no CORS headers, so a direct-to-S3 upload from a page still needs them added. Server side uploads and plain image or download links are unaffected.

Refs #1703
