### PR TITLE
fix: answer lerd version, and say what lerd restart restarts

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -177,6 +177,7 @@ func main() {
 	root.AddCommand(cli.NewCheckCmd())
 	root.AddCommand(cli.NewRunCmd())
 	root.AddCommand(cli.NewAboutCmd())
+	root.AddCommand(cli.NewVersionCmd())
 	root.AddCommand(cli.NewLicensesCmd())
 	root.AddCommand(cli.NewWhatsnewCmd())
 	root.AddCommand(cli.NewManCmd())

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -27,6 +27,7 @@
 | `lerd status` | Health summary: DNS, nginx, PHP-FPM containers, watcher, services, cert expiry, LAN exposure and dashboard remote access; shows a notice if an update is available |
 | `lerd which` | Show resolved PHP version, Node version, document root, and nginx config for the current site |
 | `lerd about` | Show version, build info, and project URL |
+| `lerd version` | Print the installed version, the same line as `lerd --version` |
 | `lerd licenses` | Print the third-party license notices bundled with lerd, the copyright notices and license terms of every Go module linked into the binary and every npm package used to build the embedded dashboard |
 | `lerd man [page]` | Browse the built-in documentation in the terminal; pass a page name to jump directly (e.g. `lerd man sites`) |
 | `lerd tui` | Open a btop-style terminal dashboard with live site / service / worker status, per-site detail pane, inline domain and version editing, shell drop-in, log tailing, filter + sort, and global settings |
@@ -92,7 +93,7 @@ Setup steps include common tasks (composer install, npm install, lerd env) plus 
 | `lerd unsecure [name]` | Remove TLS and switch back to HTTP, updates `APP_URL` in `.env` |
 | `lerd pause [name]` | Pause a site: stop workers (and custom container if applicable), replace vhost with landing page |
 | `lerd unpause [name]` | Resume a paused site: start container, restore vhost, restart workers |
-| `lerd restart [name]` | Restart the container for the current or named site (custom container or PHP-FPM) |
+| `lerd restart [name]` | Restart the container serving one site (custom container, FrankenPHP, PHP-FPM or dev server). Run it inside the site's directory or name the site; it does not restart lerd, for that use `lerd stop` then `lerd start` |
 | `lerd rebuild [name]` | Rebuild the custom container image from Containerfile and restart |
 | `lerd nginx show [site]` | Print the site's custom nginx override; `--path` prints the file path instead of its content |
 | `lerd nginx edit [site]` | Open the override in `$EDITOR`, then validate it with `nginx -t` and reload on save |

--- a/internal/cli/restart.go
+++ b/internal/cli/restart.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -17,10 +18,13 @@ import (
 func NewRestartCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "restart [site]",
-		Short: "Restart the container for the current or named site",
-		Args:  cobra.MaximumNArgs(1),
+		Short: "Restart a site's container, not lerd itself",
+		Long: `Restart the container serving one site: its PHP-FPM, custom container or dev server.
+
+Run it from inside the site's directory, or name the site. This does not restart lerd; for that, use 'lerd stop' then 'lerd start', or 'lerd service restart <name>' for a single service.`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			name, err := resolveSiteName(args)
+			name, err := restartTargetName(args, siteRegistered)
 			if err != nil {
 				return err
 			}
@@ -28,6 +32,26 @@ func NewRestartCmd() *cobra.Command {
 			return RestartSite(name)
 		},
 	}
+}
+
+// restartTargetName resolves the site to restart, and says what the command is
+// for when the directory is not one. Falling through to the directory name
+// reported `site "Downloads" not found`, which reads as a site that went
+// missing rather than as a command that has to be pointed at one.
+func restartTargetName(args []string, exists func(string) bool) (string, error) {
+	name, err := resolveSiteName(args)
+	if err != nil {
+		return "", err
+	}
+	if len(args) == 0 && !exists(name) {
+		return "", errors.New("no site registered for this directory: run 'lerd restart' inside a site, or name one with 'lerd restart <site>'. It restarts that site's container, not lerd itself; for lerd run 'lerd stop' and then 'lerd start'")
+	}
+	return name, nil
+}
+
+func siteRegistered(name string) bool {
+	_, err := config.FindSite(name)
+	return err == nil
 }
 
 // hostProxyStopTimeout bounds how long an explicit restart waits for the old

--- a/internal/cli/restart_target_test.go
+++ b/internal/cli/restart_target_test.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// Run outside a site, restart used to fall through to the directory name and
+// report it as a missing site. The command has to say what it is for instead,
+// including that it is not how lerd is restarted.
+func TestRestartTargetNameOutsideASite(t *testing.T) {
+	_, err := restartTargetName(nil, func(string) bool { return false })
+	if err == nil {
+		t.Fatal("expected an error outside a site")
+	}
+	for _, want := range []string{"inside a site", "lerd restart <site>", "not lerd itself"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the message should mention %q, got: %v", want, err)
+		}
+	}
+}
+
+// A named site is taken as given: naming one is how the command is pointed at a
+// site from anywhere, and the run itself reports a name that does not exist.
+func TestRestartTargetNameTakesTheNamedSite(t *testing.T) {
+	got, err := restartTargetName([]string{"shop"}, func(string) bool { return false })
+	if err != nil || got != "shop" {
+		t.Errorf("named site = %q, %v; want shop", got, err)
+	}
+}

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/geodro/lerd/internal/version"
+	"github.com/spf13/cobra"
+)
+
+// NewVersionCmd returns the version command. It prints exactly what
+// `lerd --version` prints: reaching for `lerd version` first is common enough
+// that answering it with "unknown command" is the wrong reply to a question
+// lerd can answer.
+func NewVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Show the installed lerd version",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			fmt.Fprintln(cmd.OutOrStdout(), "lerd version "+version.String())
+			return nil
+		},
+	}
+}

--- a/internal/cli/version_cmd_test.go
+++ b/internal/cli/version_cmd_test.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/version"
+)
+
+// `lerd version` has to answer the same thing as `lerd --version`: a second
+// spelling that printed something else would be a second version to trust.
+func TestVersionCmdPrintsTheVersion(t *testing.T) {
+	cmd := NewVersionCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("version: %v", err)
+	}
+	got := strings.TrimSpace(out.String())
+	if want := "lerd version " + version.String(); got != want {
+		t.Errorf("version = %q, want %q", got, want)
+	}
+	if !strings.Contains(got, version.Version) {
+		t.Errorf("version output does not name the version: %q", got)
+	}
+}


### PR DESCRIPTION
The version has always been behind a flag, so typing lerd version, which is what most people reach for first, got an unknown command back for something lerd knows. It is a command now, printing the same line lerd --version prints.

lerd restart had the opposite problem. Its help described the container it restarts without saying whose, which reads like the way to restart lerd when that is what you are looking for, and run outside a site it named the current directory as a site that could not be found. The help now says it restarts one site container and points at lerd stop and lerd start for lerd itself, and running it outside a site says that instead of reporting a site nobody was asking about.

Closes #1716