### PR TITLE
fix: scaffold from the newest major that has a skeleton

### DIFF
--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -159,6 +159,13 @@ the release that lands on disk is the one you asked for rather than whatever is
 newest, and the PHP range, workers and env wiring the definition brings match the
 code beside them.
 
+Not every major has a skeleton to start from. A framework can outlive the project
+template it shipped with, and the definition for such a major carries no create
+command at all. The version question leaves those majors out, and a run that
+pinned none scaffolds from the newest one that still has a skeleton, so the
+project on disk is a release that really exists. Asking for that major by name
+with `--framework-version` says so rather than quietly building an older one.
+
 The command then carries the project the rest of the way: it links the new
 directory, which routes a project with no `.lerd.yaml` through the
 [init wizard](/usage/sites) for PHP version, HTTPS and services, and offers setup

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -195,6 +195,20 @@ func runScaffold(plan scaffold, workDir, version string) error {
 	return cmd.Run()
 }
 
+// scaffoldUnavailableError explains a framework lerd cannot start a project
+// from. A major that ships no project skeleton while the ones before it do is
+// not a broken definition, so it names the run that would work instead.
+func scaffoldUnavailableError(name, version string) error {
+	if version != "" {
+		for _, scaffolds := range config.FrameworkScaffoldSupport(name) {
+			if scaffolds {
+				return fmt.Errorf("%s %s ships no project skeleton — leave --framework-version off to scaffold the newest major that does", name, version)
+			}
+		}
+	}
+	return fmt.Errorf("framework %q has no create command — add a 'create' field to its YAML definition", name)
+}
+
 func runNew(target, frameworkName, frameworkVersion string, extraArgs []string) error {
 	interactive := isInteractive()
 
@@ -246,7 +260,7 @@ func runNew(target, frameworkName, frameworkVersion string, extraArgs []string) 
 		return fmt.Errorf("unknown framework %q — run 'lerd framework list' to see available frameworks", frameworkName)
 	}
 	if fw.Create == "" {
-		return fmt.Errorf("framework %q has no create command — add a 'create' field to its YAML definition", frameworkName)
+		return scaffoldUnavailableError(frameworkName, frameworkVersion)
 	}
 
 	if err := prepareScaffoldParent(target); err != nil {

--- a/internal/cli/new_version_flag_test.go
+++ b/internal/cli/new_version_flag_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/geodro/lerd/internal/config"
 )
 
 // runNewCmdVersion parses args through the real command and reports both
@@ -60,5 +62,53 @@ func TestRunNewRejectsVersionWithoutFramework(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--framework") {
 		t.Errorf("error = %v, want it to name the missing flag", err)
+	}
+}
+
+// A major that ships no project skeleton while others do is not a broken
+// definition, and telling the user to add a create field sends them to fix a
+// file that is right. It names the run that would work instead.
+func TestScaffoldUnavailableError_PointsAtTheMajorsThatScaffold(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	if err := config.SaveStoreFramework(&config.Framework{
+		Name: "lumen", Label: "Lumen", Version: "11", PublicDir: "public",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveStoreFramework(&config.Framework{
+		Name: "lumen", Label: "Lumen", Version: "10", PublicDir: "public",
+		Create: "composer create-project laravel/lumen",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := scaffoldUnavailableError("lumen", "11")
+	if !strings.Contains(err.Error(), "--framework-version") {
+		t.Errorf("error = %v, want it to name the flag to drop", err)
+	}
+	if strings.Contains(err.Error(), "create") {
+		t.Errorf("error = %v, want no advice to edit the definition", err)
+	}
+}
+
+// A framework no major of which can scaffold is a definition question after all,
+// and the message stays the one that says so.
+func TestScaffoldUnavailableError_KeepsTheDefinitionAdvice(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	if err := config.SaveStoreFramework(&config.Framework{
+		Name: "wordpress", Label: "WordPress", Version: "6", PublicDir: ".",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := scaffoldUnavailableError("wordpress", "6")
+	if !strings.Contains(err.Error(), "create") {
+		t.Errorf("error = %v, want the definition advice", err)
 	}
 }

--- a/internal/cli/new_wizard.go
+++ b/internal/cli/new_wizard.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -32,6 +33,9 @@ type scaffoldChoice struct {
 	// nothing about it is known yet, and it is offered rather than hidden.
 	sawDefinition bool
 	creatable     bool
+	// scaffolds answers, for each major a definition was read for, whether that
+	// major can start a project. A major missing from it was never inspected.
+	scaffolds map[string]bool
 }
 
 // canScaffold reports whether the wizard should offer this framework. Not every
@@ -39,7 +43,18 @@ type scaffoldChoice struct {
 // is not a composer create-project at all, and offering one only to refuse it
 // after the questions is worse than never listing it.
 func (c scaffoldChoice) canScaffold() bool {
-	return c.creatable || !c.sawDefinition
+	if c.creatable || !c.sawDefinition {
+		return true
+	}
+	// A major whose definition is not installed says nothing either way, so the
+	// framework is only dropped once every major it publishes has been read and
+	// none of them can scaffold.
+	for _, v := range c.Versions {
+		if _, inspected := c.scaffolds[v]; !inspected {
+			return true
+		}
+	}
+	return false
 }
 
 // scaffoldCatalogue lists the frameworks `lerd new` can scaffold. It reads the
@@ -83,8 +98,14 @@ func scaffoldCatalogue() []scaffoldChoice {
 		c := add(info.Name, info.Label)
 		c.Versions = appendVersion(c.Versions, info.Version)
 		c.sawDefinition = true
+		c.scaffolds = config.FrameworkScaffoldSupport(info.Name)
 		if info.Create != "" {
 			c.creatable = true
+		}
+		for _, scaffolds := range c.scaffolds {
+			if scaffolds {
+				c.creatable = true
+			}
 		}
 	}
 	sort.Strings(localOnly)
@@ -96,6 +117,7 @@ func scaffoldCatalogue() []scaffoldChoice {
 			continue
 		}
 		sortFrameworkVersionsDesc(c.Versions)
+		c.Versions = versionsThatScaffold(c.Versions, c.scaffolds)
 		if c.Latest == "" && len(c.Versions) > 0 {
 			c.Latest = c.Versions[0]
 		}
@@ -140,6 +162,21 @@ func appendVersion(versions []string, v string) []string {
 		}
 	}
 	return append(versions, v)
+}
+
+// versionsThatScaffold drops the majors whose definition was read here and
+// carries no create command, so the wizard never asks a question it would only
+// refuse to act on. A major with no definition here stays: nothing is known
+// about it yet, and it is fetched when picked.
+func versionsThatScaffold(versions []string, scaffolds map[string]bool) []string {
+	out := make([]string, 0, len(versions))
+	for _, v := range versions {
+		if canScaffold, inspected := scaffolds[v]; inspected && !canScaffold {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
 }
 
 // sortFrameworkVersionsDesc orders majors newest first, numerically, so 9 sits
@@ -258,6 +295,9 @@ func askScaffoldFramework(catalogue []scaffoldChoice) (string, string, error) {
 	}
 
 	version := choice.Latest
+	if !slices.Contains(choice.Versions, version) {
+		version = choice.Versions[0]
+	}
 	if err := huh.NewForm(huh.NewGroup(
 		huh.NewSelect[string]().
 			Title(choice.Label + " version").

--- a/internal/cli/new_wizard_test.go
+++ b/internal/cli/new_wizard_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
@@ -113,6 +114,68 @@ func TestScaffoldCatalogue_KeepsPublishedFrameworksItCannotInspect(t *testing.T)
 	if scaffoldChoiceByName(got, "tempest") == nil {
 		t.Errorf("catalogue = %v, want the uninstalled tempest still offered",
 			catalogueNames(got))
+	}
+}
+
+// A framework whose newest major ships no project skeleton keeps the majors that
+// do. Dropping the whole name would hide every version it can still scaffold,
+// and offering the major it cannot only refuses the run after every question.
+func TestScaffoldCatalogue_OffersOnlyTheMajorsThatScaffold(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	writeStoreIndex(t, `{"frameworks":[
+	  {"name":"lumen","label":"Lumen","versions":["11","10"],"latest":"11"}
+	]}`)
+	if err := config.SaveStoreFramework(&config.Framework{
+		Name: "lumen", Label: "Lumen", Version: "11", PublicDir: "public",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveStoreFramework(&config.Framework{
+		Name: "lumen", Label: "Lumen", Version: "10", PublicDir: "public",
+		Create: "composer create-project laravel/lumen",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := scaffoldCatalogue()
+	lumen := scaffoldChoiceByName(got, "lumen")
+	if lumen == nil {
+		t.Fatalf("catalogue = %v, want lumen offered: major 10 scaffolds", catalogueNames(got))
+	}
+	if slices.Contains(lumen.Versions, "11") {
+		t.Errorf("versions = %v, want 11 left out: it ships no skeleton", lumen.Versions)
+	}
+	if !slices.Contains(lumen.Versions, "10") {
+		t.Errorf("versions = %v, want 10 offered", lumen.Versions)
+	}
+}
+
+// A major this machine holds no definition for says nothing about whether it can
+// scaffold, so the one installed major failing to is no reason to drop the rest.
+func TestScaffoldCatalogue_KeepsMajorsItHasNotRead(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	writeStoreIndex(t, `{"frameworks":[
+	  {"name":"lumen","label":"Lumen","versions":["11","10"],"latest":"11"}
+	]}`)
+	if err := config.SaveStoreFramework(&config.Framework{
+		Name: "lumen", Label: "Lumen", Version: "11", PublicDir: "public",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := scaffoldCatalogue()
+	lumen := scaffoldChoiceByName(got, "lumen")
+	if lumen == nil {
+		t.Fatalf("catalogue = %v, want lumen offered: major 10 was never read", catalogueNames(got))
+	}
+	if !slices.Contains(lumen.Versions, "10") {
+		t.Errorf("versions = %v, want the uninspected 10 offered", lumen.Versions)
 	}
 }
 

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -1165,7 +1165,48 @@ func GetFrameworkForScaffold(name, version string) (*Framework, bool) {
 	if base == nil || (base.Create == "" && builtinFramework(name) != nil) {
 		return GetFramework(name)
 	}
+	// A framework's newest major can ship no project skeleton at all while the
+	// ones before it do. Only a run that pinned that major asked for it, so an
+	// unpinned one starts from the newest definition that can still scaffold.
+	if base.Create == "" && version == "" {
+		if creatable := newestScaffoldableFramework(name); creatable != nil {
+			base = creatable
+		}
+	}
 	return mergeBuiltinTinker(mergeBuiltinFrankenPHP(mergeUserOverlay(base))), true
+}
+
+// newestScaffoldableFramework returns the highest major of a framework whose
+// definition carries a create command, or nil when none does. It walks the
+// majors this install knows of, published as well as installed, since a machine
+// that has only ever fetched the newest definition has nothing older on disk.
+func newestScaffoldableFramework(name string) *Framework {
+	vers := availableFrameworkVersions(name)
+	for i := len(vers) - 1; i >= 0; i-- {
+		v := strconv.Itoa(vers[i])
+		fw := loadFrameworkYAML(filepath.Join(StoreFrameworksDir(), name+"@"+v+".yaml"))
+		if fw == nil && frameworkFetchHook != nil {
+			fw, _ = frameworkFetchHook(name, v)
+		}
+		if fw != nil && fw.Create != "" {
+			return fw
+		}
+	}
+	return nil
+}
+
+// FrameworkScaffoldSupport reports, for every major this install holds a
+// definition of, whether that definition can start a project. Scaffolding is a
+// question per major rather than per framework: the newest one can ship no
+// skeleton while the ones before it do.
+func FrameworkScaffoldSupport(name string) map[string]bool {
+	out := map[string]bool{}
+	for _, path := range versionedFrameworkPaths(name) {
+		if fw := loadFrameworkYAML(path); fw != nil && fw.Version != "" {
+			out[fw.Version] = fw.Create != ""
+		}
+	}
+	return out
 }
 
 // loadBaseFramework returns the base definition for a framework:

--- a/internal/config/framework_test.go
+++ b/internal/config/framework_test.go
@@ -277,6 +277,46 @@ func TestGetFrameworkForScaffold_BuiltinSurvivesADefinitionThatCannotScaffold(t 
 	}
 }
 
+// A framework's newest major can ship no project skeleton at all while the ones
+// before it do, and a run that pinned nothing did not ask for that major. It
+// scaffolds from the newest one that can rather than refusing the framework.
+func TestGetFrameworkForScaffold_FallsBackToTheNewestMajorThatScaffolds(t *testing.T) {
+	setConfigDir(t)
+
+	const create = "composer create-project laravel/lumen:^10.0"
+	installStoreFramework(t, &Framework{Name: "lumen", Label: "Lumen", Version: "11", PublicDir: "public"})
+	installStoreFramework(t, &Framework{Name: "lumen", Label: "Lumen", Version: "10", PublicDir: "public", Create: create})
+
+	got, ok := GetFrameworkForScaffold("lumen", "")
+	if !ok {
+		t.Fatal("GetFrameworkForScaffold(lumen): not found")
+	}
+	if got.Create != create {
+		t.Errorf("Create = %q, want %q", got.Create, create)
+	}
+	if got.Version != "10" {
+		t.Errorf("Version = %q, want the newest major that scaffolds, 10", got.Version)
+	}
+}
+
+// A pinned major is the one asked for. Answering it with an older skeleton would
+// lay down a project of a different major than the one requested.
+func TestGetFrameworkForScaffold_KeepsAPinnedMajorThatCannotScaffold(t *testing.T) {
+	setConfigDir(t)
+
+	installStoreFramework(t, &Framework{Name: "lumen", Label: "Lumen", Version: "11", PublicDir: "public"})
+	installStoreFramework(t, &Framework{Name: "lumen", Label: "Lumen", Version: "10", PublicDir: "public",
+		Create: "composer create-project laravel/lumen:^10.0"})
+
+	got, ok := GetFrameworkForScaffold("lumen", "11")
+	if !ok {
+		t.Fatal("GetFrameworkForScaffold(lumen, 11): not found")
+	}
+	if got.Create != "" {
+		t.Errorf("Create = %q, want none: major 11 ships no skeleton", got.Create)
+	}
+}
+
 // An unreachable store leaves the built-in as the scaffold definition, so
 // `lerd new` still works offline.
 func TestGetFrameworkForScaffold_FallsBackToBuiltin(t *testing.T) {


### PR DESCRIPTION
A framework definition can carry no create command at all. That is what one looks like once a framework outlives the project template it shipped with, and its newest major has no skeleton left to scaffold from. Lumen is the first of these to reach the store: major 11 exists, but the skeleton repository was archived at 10.

Until now that cost the whole framework rather than the one major. The scaffold catalogue reads one definition per name, the highest installed, so a machine that had fetched the newest one stopped offering the framework in `lerd new` and in the dashboard wizard, even though every major before it scaffolds fine. A run that pinned nothing resolved to that major and refused, asking for a create field to be added to a definition that is already right.

A run that pins no major now falls back to the newest one that still has a skeleton, and the version question leaves out the majors whose definition says they have none. A major the machine holds no definition for stays on offer, since nothing is known about it either way and it is fetched when picked. Pinning the major that ships no skeleton still resolves to that major rather than quietly laying down an older release under its name, and reports what happened instead of pointing at the definition.

Closes #1714