### PR TITLE
fix: drop a token GitHub rejects and check for a pre-release anonymously

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -449,6 +449,8 @@ lerd update --beta
 ```
 
 The token needs no scopes, public release metadata is all lerd reads, and it is only ever sent to `api.github.com` over https, never to a mirror configured through `LERD_RELEASES_API_URL`.
+
+A token that has expired or been revoked costs you nothing: GitHub answers it with a 401, and lerd drops the token and asks again anonymously, so the check still works on the 60 requests an hour every IP gets.
 :::
 
 ::: details Error: NetworkUpdate is not supported for backend CNI: invalid argument

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -2,6 +2,7 @@ package update
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -143,31 +144,7 @@ func FetchLatestPrerelease() (string, error) {
 
 func fetchPrereleaseFrom(base string) (string, error) {
 	url := base + "/releases"
-	req, err := http.NewRequest(http.MethodGet, url, nil) //nolint:noctx
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("User-Agent", "lerd-cli")
-	req.Header.Set("Accept", "application/vnd.github+json")
-	token := tokenFor(url)
-	if token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		if err := rateLimitError(url, resp, token != ""); err != nil {
-			return "", err
-		}
-		return "", fmt.Errorf("unexpected status from %s: HTTP %d", url, resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(resp.Body)
+	body, err := releasesJSON(url, tokenFor(url))
 	if err != nil {
 		return "", err
 	}
@@ -183,6 +160,57 @@ func fetchPrereleaseFrom(base string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("no pre-release found from %s", url)
+}
+
+// errRejectedToken marks the 401 GitHub answers with when the token it was
+// given has expired or been revoked.
+var errRejectedToken = errors.New("rejected token")
+
+// releasesJSON reads the release list, and when GitHub rejects the token it
+// asks again as nobody: a stale GITHUB_TOKEN left in a shell must not cost an
+// update that would have worked anonymously.
+func releasesJSON(url, token string) ([]byte, error) {
+	body, err := getReleases(url, token, token == "")
+	if token != "" && errors.Is(err, errRejectedToken) {
+		body, err = getReleases(url, "", false)
+		if err != nil {
+			err = fmt.Errorf("%w (GitHub rejected the token in GITHUB_TOKEN or GH_TOKEN)", err)
+		}
+	}
+	return body, err
+}
+
+// getReleases makes one call. suggestToken says whether a failure may point at
+// the token that raises the rate limit, which is wrong to offer to someone who
+// already has one set and had it turned down.
+func getReleases(url, token string, suggestToken bool) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil) //nolint:noctx
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "lerd-cli")
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		if err := rateLimitError(url, resp, suggestToken); err != nil {
+			return nil, err
+		}
+		if resp.StatusCode == http.StatusUnauthorized {
+			return nil, fmt.Errorf("%w: HTTP 401 from %s", errRejectedToken, url)
+		}
+		return nil, fmt.Errorf("unexpected status from %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	return io.ReadAll(resp.Body)
 }
 
 // githubAPIHost is the only host a token may be sent to. A
@@ -210,7 +238,7 @@ func tokenFor(rawURL string) string {
 // rateLimitError turns an exhausted-quota response into an error that says so
 // and when the quota comes back, instead of a bare HTTP 403 that reads like a
 // broken network. It returns nil for any other failure.
-func rateLimitError(url string, resp *http.Response, authenticated bool) error {
+func rateLimitError(url string, resp *http.Response, suggestToken bool) error {
 	if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusTooManyRequests {
 		return nil
 	}
@@ -223,7 +251,7 @@ func rateLimitError(url string, resp *http.Response, authenticated bool) error {
 			msg += fmt.Sprintf(", it resets in %d min", int((d+time.Minute-1)/time.Minute))
 		}
 	}
-	if !authenticated {
+	if suggestToken {
 		msg += "; set GITHUB_TOKEN to raise the limit"
 	}
 	return fmt.Errorf("%s", msg)

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -259,3 +259,78 @@ func TestFetchLatestPrerelease_keepsPlainStatusErrorWithQuotaLeft(t *testing.T) 
 		t.Errorf("error should carry the status, got: %v", err)
 	}
 }
+
+// A stale or revoked token in the environment used to turn an update that
+// would have worked anonymously into a bare HTTP 401, so a rejected token is
+// dropped and the call is made again as nobody.
+func TestReleasesJSON_retriesWithoutARejectedToken(t *testing.T) {
+	var auths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auths = append(auths, r.Header.Get("Authorization"))
+		if r.Header.Get("Authorization") != "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"tag_name":"v1.34.0-beta.3","prerelease":true}]`))
+	}))
+	defer srv.Close()
+
+	body, err := releasesJSON(srv.URL+"/releases", "ghp_expired")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(body), "v1.34.0-beta.3") {
+		t.Errorf("body should carry the release list, got: %s", body)
+	}
+	want := []string{"Bearer ghp_expired", ""}
+	if len(auths) != len(want) || auths[0] != want[0] || auths[1] != want[1] {
+		t.Errorf("requests sent %q, want %q", auths, want)
+	}
+}
+
+// Without a token there is nothing to retry without, so a 401 is reported as
+// it arrives rather than doubling every failed call.
+func TestReleasesJSON_doesNotRetryAnAnonymous401(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	if _, err := releasesJSON(srv.URL+"/releases", ""); err == nil {
+		t.Fatal("expected an error for HTTP 401")
+	}
+	if calls != 1 {
+		t.Errorf("made %d requests, want 1", calls)
+	}
+}
+
+// When the retry fails too, the message has to say the token was rejected,
+// otherwise the rate-limit advice reads as nonsense to someone who already set
+// GITHUB_TOKEN.
+func TestReleasesJSON_namesTheRejectedTokenWhenTheRetryFailsToo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	_, err := releasesJSON(srv.URL+"/releases", "ghp_expired")
+	if err == nil {
+		t.Fatal("expected an error when both calls fail")
+	}
+	for _, want := range []string{"rate limit exhausted", "GITHUB_TOKEN"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q, got: %v", want, err)
+		}
+	}
+	if !strings.Contains(err.Error(), "rejected") {
+		t.Errorf("error should say the token was rejected, got: %v", err)
+	}
+}


### PR DESCRIPTION
The beta check sends GITHUB_TOKEN or GH_TOKEN when either is set, and nothing tells it whether that token is still any good. A token that has expired or been revoked came back as a bare HTTP 401, so a stale variable left in a shell profile broke an update that would have gone through anonymously a moment earlier.

A 401 is now a reason to drop the token rather than a reason to give up. The call is repeated without the header, which is exactly the path the command took before it ever authenticated, so an unusable token costs nothing. A 401 on a call that carried no token is reported as it arrives, since there is nothing to retry without.

When the anonymous retry fails as well, the error says the token was rejected and the rate limit message stops offering GITHUB_TOKEN, advice that reads as nonsense to someone who already has one set.

Closes #1705