### PR TITLE
feat: keep rolling backups of the site registry and add lerd sites:restore

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -135,6 +135,7 @@ func main() {
 	root.AddCommand(cli.NewRebuildCmd())
 	root.AddCommand(cli.NewUnparkCmd())
 	root.AddCommand(cli.NewSitesCmd())
+	root.AddCommand(cli.NewSitesRestoreCmd())
 	root.AddCommand(cli.NewSecureCmd())
 	root.AddCommand(cli.NewUnsecureCmd())
 	root.AddCommand(cli.NewUseCmd())

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -77,6 +77,7 @@ Setup steps include common tasks (composer install, npm install, lerd env) plus 
 | `lerd link [name] --domain foo.test` | Register with a custom domain |
 | `lerd unlink [name]` | Stop serving the site; defaults to the site in the current directory, and naming one is the way to unlink a site whose directory has moved or been deleted |
 | `lerd sites` | Table view of all registered sites |
+| `lerd sites:restore [backup]` | Put the site registry back from one of its automatic backups; `--list` shows what is kept |
 | `lerd open [name]` | Open the site in the default browser |
 | `lerd code [name]` | Open the site's directory in your editor: the `editor` command from `~/.config/lerd/config.yaml` if set, otherwise the first known GUI editor found on PATH. Run from inside a git worktree it opens the worktree itself |
 | `lerd share [name]` | Expose the site publicly via ngrok, cloudflared, or Expose (auto-detected); `--serveo`, `--localhost-run` and `--pinggy` pick the SSH tunnels that need no signup |

--- a/docs/reference/directory-layout.md
+++ b/docs/reference/directory-layout.md
@@ -30,7 +30,8 @@
 ├── vapid-public.key                 # Web Push public key, served to browsers
 ├── push-subscriptions.json          # Browser push subscriptions + per-category prefs (mode 0600)
 ├── nginx-trust-token                # Per-install secret for lerd.localhost → lerd-ui proxy
-└── sites.yaml
+├── sites.yaml
+└── sites.bkp/                      # last 10 versions of sites.yaml (lerd sites:restore)
 ```
 
 All directories follow the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/). Lerd never writes to system directories except during `lerd install` (DNS setup) which requires `sudo`.

--- a/docs/usage/sites.md
+++ b/docs/usage/sites.md
@@ -13,6 +13,7 @@ This page covers getting a project registered and served: the init wizard, linki
 | `lerd link [domain]` | Register the current directory as a site (domain name without TLD, defaults to directory name). On a fresh project in an interactive terminal it runs the `lerd init` wizard first |
 | `lerd unlink` | Unlink the current directory site (removes all domains) |
 | `lerd sites` | Table view of all registered sites |
+| `lerd sites:restore [backup]` | Put the site registry back from one of its automatic backups |
 | `lerd open [name]` | Open the site in the default browser |
 | `lerd code [name]` | Open the site's directory in the configured editor |
 | `lerd secure [name]` | Issue a mkcert TLS cert and enable HTTPS, updates `APP_URL` in `.env` |
@@ -226,6 +227,20 @@ success.
 When you unlink a site that lives inside a parked directory, the vhost is removed but the registry entry is kept and marked as *ignored*; the watcher will not re-register it on its next scan. Running `lerd link` in that directory clears the ignored flag and restores the site.
 
 Either way, unlinking also drops the site's per-site [request-timing](../features/request-timing.md) and idle state: its rows in the durable request store, its entries in the persisted request-timing and idle-activity snapshots, and the running watcher's in-memory copy, so an unlinked site leaves no stale traffic history behind. A site's git worktrees are covered too.
+
+---
+
+## Registry backups
+
+Every registered site lives in `~/.local/share/lerd/sites.yaml`. Lerd copies that file aside before each change that rewrites it, keeping the last ten versions in `~/.local/share/lerd/sites.bkp/`, so a registry that comes back short does not mean linking everything again. A rewrite that changes nothing is not backed up, which keeps the window covering real edits rather than the last few minutes of background activity.
+
+```bash
+lerd sites:restore --list     # what is kept, with the number of sites in each
+lerd sites:restore            # put the newest one back
+lerd sites:restore sites-20260908-141530.000.yaml
+```
+
+Restoring rewrites `sites.yaml` and regenerates the nginx vhosts for the sites that came back. The registry it replaced is backed up in turn, so restoring the wrong version is undone by restoring again. Containers and workers are not touched, run `lerd start` afterwards to bring them back up.
 
 ---
 

--- a/internal/cli/sites_restore.go
+++ b/internal/cli/sites_restore.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
+	"github.com/geodro/lerd/internal/nginx"
+	"github.com/spf13/cobra"
+)
+
+// NewSitesRestoreCmd returns the sites:restore command.
+func NewSitesRestoreCmd() *cobra.Command {
+	var list bool
+	cmd := &cobra.Command{
+		Use:   "sites:restore [backup]",
+		Short: "Put the site registry back from one of its automatic backups",
+		Long: `Lerd copies its site registry aside before every change that rewrites it, so
+a registry that loses sites can be put back without relinking them one by one.
+
+With no argument the newest backup is restored. The registry it replaces is
+backed up in turn, so restoring the wrong one is undone by restoring again.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			name := ""
+			if len(args) > 0 {
+				name = args[0]
+			}
+			return runSitesRestore(name, list)
+		},
+	}
+	cmd.Flags().BoolVar(&list, "list", false, "Show the available backups without restoring anything")
+	return cmd
+}
+
+func runSitesRestore(name string, list bool) error {
+	backups, err := config.ListSitesBackups()
+	if err != nil {
+		return err
+	}
+	if len(backups) == 0 {
+		return fmt.Errorf("no site registry backup available yet")
+	}
+
+	if list {
+		fmt.Println()
+		for _, b := range backups {
+			fmt.Printf("  %s  %s  %s\n",
+				b.Name,
+				b.Time.Format("2006-01-02 15:04:05"),
+				feedback.Dim(fmt.Sprintf("%d site(s)", b.Sites)))
+		}
+		fmt.Println()
+		fmt.Println("Restore one with: lerd sites:restore <name>")
+		return nil
+	}
+
+	reg, used, err := config.RestoreSitesBackup(name)
+	if err != nil {
+		return err
+	}
+
+	feedback.Begin()
+	feedback.Start("restoring the site registry").OK(feedback.Val(used))
+	for _, site := range reg.Sites {
+		if err := nginx.RegenerateVhost(site); err != nil {
+			feedback.Warn("regenerating vhost for %s: %v", site.Name, err)
+		}
+	}
+	nginx.ReloadOrWarn("  ")
+	feedback.Done(fmt.Sprintf("%d site(s) restored", len(reg.Sites)))
+	fmt.Println("Run 'lerd start' to bring their containers and workers back up.")
+	return nil
+}

--- a/internal/cli/sites_restore_test.go
+++ b/internal/cli/sites_restore_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// A registry that has never been rewritten has nothing to restore, and the
+// command has to say so rather than report a successful restore of nothing.
+func TestSitesRestoreWithoutBackups(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	err := runSitesRestore("", false)
+	if err == nil || !strings.Contains(err.Error(), "no site registry backup") {
+		t.Fatalf("want a no-backup error, got %v", err)
+	}
+	if err := runSitesRestore("", true); err == nil {
+		t.Error("--list should report the same when there is nothing to list")
+	}
+}
+
+func TestSitesRestoreRejectsUnknownBackup(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if err := config.SaveSites(&config.SiteRegistry{Sites: []config.Site{{
+		Name: "one", Domains: []string{"one.test"}, Path: "/srv/one",
+	}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveSites(&config.SiteRegistry{}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runSitesRestore("sites-20260101-000000.000.yaml", false)
+	if err == nil || !strings.Contains(err.Error(), "no such backup") {
+		t.Fatalf("want a no-such-backup error, got %v", err)
+	}
+}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -156,6 +156,12 @@ func SitesFile() string {
 	return filepath.Join(DataDir(), "sites.yaml")
 }
 
+// SitesBackupDir holds the rolling copies of sites.yaml taken before each
+// change, so a registry that loses its sites can be put back.
+func SitesBackupDir() string {
+	return filepath.Join(DataDir(), "sites.bkp")
+}
+
 // GlobalConfigFile returns the path to config.yaml.
 func GlobalConfigFile() string {
 	return filepath.Join(ConfigDir(), "config.yaml")

--- a/internal/config/site.go
+++ b/internal/config/site.go
@@ -390,13 +390,9 @@ func LoadSites() (*SiteRegistry, error) {
 		return nil, err
 	}
 
-	var raw siteRegistryYAML
-	if err := yaml.Unmarshal(data, &raw); err != nil {
+	reg, err := decodeSiteRegistry(data)
+	if err != nil {
 		return nil, err
-	}
-	reg := &SiteRegistry{Sites: make([]Site, len(raw.Sites))}
-	for i, sy := range raw.Sites {
-		reg.Sites[i] = sy.toSite()
 	}
 
 	if statErr == nil {
@@ -405,6 +401,20 @@ func LoadSites() (*SiteRegistry, error) {
 		sitesCacheAt = info.ModTime()
 		sitesCacheSz = info.Size()
 		sitesCacheMu.Unlock()
+	}
+	return reg, nil
+}
+
+// decodeSiteRegistry parses sites.yaml bytes, shared by the live file and the
+// rolling backups so both go through one schema.
+func decodeSiteRegistry(data []byte) (*SiteRegistry, error) {
+	var raw siteRegistryYAML
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	reg := &SiteRegistry{Sites: make([]Site, len(raw.Sites))}
+	for i, sy := range raw.Sites {
+		reg.Sites[i] = sy.toSite()
 	}
 	return reg, nil
 }
@@ -457,6 +467,7 @@ func SaveSites(reg *SiteRegistry) error {
 	if err != nil {
 		return err
 	}
+	backupSitesFile(data)
 	if err := writeFileAtomic(SitesFile(), data, 0644); err != nil {
 		return err
 	}

--- a/internal/config/site_backup.go
+++ b/internal/config/site_backup.go
@@ -1,0 +1,195 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// sitesBackupKeep is how many previous versions of sites.yaml are kept. Only a
+// save that changes the file pushes one in, so ten covers days of ordinary use
+// while staying small enough to never matter on disk.
+const sitesBackupKeep = 10
+
+// A backup is named for the second it was taken plus a counter, so the names
+// sort in the order the backups were taken even when a save follows a save.
+const sitesBackupTimeLayout = "20060102-150405"
+
+var sitesBackupRe = regexp.MustCompile(`\Asites-(\d{8}-\d{6})\.(\d{3})\.yaml\z`)
+
+// SitesBackup is one kept registry. Sites is the number of sites it holds,
+// which is what tells a good backup from the one taken right after a wipe.
+type SitesBackup struct {
+	Name  string    `json:"name"`
+	Time  time.Time `json:"time"`
+	Sites int       `json:"sites"`
+}
+
+var sitesBackupMu sync.Mutex
+
+// backupSitesFile preserves the current sites.yaml before next is written over
+// it. A save that changes nothing is skipped, which matters because the daemon
+// rewrites the registry constantly (idle state, worker toggles, version
+// refreshes) and that churn would otherwise push the last real edit out of the
+// window within minutes.
+//
+// Every failure here is silent on purpose: a safety net that fails must not
+// take the save down with it.
+func backupSitesFile(next []byte) {
+	// Two writers picking the same free name would leave one version behind.
+	sitesBackupMu.Lock()
+	defer sitesBackupMu.Unlock()
+
+	current, err := os.ReadFile(SitesFile())
+	if err != nil || len(current) == 0 || bytes.Equal(current, next) {
+		return
+	}
+	if newest, err := newestSitesBackup(); err == nil && bytes.Equal(newest, current) {
+		return
+	}
+	if err := os.MkdirAll(SitesBackupDir(), 0755); err != nil {
+		return
+	}
+	path, err := uniqueSitesBackupPath(time.Now())
+	if err != nil {
+		return
+	}
+	if err := writeFileAtomic(path, current, 0644); err != nil {
+		return
+	}
+	pruneSitesBackups()
+}
+
+// uniqueSitesBackupPath names the next backup for this second: one past the
+// highest counter already there, never a freed one, so the names keep sorting
+// in the order the backups were taken even after a prune.
+func uniqueSitesBackupPath(now time.Time) (string, error) {
+	stamp := now.Format(sitesBackupTimeLayout)
+	names, err := listSitesBackupNames()
+	if err != nil {
+		return "", err
+	}
+	next := 0
+	for _, name := range names {
+		m := sitesBackupRe.FindStringSubmatch(name)
+		if m[1] != stamp {
+			continue
+		}
+		n, _ := strconv.Atoi(m[2])
+		if n+1 > next {
+			next = n + 1
+		}
+	}
+	if next > 999 {
+		return "", fmt.Errorf("backup name space exhausted for %s", stamp)
+	}
+	return filepath.Join(SitesBackupDir(), fmt.Sprintf("sites-%s.%03d.yaml", stamp, next)), nil
+}
+
+func newestSitesBackup() ([]byte, error) {
+	list, err := listSitesBackupNames()
+	if err != nil || len(list) == 0 {
+		if err == nil {
+			err = os.ErrNotExist
+		}
+		return nil, err
+	}
+	return os.ReadFile(filepath.Join(SitesBackupDir(), list[0]))
+}
+
+// listSitesBackupNames returns the backup file names, newest first.
+func listSitesBackupNames() ([]string, error) {
+	entries, err := os.ReadDir(SitesBackupDir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() && sitesBackupRe.MatchString(e.Name()) {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(names)))
+	return names, nil
+}
+
+func pruneSitesBackups() {
+	names, err := listSitesBackupNames()
+	if err != nil {
+		return
+	}
+	for _, name := range names[min(len(names), sitesBackupKeep):] {
+		os.Remove(filepath.Join(SitesBackupDir(), name)) //nolint:errcheck
+	}
+}
+
+// ListSitesBackups returns the kept registries, newest first.
+func ListSitesBackups() ([]SitesBackup, error) {
+	names, err := listSitesBackupNames()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]SitesBackup, 0, len(names))
+	for _, name := range names {
+		reg, err := ReadSitesBackup(name)
+		if err != nil {
+			continue
+		}
+		stamp, _ := time.ParseInLocation(sitesBackupTimeLayout, sitesBackupRe.FindStringSubmatch(name)[1], time.Local)
+		out = append(out, SitesBackup{Name: name, Time: stamp, Sites: len(reg.Sites)})
+	}
+	return out, nil
+}
+
+// ReadSitesBackup parses one backup. The name is validated first, so a caller
+// can pass it straight through from a CLI argument or an API request.
+func ReadSitesBackup(name string) (*SiteRegistry, error) {
+	if !sitesBackupRe.MatchString(name) {
+		return nil, os.ErrNotExist
+	}
+	data, err := os.ReadFile(filepath.Join(SitesBackupDir(), name))
+	if err != nil {
+		return nil, err
+	}
+	return decodeSiteRegistry(data)
+}
+
+// RestoreSitesBackup writes a kept registry back over sites.yaml, returning it
+// with the name it came from. An empty name takes the newest. The registry it
+// replaces is backed up by the save itself, so restoring the wrong one is
+// undone by restoring again.
+func RestoreSitesBackup(name string) (*SiteRegistry, string, error) {
+	siteWriteMu.Lock()
+	defer siteWriteMu.Unlock()
+
+	names, err := listSitesBackupNames()
+	if err != nil {
+		return nil, "", err
+	}
+	if len(names) == 0 {
+		return nil, "", fmt.Errorf("no sites.yaml backup available")
+	}
+	if name == "" {
+		name = names[0]
+	} else if !slices.Contains(names, name) {
+		return nil, "", fmt.Errorf("no such backup: %s", name)
+	}
+	reg, err := ReadSitesBackup(name)
+	if err != nil {
+		return nil, "", fmt.Errorf("reading backup %s: %w", name, err)
+	}
+	if err := SaveSites(reg); err != nil {
+		return nil, "", err
+	}
+	return reg, name, nil
+}

--- a/internal/config/site_backup_test.go
+++ b/internal/config/site_backup_test.go
@@ -1,0 +1,188 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func regOf(names ...string) *SiteRegistry {
+	reg := &SiteRegistry{}
+	for _, n := range names {
+		reg.Sites = append(reg.Sites, Site{Name: n, Domains: []string{n + ".test"}, Path: "/srv/" + n})
+	}
+	return reg
+}
+
+func backupNames(t *testing.T) []string {
+	t.Helper()
+	list, err := ListSitesBackups()
+	if err != nil {
+		t.Fatalf("ListSitesBackups: %v", err)
+	}
+	out := make([]string, len(list))
+	for i, b := range list {
+		out[i] = b.Name
+	}
+	return out
+}
+
+// The first save has nothing to preserve, and every later save keeps the
+// contents it is about to overwrite.
+func TestSaveSitesKeepsPreviousContents(t *testing.T) {
+	setDataDir(t)
+
+	if err := SaveSites(regOf("one")); err != nil {
+		t.Fatal(err)
+	}
+	if got := backupNames(t); len(got) != 0 {
+		t.Fatalf("first save should not back anything up, got %v", got)
+	}
+
+	if err := SaveSites(regOf("one", "two")); err != nil {
+		t.Fatal(err)
+	}
+	list, err := ListSitesBackups()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("want 1 backup, got %d", len(list))
+	}
+	if list[0].Sites != 1 {
+		t.Errorf("backup should hold the pre-save registry, got %d sites", list[0].Sites)
+	}
+
+	reg, err := ReadSitesBackup(list[0].Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reg.Sites) != 1 || reg.Sites[0].Name != "one" {
+		t.Errorf("backup contents = %+v", reg.Sites)
+	}
+}
+
+// The registry is rewritten constantly (idle state, worker toggles, version
+// refreshes). A save that changes nothing must not push a real edit out of the
+// window.
+func TestSaveSitesSkipsUnchangedWrites(t *testing.T) {
+	setDataDir(t)
+
+	if err := SaveSites(regOf("one")); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 5; i++ {
+		if err := SaveSites(regOf("one")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := backupNames(t); len(got) != 0 {
+		t.Fatalf("identical saves should not create backups, got %v", got)
+	}
+}
+
+func TestSaveSitesRotatesBackups(t *testing.T) {
+	setDataDir(t)
+
+	for i := 0; i <= sitesBackupKeep+3; i++ {
+		if err := SaveSites(regOf(names(i)...)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	list, err := ListSitesBackups()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != sitesBackupKeep {
+		t.Fatalf("want %d backups, got %d", sitesBackupKeep, len(list))
+	}
+	// Newest first, and the newest holds the registry the last save replaced.
+	if list[0].Sites != sitesBackupKeep+2 {
+		t.Errorf("newest backup has %d sites, want %d", list[0].Sites, sitesBackupKeep+2)
+	}
+	if list[0].Name <= list[len(list)-1].Name {
+		t.Errorf("backups are not newest first: %v", backupNames(t))
+	}
+}
+
+// The wipe this exists for: the registry is emptied and keeps being rewritten
+// empty. The last good state must still be in the window.
+func TestEmptySavesDoNotFlushTheWindow(t *testing.T) {
+	setDataDir(t)
+
+	if err := SaveSites(regOf(names(20)...)); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 30; i++ {
+		if err := SaveSites(&SiteRegistry{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	list, err := ListSitesBackups()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 || list[0].Sites != 20 {
+		t.Fatalf("want the 20-site registry preserved, got %+v", list)
+	}
+}
+
+func TestRestoreSitesBackup(t *testing.T) {
+	setDataDir(t)
+
+	if err := SaveSites(regOf("one", "two")); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveSites(&SiteRegistry{}); err != nil {
+		t.Fatal(err)
+	}
+
+	restored, name, err := RestoreSitesBackup("")
+	if err != nil {
+		t.Fatalf("RestoreSitesBackup: %v", err)
+	}
+	if name == "" {
+		t.Error("restore should report which backup it used")
+	}
+	if len(restored.Sites) != 2 {
+		t.Fatalf("restored %d sites, want 2", len(restored.Sites))
+	}
+	live, err := LoadSites()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(live.Sites) != 2 {
+		t.Fatalf("sites.yaml holds %d sites after restore, want 2", len(live.Sites))
+	}
+	// The registry the restore replaced is itself backed up, so a restore of
+	// the wrong backup can be undone.
+	list, err := ListSitesBackups()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) == 0 || list[0].Sites != 0 {
+		t.Errorf("restore should back up the emptied registry, got %+v", list)
+	}
+}
+
+func TestRestoreSitesBackupRejectsUnknownName(t *testing.T) {
+	setDataDir(t)
+
+	if _, _, err := RestoreSitesBackup("sites-20260101-000000.yaml"); err == nil {
+		t.Error("restoring a missing backup should fail")
+	}
+	if _, _, err := RestoreSitesBackup("../../sites.yaml"); err == nil {
+		t.Error("a traversing name should be refused")
+	}
+	if _, err := os.Stat(filepath.Join(SitesBackupDir())); err == nil {
+		t.Error("a failed restore should not create the backup dir")
+	}
+}
+
+func names(n int) []string {
+	out := make([]string, n)
+	for i := range out {
+		out[i] = "s" + string(rune('a'+i%26)) + string(rune('a'+i/26))
+	}
+	return out
+}


### PR DESCRIPTION
A registry that comes back short is the worst thing lerd can do to someone, because the only way out is linking every project again by hand. Nothing in lerd empties sites.yaml on its own and the file is written atomically, so a report of sites disappearing after a reboot has nowhere to point, and by the time anyone looks the evidence has been overwritten by the next save.

Lerd now copies sites.yaml aside before every change that rewrites it, keeping the last ten versions in sites.bkp next to it. A save that changes nothing is skipped, which matters more than it sounds: the daemon rewrites the registry constantly for idle state, worker toggles and version refreshes, and that churn would push the last real edit out of the window within minutes. It also means a wipe that keeps rewriting an empty registry only takes one slot, so the good state stays at the top instead of being flushed out by the failure repeating itself.

lerd sites:restore puts one back, the newest by default or a named one, and --list shows what is kept with the number of sites in each, which is what tells a good version from the one taken right after a wipe. Restoring regenerates the nginx vhosts for the sites that came back and reloads, and the registry it replaces is backed up in turn, so restoring the wrong version is undone by restoring again.

Refs #1712
