### PR TITLE
feat: answer browser preflights on a service domain

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -244,7 +244,7 @@ Switch the PHP runtime for the current site between shared PHP-FPM and per-site 
 | `lerd service preset [name]` | List presets, or install one (use `--version` for multi-version presets); a store-only preset is fetched on demand |
 | `lerd service search [query]` | Browse the external service-preset store; filter by name, description, or family |
 | `lerd service remove <name> [--purge] [--no-snapshot]` | Stop and remove a service (custom or default). With `--purge`, snapshot every database on it, then rename the data dir aside (recoverable as `<name>.pre-remove-<ts>`). `--no-snapshot` skips the snapshot |
-| `lerd service domain <service> [domain] [--port N] [--remove]` | Serve a service on its own HTTPS domain, resolvable from the app container and the browser alike. `--port` picks the container port for a service exposing several. With no domain, show the current one |
+| `lerd service domain <service> [domain] [--port N] [--cors\|--no-cors] [--remove]` | Serve a service on its own HTTPS domain, resolvable from the app container and the browser alike. `--port` picks the container port for a service exposing several. `--cors` answers browser preflights, for a page that uploads to the service directly. With no domain, show the current one |
 | `lerd service reinstall <name> [--reset-data] [--no-snapshot]` | Stop, remove, and reinstall at the current version, then recreate any linked site's missing database or bucket on it. With `--reset-data`, snapshot every database on it and rename the data dir aside first. `--no-snapshot` skips the snapshot |
 | `lerd minio:migrate` | Migrate existing MinIO data to RustFS |
 

--- a/docs/usage/services.md
+++ b/docs/usage/services.md
@@ -253,7 +253,22 @@ AWS_ENDPOINT=https://rustfs.test
 AWS_URL=https://rustfs.test/my-project
 ```
 
-The vhost sends no CORS headers, so a browser fetching across origins (a direct-to-S3 upload from the site's own page) still needs them added; server-side uploads and plain `<img>` or download links are unaffected.
+#### Uploading to the service from the browser
+
+A presigned upload is issued by the app but sent by the browser, and it goes to a different origin than the page it was issued to. The browser asks the service for permission first, and sends nothing at all unless the answer names that page's origin. Server-side uploads and plain `<img>` or download links never ask, so they were never affected.
+
+RustFS's preset asks for the preflight to be answered, so an install that has its domain gets it. For a service whose preset says nothing, or one of your own:
+
+```bash
+lerd service domain rustfs --cors      # answer preflights on the domain
+lerd service domain rustfs --no-cors   # stop answering them
+```
+
+The origin is reflected rather than answered with `*`: the vhost matches the request's `Origin` against the hosts lerd serves and echoes it back, so `https://myapp.test` is answered and a page on the open internet is not. A wildcard would let any site the browser happens to have open read the service over JS. An origin lerd does not serve leaves the header off entirely, which the browser refuses exactly as it would with nothing configured.
+
+Whatever the service says about CORS itself is dropped before lerd's answer is added. An object store that sends its own `Access-Control-Allow-Origin` would otherwise leave two on the response, and a browser rejects that outright rather than picking one. If you would rather configure CORS on the bucket, turn lerd's off with `--no-cors` and the service's own headers pass through untouched.
+
+The preflight answer reflects the headers the browser asked for rather than replying `*`, which Safari does not accept, and `ETag` is exposed because a multipart upload confirms each part by the ETag it comes back with.
 
 If a bucket a site points at is not there, `lerd site:doctor` reports it under **Bucket** with a fix that creates it. Such a site serves every page fine and fails on the first upload, which is exactly the kind of thing that reads as an application bug. The check is driven by the service preset rather than by any framework: the preset names the `.env` key holding the entity a site owns (`owner_env: AWS_BUCKET` for RustFS), and only a project whose env also points at the lerd service is measured against it, so one configured for real AWS is left alone.
 

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -93,6 +93,7 @@ func NewServiceCmd() *cobra.Command {
 func newServiceDomainCmd() *cobra.Command {
 	var remove bool
 	var port int
+	var cors, noCORS bool
 	cmd := &cobra.Command{
 		Use:   "domain <service> [domain]",
 		Short: "Serve a service on its own domain, reachable from the app and the browser",
@@ -116,12 +117,25 @@ service is yours or the preset says nothing:
 
     lerd service domain rustfs console.rustfs.test --port 9001
 
+A page that talks to the service directly, rather than through the app, needs
+the browser preflight answered: a presigned upload is issued by the app but sent
+by the browser, which asks first and sends nothing if the answer does not name
+the origin it came from. Services that work this way ask for it themselves, and
+--cors turns it on for one that does not, --no-cors off for one that does:
+
+    lerd service domain rustfs --cors
+
+Only origins lerd serves are answered, never "*".
+
 Run with no domain to show the current one, or --remove to stop serving it. The
 service stays reachable at lerd-<name> on the podman network either way.`,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(_ *cobra.Command, args []string) error {
 			name := args[0]
 			feedback.Begin()
+			if cors && noCORS {
+				return fmt.Errorf("--cors and --no-cors ask for opposite things; pass one")
+			}
 			// Resolved before the change: a site is recognised by whichever
 			// address its env currently names, so removing the domain first
 			// would lose every site the domain itself is what wired.
@@ -134,9 +148,20 @@ service stays reachable at lerd-<name> on the podman network either way.`,
 				syncServiceDomainSites(name, affected)
 				return nil
 			}
+			// --cors alone changes the answer on the domain the service already
+			// has, so it does not have to be renamed to its current value to
+			// turn the preflight on.
+			if len(args) == 1 && (cors || noCORS) {
+				if err := serviceops.SetServiceDomainCORS(name, cors); err != nil {
+					return err
+				}
+				feedback.Done(corsDoneMessage(name, cors))
+				return nil
+			}
 			if len(args) == 1 {
 				if current := config.ServiceDomain(name); current != "" {
-					fmt.Printf("%s is served at https://%s -> port %d\n", name, current, serviceops.ServiceDomainPort(name))
+					fmt.Printf("%s is served at https://%s -> port %d%s\n", name, current,
+						serviceops.ServiceDomainPort(name), corsSuffix(name))
 					return nil
 				}
 				fmt.Printf("%s has no domain. Give it one with: lerd service domain %s %s\n",
@@ -147,14 +172,37 @@ service stays reachable at lerd-<name> on the podman network either way.`,
 			if err != nil {
 				return err
 			}
-			feedback.Done("serving " + feedback.Val(name) + " at https://" + domain)
+			if cors || noCORS {
+				if err := serviceops.SetServiceDomainCORS(name, cors); err != nil {
+					return err
+				}
+			}
+			feedback.Done("serving " + feedback.Val(name) + " at https://" + domain + corsSuffix(name))
 			syncServiceDomainSites(name, affected)
 			return nil
 		},
 	}
 	cmd.Flags().BoolVar(&remove, "remove", false, "Stop serving the service on its domain")
 	cmd.Flags().IntVar(&port, "port", 0, "Container port the domain proxies to (default: the preset's, then the service's primary)")
+	cmd.Flags().BoolVar(&cors, "cors", false, "Answer browser preflights on the domain, for a page that uploads to the service directly")
+	cmd.Flags().BoolVar(&noCORS, "no-cors", false, "Stop answering browser preflights on a service whose preset asks for them")
 	return cmd
+}
+
+// corsSuffix names the preflight answer wherever the domain is reported, so the
+// state is visible without opening config.yaml to find it.
+func corsSuffix(service string) string {
+	if serviceops.ServiceDomainCORS(service) {
+		return ", answering browser preflights"
+	}
+	return ""
+}
+
+func corsDoneMessage(service string, enabled bool) string {
+	if enabled {
+		return "answering browser preflights on " + feedback.Val(service)
+	}
+	return "no longer answering browser preflights on " + feedback.Val(service)
 }
 
 // adoptDefaultServiceDomains takes the domain each preset declares for a service

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -46,7 +46,15 @@ type ServiceConfig struct {
 	DomainOptOut bool `yaml:"domain_opt_out,omitempty" mapstructure:"domain_opt_out"`
 	// DomainPort overrides the container port the domain proxies to. 0 = the
 	// preset's choice, then the service's primary port.
-	DomainPort    int    `yaml:"domain_port,omitempty" mapstructure:"domain_port"`
+	DomainPort int `yaml:"domain_port,omitempty" mapstructure:"domain_port"`
+	// DomainCORS turns the browser preflight answer on for a service whose
+	// preset does not ask for it, and DomainCORSOptOut turns it off for one that
+	// does. Two fields rather than one because the preset owns the default and
+	// silence has to stay distinguishable from a deliberate no, the same reason
+	// DomainOptOut sits beside Domain.
+	DomainCORS       bool `yaml:"domain_cors,omitempty" mapstructure:"domain_cors"`
+	DomainCORSOptOut bool `yaml:"domain_cors_opt_out,omitempty" mapstructure:"domain_cors_opt_out"`
+
 	PreviousImage string `yaml:"previous_image,omitempty" mapstructure:"previous_image"`
 	// LastOp records the most recent mutation kind ("update" or "migrate") so
 	// the rollback flow can refuse a swap that would race the new image

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -102,6 +102,13 @@ type Preset struct {
 	// the API for an object store but the SMTP port for a mail catcher whose web
 	// UI is the thing worth a hostname.
 	DomainPort int `yaml:"domain_port,omitempty"`
+	// DomainCORS asks for the browser preflight to be answered on the domain. A
+	// service declares it when a page talks to it directly rather than through
+	// the app: a presigned upload is issued by the app but sent by the browser,
+	// which will not send it at all until the preflight is answered from an
+	// origin the page was served from. Like the domain itself it lives here so
+	// the answer travels with the service definition.
+	DomainCORS bool `yaml:"domain_cors,omitempty"`
 	// DataVersionFile names a file inside the service's data dir whose contents
 	// identify the version that wrote the data (postgres PG_VERSION, mariadb
 	// mariadb_upgrade_info). It is matched against Versions[].Tag so a data dir

--- a/internal/config/presets/rustfs.yaml
+++ b/internal/config/presets/rustfs.yaml
@@ -81,3 +81,7 @@ introspect:
 # signed, so this service is served on rustfs.test rather than only at its
 # container name. Remove it with: lerd service domain rustfs --remove
 domain: rustfs
+# A presigned upload is issued by the app but sent by the browser, which asks
+# before it sends and gives up if the answer does not name the page's origin.
+# Turn it off with: lerd service domain rustfs --no-cors
+domain_cors: true

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -970,6 +970,26 @@ type proxyVhostData struct {
 	UpstreamHost   string
 	UpstreamPort   int
 	RequestTimeout int
+	// CORS answers the browser preflight on this domain, and CORSOrigin is the
+	// nginx regex deciding which origins are answered for.
+	CORS       bool
+	CORSOrigin string
+}
+
+// tldLabel is what a TLD may look like before it is interpolated into the CORS
+// origin regex. It comes from user config, and a value that was never a TLD
+// would otherwise build a pattern matching more than the hosts lerd serves.
+var tldLabel = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$`)
+
+// corsOriginPattern builds the regex matching every origin lerd serves: any host
+// under the configured TLD, on either scheme, with or without an explicit port,
+// since nginx's own ports are configurable. Reflecting these rather than
+// answering "*" keeps a page on the open internet from reading a local service.
+func corsOriginPattern(tld string) string {
+	if !tldLabel.MatchString(tld) {
+		tld = "test"
+	}
+	return `^https?://[^/]+\.` + strings.ReplaceAll(tld, ".", `\.`) + `(:[0-9]+)?$`
 }
 
 // renderProxyVhost is renderVhost for the LAN proxy template, which carries its
@@ -1022,8 +1042,9 @@ func GenerateProxyVhost(domain, upstreamHost string, upstreamPort int) error {
 // GenerateServiceProxyVhost writes the vhost that serves a service on its own
 // domain: HTTP when ssl is false, HTTPS with an HTTP redirect in front when it
 // is. It is the plain proxy vhost with TLS, kept separate so the LAN proxy above
-// keeps its narrower shape.
-func GenerateServiceProxyVhost(domain, upstreamHost string, upstreamPort int, ssl bool) error {
+// keeps its narrower shape. cors additionally answers the browser preflight, for
+// a service a page talks to directly rather than through the app.
+func GenerateServiceProxyVhost(domain, upstreamHost string, upstreamPort int, ssl, cors bool) error {
 	if !ssl {
 		return GenerateProxyVhost(domain, upstreamHost, upstreamPort)
 	}
@@ -1040,6 +1061,8 @@ func GenerateServiceProxyVhost(domain, upstreamHost string, upstreamPort int, ss
 		UpstreamHost:   upstreamHost,
 		UpstreamPort:   upstreamPort,
 		RequestTimeout: resolveRequestTimeout("", ""),
+		CORS:           cors,
+		CORSOrigin:     corsOriginPattern(config.EffectiveTLD()),
 	})
 	if err != nil {
 		return err

--- a/internal/nginx/service_vhost_cors_test.go
+++ b/internal/nginx/service_vhost_cors_test.go
@@ -1,0 +1,128 @@
+package nginx
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func corsVhostBody(t *testing.T, cors bool) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	if err := GenerateServiceProxyVhost("rustfs.test", "lerd-rustfs", 9000, true, cors); err != nil {
+		t.Fatalf("GenerateServiceProxyVhost: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(config.NginxConfD(), "rustfs.test.conf"))
+	if err != nil {
+		t.Fatalf("reading vhost: %v", err)
+	}
+	return string(body)
+}
+
+// A presigned upload is sent by the browser, which asks before it sends and
+// gives up unless the answer names the origin the page came from.
+func TestServiceVhostCORS_AnswersThePreflight(t *testing.T) {
+	got := corsVhostBody(t, true)
+	for _, want := range []string{
+		`if ($request_method = OPTIONS)`,
+		"return 204;",
+		"add_header Access-Control-Allow-Methods",
+		`add_header Access-Control-Expose-Headers "ETag" always;`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("vhost missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// The origin is reflected, never wildcarded: "*" would let any page the user
+// happens to have open read a local service over JS.
+func TestServiceVhostCORS_ReflectsOnlyLerdOrigins(t *testing.T) {
+	got := corsVhostBody(t, true)
+	if !strings.Contains(got, `if ($http_origin ~ "^https?://[^/]+\.test(:[0-9]+)?$")`) {
+		t.Errorf("origin is not matched against the TLD lerd serves:\n%s", got)
+	}
+	if !strings.Contains(got, "set $cors $http_origin;") {
+		t.Errorf("origin is not reflected:\n%s", got)
+	}
+	if strings.Contains(got, "Access-Control-Allow-Origin *") ||
+		strings.Contains(got, `Access-Control-Allow-Origin "*"`) {
+		t.Errorf("origin was wildcarded:\n%s", got)
+	}
+}
+
+// An object store that sends CORS headers of its own would otherwise leave two
+// of each on the response, and a browser rejects that outright rather than
+// picking one, so ours only land after the upstream's are dropped.
+func TestServiceVhostCORS_DropsTheUpstreamHeadersFirst(t *testing.T) {
+	got := corsVhostBody(t, true)
+	for _, header := range []string{
+		"Access-Control-Allow-Origin",
+		"Access-Control-Allow-Methods",
+		"Access-Control-Allow-Headers",
+		"Access-Control-Expose-Headers",
+		"Access-Control-Max-Age",
+	} {
+		if !strings.Contains(got, "proxy_hide_header "+header+";") {
+			t.Errorf("upstream %s is not hidden, so the browser can see two:\n%s", header, got)
+		}
+	}
+}
+
+// The response differs by the origin that asked for it, so a cache must not
+// hand one origin's copy to another.
+func TestServiceVhostCORS_VariesOnOrigin(t *testing.T) {
+	if got := corsVhostBody(t, true); !strings.Contains(got, "add_header Vary Origin always;") {
+		t.Errorf("response does not vary on Origin:\n%s", got)
+	}
+}
+
+// Safari does not accept "*" for the allowed headers, so the preflight answers
+// with the headers that were actually asked for.
+func TestServiceVhostCORS_ReflectsRequestedHeaders(t *testing.T) {
+	got := corsVhostBody(t, true)
+	if !strings.Contains(got, "add_header Access-Control-Allow-Headers $http_access_control_request_headers always;") {
+		t.Errorf("requested headers are not reflected:\n%s", got)
+	}
+}
+
+// A service nobody calls from a page is not quietly made readable by one.
+func TestServiceVhostCORS_AbsentUnlessAskedFor(t *testing.T) {
+	if got := corsVhostBody(t, false); strings.Contains(got, "Access-Control") {
+		t.Errorf("CORS rendered without being asked for:\n%s", got)
+	}
+}
+
+func TestCORSOriginPattern(t *testing.T) {
+	cases := []struct{ tld, want string }{
+		{"test", `^https?://[^/]+\.test(:[0-9]+)?$`},
+		{"localhost", `^https?://[^/]+\.localhost(:[0-9]+)?$`},
+		// A dotted TLD has its dots escaped rather than left matching any character.
+		{"dev.local", `^https?://[^/]+\.dev\.local(:[0-9]+)?$`},
+		// The TLD comes from user config; one that was never a TLD must not
+		// reach the regex and widen what it matches.
+		{`bad" { deny all; }`, `^https?://[^/]+\.test(:[0-9]+)?$`},
+		{"", `^https?://[^/]+\.test(:[0-9]+)?$`},
+	}
+	for _, c := range cases {
+		if got := corsOriginPattern(c.tld); got != c.want {
+			t.Errorf("corsOriginPattern(%q) = %q, want %q", c.tld, got, c.want)
+		}
+	}
+}
+
+// The origin regex reaches nginx inside a quoted directive, so it must not be
+// able to end one, whatever the configured TLD is.
+func TestCORSOriginPatternCannotEndADirective(t *testing.T) {
+	for _, tld := range []string{"test", "dev.local", `x"; }`, "a;b"} {
+		if i := strings.IndexAny(corsOriginPattern(tld), nginxValueForbidden); i >= 0 {
+			t.Errorf("pattern for TLD %q carries %q", tld, string(corsOriginPattern(tld)[i]))
+		}
+	}
+}

--- a/internal/nginx/service_vhost_test.go
+++ b/internal/nginx/service_vhost_test.go
@@ -17,7 +17,7 @@ func TestGenerateServiceProxyVhost_ForwardsTheRequestedHostOverTLS(t *testing.T)
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	t.Setenv("XDG_DATA_HOME", tmp)
 
-	if err := GenerateServiceProxyVhost("rustfs.test", "lerd-rustfs", 9000, true); err != nil {
+	if err := GenerateServiceProxyVhost("rustfs.test", "lerd-rustfs", 9000, true, false); err != nil {
 		t.Fatalf("GenerateServiceProxyVhost: %v", err)
 	}
 	body, err := os.ReadFile(filepath.Join(config.NginxConfD(), "rustfs.test.conf"))
@@ -45,7 +45,7 @@ func TestGenerateServiceProxyVhost_PlainHTTPWhenNotSecured(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	t.Setenv("XDG_DATA_HOME", tmp)
 
-	if err := GenerateServiceProxyVhost("rustfs.test", "lerd-rustfs", 9000, false); err != nil {
+	if err := GenerateServiceProxyVhost("rustfs.test", "lerd-rustfs", 9000, false, false); err != nil {
 		t.Fatalf("GenerateServiceProxyVhost: %v", err)
 	}
 	body, err := os.ReadFile(filepath.Join(config.NginxConfD(), "rustfs.test.conf"))
@@ -78,7 +78,7 @@ func TestRepairVhosts_KeepsAServiceDomainVhost(t *testing.T) {
 		t.Fatalf("SaveGlobal: %v", err)
 	}
 
-	if err := GenerateServiceProxyVhost("rustfs.test", "lerd-rustfs", 9000, true); err != nil {
+	if err := GenerateServiceProxyVhost("rustfs.test", "lerd-rustfs", 9000, true, false); err != nil {
 		t.Fatalf("GenerateServiceProxyVhost: %v", err)
 	}
 	conf := filepath.Join(config.NginxConfD(), "rustfs.test.conf")

--- a/internal/nginx/templates/vhost-proxy-ssl.conf.tmpl
+++ b/internal/nginx/templates/vhost-proxy-ssl.conf.tmpl
@@ -21,6 +21,43 @@ server {
     proxy_buffering off;
 
     location / {
+{{- if .CORS}}
+        # A presigned upload is issued by the app but sent by the browser, which
+        # asks first and sends nothing unless the answer names its own origin.
+        # The origin is reflected rather than answered with "*": a wildcard would
+        # let any page the user happens to have open read this service over JS.
+        # An origin lerd does not serve leaves $cors empty, and an empty
+        # add_header is not emitted at all, so the browser refuses it exactly as
+        # it would with no CORS configured.
+        set $cors "";
+        if ($http_origin ~ "{{.CORSOrigin}}") {
+            set $cors $http_origin;
+        }
+        # Whatever the upstream says about CORS is dropped first. An object store
+        # that answers with its own header would otherwise leave two on the
+        # response, and a browser rejects that outright rather than picking one.
+        proxy_hide_header Access-Control-Allow-Origin;
+        proxy_hide_header Access-Control-Allow-Methods;
+        proxy_hide_header Access-Control-Allow-Headers;
+        proxy_hide_header Access-Control-Expose-Headers;
+        proxy_hide_header Access-Control-Max-Age;
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin  $cors always;
+            add_header Access-Control-Allow-Methods "GET, PUT, POST, DELETE, HEAD, OPTIONS" always;
+            # Reflected rather than "*", which Safari does not accept here.
+            add_header Access-Control-Allow-Headers $http_access_control_request_headers always;
+            add_header Access-Control-Max-Age       86400 always;
+            add_header Vary                         Origin always;
+            return 204;
+        }
+        add_header Access-Control-Allow-Origin $cors always;
+        # A multipart upload confirms each part by the ETag it comes back with,
+        # which a script cannot read unless it is exposed.
+        add_header Access-Control-Expose-Headers "ETag" always;
+        # The answer depends on the origin that asked, so a cache must not hand
+        # one origin's response to another.
+        add_header Vary Origin always;
+{{end}}
         # Through a variable, the same way the custom-container vhosts do it: a
         # literal upstream is resolved when the config loads, so a reload while
         # the service container is absent is rejected outright and takes every

--- a/internal/serviceops/domain.go
+++ b/internal/serviceops/domain.go
@@ -200,7 +200,7 @@ func ApplyServiceDomain(service string) error {
 	if err := domainIssueCertFn(domain); err != nil {
 		return fmt.Errorf("issuing certificate for %s: %w", domain, err)
 	}
-	if err := domainVhostFn(domain, "lerd-"+service, port, true); err != nil {
+	if err := domainVhostFn(domain, "lerd-"+service, port, true, serviceDomainCORS(service)); err != nil {
 		return fmt.Errorf("writing vhost for %s: %w", domain, err)
 	}
 	if err := domainWriteHostsFn(); err != nil {
@@ -326,6 +326,48 @@ func ApplyServiceDomains() error {
 // port a service's domain actually proxies to, so a surface can show it rather
 // than leave the user guessing which of a multi-port service answers.
 func ServiceDomainPort(service string) int { return serviceDomainPort(service) }
+
+// ServiceDomainCORS is serviceDomainCORS for callers outside this package.
+func ServiceDomainCORS(service string) bool { return serviceDomainCORS(service) }
+
+// serviceDomainCORS reports whether the domain answers the browser preflight.
+// The user's own choice wins in either direction, then the preset's, which is
+// where a service that a page talks to directly says so. Silence is not a no:
+// only DomainCORSOptOut is, which is what keeps a preset default from being
+// handed back to a user who turned it off.
+func serviceDomainCORS(service string) bool {
+	sc := config.ServiceConfigFor(service)
+	if sc.DomainCORSOptOut {
+		return false
+	}
+	if sc.DomainCORS {
+		return true
+	}
+	preset, err := config.LoadPreset(service)
+	return err == nil && preset != nil && preset.DomainCORS
+}
+
+// SetServiceDomainCORS records the user's answer on the preflight and re-renders
+// the vhost so it takes effect without a restart. A service with no domain has
+// no vhost to carry it, so the choice is refused rather than saved somewhere it
+// would silently do nothing.
+func SetServiceDomainCORS(service string, enabled bool) error {
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return err
+	}
+	if cfg.Services[service].Domain == "" {
+		return fmt.Errorf("service %q has no domain to answer preflights on", service)
+	}
+	svcCfg := cfg.Services[service]
+	svcCfg.DomainCORS = enabled
+	svcCfg.DomainCORSOptOut = !enabled
+	cfg.Services[service] = svcCfg
+	if err := config.SaveGlobal(cfg); err != nil {
+		return err
+	}
+	return ApplyServiceDomain(service)
+}
 
 // serviceDomainPort is the container-internal port nginx proxies the domain to.
 // The published host port is deliberately not used: nginx reaches the service

--- a/internal/serviceops/domain_cors_test.go
+++ b/internal/serviceops/domain_cors_test.go
@@ -1,0 +1,112 @@
+package serviceops
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func setServiceCORSConfig(t *testing.T, on, optOut bool) {
+	t.Helper()
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	sc := cfg.Services["rustfs"]
+	sc.DomainCORS = on
+	sc.DomainCORSOptOut = optOut
+	cfg.Services["rustfs"] = sc
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+}
+
+// The preset is where a service says a page talks to it directly, so a user who
+// has expressed no opinion gets the answer the service definition carries.
+func TestServiceDomainCORS_FollowsThePresetByDefault(t *testing.T) {
+	domainTestConfig(t)
+	if !serviceDomainCORS("rustfs") {
+		t.Error("rustfs declares domain_cors, so it should be on with no user choice")
+	}
+	// A service whose preset says nothing stays off rather than being made
+	// readable from a page nobody asked to let in.
+	if serviceDomainCORS("postgres") {
+		t.Error("a preset that does not ask for CORS should not get it")
+	}
+}
+
+// Silence is not a no: only a recorded opt-out is, which is what stops a preset
+// default from being handed back to a user who turned it off.
+func TestServiceDomainCORS_OptOutBeatsThePreset(t *testing.T) {
+	domainTestConfig(t)
+	setServiceCORSConfig(t, false, true)
+	if serviceDomainCORS("rustfs") {
+		t.Error("the recorded opt-out did not survive the preset default")
+	}
+}
+
+func TestServiceDomainCORS_UserChoiceTurnsItOnForAPresetThatIsSilent(t *testing.T) {
+	domainTestConfig(t)
+	cfg, _ := config.LoadGlobal()
+	sc := cfg.Services["postgres"]
+	sc.DomainCORS = true
+	cfg.Services["postgres"] = sc
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+	if !serviceDomainCORS("postgres") {
+		t.Error("an explicit choice was ignored")
+	}
+}
+
+// The vhost is what carries the preflight answer, so the resolved value has to
+// reach it rather than being read only where it is stored.
+func TestApplyServiceDomain_PassesCORSToTheVhost(t *testing.T) {
+	domainTestConfig(t)
+	rec := stubDomainSeams(t)
+
+	if _, err := SetServiceDomain("rustfs", "rustfs", 0); err != nil {
+		t.Fatalf("SetServiceDomain: %v", err)
+	}
+	if len(rec.cors) == 0 {
+		t.Fatal("no vhost was written")
+	}
+	if !rec.cors[len(rec.cors)-1] {
+		t.Error("rustfs declares domain_cors but the vhost was written without it")
+	}
+}
+
+func TestSetServiceDomainCORS_RerendersTheVhost(t *testing.T) {
+	domainTestConfig(t)
+	rec := stubDomainSeams(t)
+	if _, err := SetServiceDomain("rustfs", "rustfs", 0); err != nil {
+		t.Fatalf("SetServiceDomain: %v", err)
+	}
+	before := len(rec.cors)
+
+	if err := SetServiceDomainCORS("rustfs", false); err != nil {
+		t.Fatalf("SetServiceDomainCORS: %v", err)
+	}
+	if len(rec.cors) <= before {
+		t.Fatal("turning CORS off did not re-render the vhost")
+	}
+	if rec.cors[len(rec.cors)-1] {
+		t.Error("the vhost was re-rendered still answering preflights")
+	}
+	if serviceDomainCORS("rustfs") {
+		t.Error("the choice was not persisted")
+	}
+}
+
+// The preflight answer lives in the domain's vhost, so a service with no domain
+// has nowhere to carry it. Saving the choice anyway would leave a setting that
+// silently does nothing.
+func TestSetServiceDomainCORS_RefusedWithoutADomain(t *testing.T) {
+	domainTestConfig(t)
+	stubDomainSeams(t)
+	err := SetServiceDomainCORS("rustfs", true)
+	if err == nil || !strings.Contains(err.Error(), "no domain") {
+		t.Fatalf("expected a missing-domain error, got %v", err)
+	}
+}

--- a/internal/serviceops/domain_test.go
+++ b/internal/serviceops/domain_test.go
@@ -13,6 +13,7 @@ type domainCalls struct {
 	certs       []string
 	removedCert []string
 	vhosts      []string
+	cors        []bool
 	removed     []string
 	hosts       int
 	reloads     int
@@ -28,8 +29,9 @@ func stubDomainSeams(t *testing.T) *domainCalls {
 		rec.certs = append(rec.certs, domain)
 		return nil
 	}
-	domainVhostFn = func(domain, upstreamHost string, upstreamPort int, ssl bool) error {
+	domainVhostFn = func(domain, upstreamHost string, upstreamPort int, ssl, cors bool) error {
 		rec.vhosts = append(rec.vhosts, fmt.Sprint(domain, "|", upstreamHost, "|", upstreamPort, "|", ssl))
+		rec.cors = append(rec.cors, cors)
 		return nil
 	}
 	domainRemoveVhostFn = func(domain string) error {


### PR DESCRIPTION
A service domain gives the app and the browser one name to agree on, which is what makes a presigned signature verify. A page that uploads to the service directly still failed before the upload started: the browser asks the service for permission first and sends nothing unless the answer names the origin the page came from, and the vhost did not answer.

It does now, for a service that asks for it. The origin is reflected rather than wildcarded, matched against the hosts lerd serves, so a page on the open internet cannot read a local service over JS the moment a developer leaves a tab open. Whatever the upstream says about CORS is dropped before ours is added, because an object store answering with its own header would otherwise leave two on the response. The preflight reflects the headers that were asked for rather than replying with a wildcard, which Safari does not accept there, and ETag is exposed so a multipart upload can confirm its parts.

RustFS asks for it in its preset, beside the domain it already declares, so the answer travels with the service definition. --cors turns it on for a service whose preset says nothing and --no-cors off for one that does, and only a recorded refusal counts as one, so a preset default is not handed back to someone who turned it off.

Closes #1710