### PR TITLE
Route PHP tooling to custom containers

### DIFF
--- a/docs/features/git-worktrees.md
+++ b/docs/features/git-worktrees.md
@@ -197,7 +197,7 @@ The override is honoured wherever lerd materialises worktree state on disk: vhos
 
 Site-level resources stay shared and cannot be overridden per worktree: domain (derived from the parent), TLS certificate (parent's wildcard cert), LAN share port (worktree-scoped LAN share is a separate toggle), workers, and any custom container settings.
 
-On a site running its own per-site image (`runtime: fpm-custom`, built from a project Containerfile), a worktree is served from that image rather than the shared per-version container, and `lerd php` and `lerd composer` inside the checkout exec into it too. Whatever the Containerfile adds is therefore present on the branch exactly as it is on the parent, wherever the checkout lives.
+On a site running its own per-site image (`runtime: fpm-custom` or a port-bearing `container:` site), a worktree is served from that image rather than the shared per-version container, and `lerd php` and `lerd composer` inside the checkout exec into it too. Whatever the Containerfile adds is therefore present on the branch exactly as it is on the parent, wherever the checkout lives.
 
 ### Per-worktree database
 

--- a/docs/usage/custom-containers.md
+++ b/docs/usage/custom-containers.md
@@ -72,6 +72,11 @@ When you `lerd link` a project with a `container` section:
 4. Nginx is configured to `proxy_pass` to the container instead of `fastcgi_pass`
 5. Your project directory is bind-mounted into the container
 
+PHP commands such as `lerd php`, `lerd composer`, and `lerd console` also exec
+into this per-project container when the image provides the requested tool.
+This makes a custom PHP runtime available to both the application and its
+development commands; language-only images should use their native commands.
+
 ## Services
 
 Services work exactly the same as for PHP sites. Containers on the `lerd` network can reach services by name:

--- a/docs/usage/custom-containers.md
+++ b/docs/usage/custom-containers.md
@@ -72,10 +72,18 @@ When you `lerd link` a project with a `container` section:
 4. Nginx is configured to `proxy_pass` to the container instead of `fastcgi_pass`
 5. Your project directory is bind-mounted into the container
 
-PHP commands such as `lerd php`, `lerd composer`, and `lerd console` also exec
-into this per-project container when the image provides the requested tool.
-This makes a custom PHP runtime available to both the application and its
-development commands; language-only images should use their native commands.
+`lerd php`, `lerd composer` and `lerd console` exec into this container when the
+image carries PHP, so a project that pins its own runtime gets that runtime for
+its development commands too, not just for the requests it serves. lerd probes
+the image once and remembers the answer against the image ID, so a rebuild is
+re-checked and nothing shells out on the path every `lerd php` takes.
+
+An image with no PHP in it, which is the usual case for a Node, Python or Go
+site, keeps the shared PHP container: the project is visible there through the
+home mount, and execing `php` into an image that has none fails at the runtime
+rather than with anything you can act on. Composer runs from lerd's own pinned
+phar either way, so lerd's bin directory is mounted read-only into the
+container.
 
 ## Services
 

--- a/internal/php/resolve.go
+++ b/internal/php/resolve.go
@@ -87,22 +87,28 @@ func SiteRootFor(dir string) string {
 	return dir
 }
 
+// customImageHasPHPFn is a seam so the routing can be tested without an image.
+var customImageHasPHPFn = podman.CustomImageHasPHP
+
 // FPMContainerForDir resolves the PHP container an exec in dir must target: the
-// per-site container for custom sites, otherwise the shared
+// per-site container for custom sites that carry PHP, otherwise the shared
 // lerd-php<version>-fpm container. Like VersionForDir this is the single answer
 // the CLI and the MCP server share, so a command can never exec into a
 // different container than the one serving the same directory. A worktree
 // resolves through its parent site, so a checkout beside its project still
-// reaches the parent's custom image.
+// reaches the parent's custom image. A custom container built from an image
+// with no PHP in it (the Node and Python sites the section exists for) keeps
+// the shared container, where the project is visible through the home mount and
+// php is actually present.
 func FPMContainerForDir(dir, version string) string {
 	if _, parent, ok := WorktreeRootFor(dir); ok {
-		if parent.IsCustomContainer() {
+		if parent.IsCustomContainer() && customImageHasPHPFn(parent.Name) {
 			return podman.CustomContainerName(parent.Name)
 		}
 		return podman.FPMContainerName(*parent, version)
 	}
 	if site, _ := config.FindSiteByPath(SiteRootFor(dir)); site != nil {
-		if site.IsCustomContainer() {
+		if site.IsCustomContainer() && customImageHasPHPFn(site.Name) {
 			return podman.CustomContainerName(site.Name)
 		}
 		return podman.FPMContainerName(*site, version)

--- a/internal/php/resolve.go
+++ b/internal/php/resolve.go
@@ -87,8 +87,8 @@ func SiteRootFor(dir string) string {
 	return dir
 }
 
-// FPMContainerForDir resolves the FPM container an exec in dir must target: the
-// per-site container for custom-FPM sites, otherwise the shared
+// FPMContainerForDir resolves the PHP container an exec in dir must target: the
+// per-site container for custom sites, otherwise the shared
 // lerd-php<version>-fpm container. Like VersionForDir this is the single answer
 // the CLI and the MCP server share, so a command can never exec into a
 // different container than the one serving the same directory. A worktree
@@ -96,9 +96,15 @@ func SiteRootFor(dir string) string {
 // reaches the parent's custom image.
 func FPMContainerForDir(dir, version string) string {
 	if _, parent, ok := WorktreeRootFor(dir); ok {
+		if parent.IsCustomContainer() {
+			return podman.CustomContainerName(parent.Name)
+		}
 		return podman.FPMContainerName(*parent, version)
 	}
 	if site, _ := config.FindSiteByPath(SiteRootFor(dir)); site != nil {
+		if site.IsCustomContainer() {
+			return podman.CustomContainerName(site.Name)
+		}
 		return podman.FPMContainerName(*site, version)
 	}
 	return podman.SharedFPMContainerName(version)

--- a/internal/php/resolve_test.go
+++ b/internal/php/resolve_test.go
@@ -42,6 +42,24 @@ func TestFPMContainerForDir_CustomFPMSite(t *testing.T) {
 	}
 }
 
+// A port-bearing custom site serves from its own container too. PHP tooling
+// invoked from the project must not fall back to the shared FPM image.
+func TestFPMContainerForDir_CustomContainerSite(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	site := filepath.Join(tempRoot(t), "app")
+	if err := os.MkdirAll(site, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.AddSite(config.Site{Name: "app", Path: site, ContainerPort: 8474}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := FPMContainerForDir(site, "8.5"), "lerd-custom-app"; got != want {
+		t.Errorf("FPMContainerForDir = %q, want %q", got, want)
+	}
+}
+
 // An ordinary site stays on the shared per-version container.
 func TestFPMContainerForDir_SharedFPMSite(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())

--- a/internal/php/resolve_test.go
+++ b/internal/php/resolve_test.go
@@ -42,10 +42,20 @@ func TestFPMContainerForDir_CustomFPMSite(t *testing.T) {
 	}
 }
 
-// A port-bearing custom site serves from its own container too. PHP tooling
-// invoked from the project must not fall back to the shared FPM image.
+// stubCustomImagePHP answers the image probe without building an image.
+func stubCustomImagePHP(t *testing.T, has bool) {
+	t.Helper()
+	orig := customImageHasPHPFn
+	t.Cleanup(func() { customImageHasPHPFn = orig })
+	customImageHasPHPFn = func(string) bool { return has }
+}
+
+// A port-bearing custom site whose image carries PHP serves its tooling from
+// its own container, so a project runtime is not silently replaced by the
+// shared one.
 func TestFPMContainerForDir_CustomContainerSite(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	stubCustomImagePHP(t, true)
 
 	site := filepath.Join(tempRoot(t), "app")
 	if err := os.MkdirAll(site, 0755); err != nil {
@@ -82,6 +92,26 @@ func TestFPMContainerForDir_UnregisteredDir(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 
 	if got, want := FPMContainerForDir(tempRoot(t), "8.3"), "lerd-php83-fpm"; got != want {
+		t.Errorf("FPMContainerForDir = %q, want %q", got, want)
+	}
+}
+
+// The section exists for Node, Python and Go sites as much as for PHP ones, and
+// execing php into an image without it fails at the OCI runtime. Those sites
+// keep the shared container, where the project is visible and php exists.
+func TestFPMContainerForDir_CustomContainerWithoutPHP(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	stubCustomImagePHP(t, false)
+
+	site := filepath.Join(tempRoot(t), "node-app")
+	if err := os.MkdirAll(site, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.AddSite(config.Site{Name: "node-app", Path: site, ContainerPort: 3000}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := FPMContainerForDir(site, "8.5"), "lerd-php85-fpm"; got != want {
 		t.Errorf("FPMContainerForDir = %q, want %q", got, want)
 	}
 }

--- a/internal/podman/custom_container.go
+++ b/internal/podman/custom_container.go
@@ -168,6 +168,7 @@ func BuildCustomImageTo(siteName, projectPath string, cfg *config.ContainerConfi
 
 // RemoveCustomImage removes the local image for a site's custom container.
 func RemoveCustomImage(siteName string) error {
+	ForgetCustomImageTools(siteName)
 	imageName := CustomImageName(siteName)
 	_ = execCommand(PodmanBin(), "rmi", "-f", imageName).Run()
 	return nil

--- a/internal/podman/custom_quadlet.go
+++ b/internal/podman/custom_quadlet.go
@@ -34,6 +34,10 @@ func GenerateCustomContainerQuadlet(siteName, projectPath string, port int) (str
 	b.WriteString("Network=lerd\n")
 	fmt.Fprintf(&b, "Volume=%s:/etc/hosts:ro,z\n", config.ContainerHostsFile())
 	fmt.Fprintf(&b, "Volume=%s:%s:rw\n", projectPath, projectPath)
+	// lerd's own tools are run by absolute host path (composer is a phar in
+	// this directory), so an image that carries PHP can only be handed the
+	// project's composer work if the directory is visible under the same path.
+	fmt.Fprintf(&b, "Volume=%s:%s:ro,z\n", config.BinDir(), config.BinDir())
 	fmt.Fprintf(&b, "PodmanArgs=--security-opt=label=disable --workdir=%s\n", projectPath)
 
 	b.WriteString("\n[Service]\n")

--- a/internal/podman/custom_quadlet_test.go
+++ b/internal/podman/custom_quadlet_test.go
@@ -1,6 +1,7 @@
 package podman
 
 import (
+	"github.com/geodro/lerd/internal/config"
 	"strings"
 	"testing"
 )
@@ -20,6 +21,7 @@ func TestGenerateCustomContainerQuadlet(t *testing.T) {
 		{"network", "Network=lerd"},
 		{"project volume", "Volume=/home/user/projects/nestapp:/home/user/projects/nestapp:rw"},
 		{"hosts volume", "/etc/hosts:ro,z"},
+		{"lerd bin volume", config.BinDir() + ":" + config.BinDir() + ":ro,z"},
 		{"security opt", "--security-opt=label=disable"},
 		{"workdir", "--workdir=/home/user/projects/nestapp"},
 		{"restart", "Restart=always"},

--- a/internal/podman/custom_tools.go
+++ b/internal/podman/custom_tools.go
@@ -1,0 +1,91 @@
+package podman
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// A custom container is built from the project's own Containerfile, so what it
+// carries is the project's business. PHP tooling may only be routed into it
+// when it actually has PHP: the `container:` section serves Node, Python and Go
+// sites too, and execing php into a node image fails with an OCI runtime error
+// rather than anything the user can act on.
+
+// customTools is the cached answer for one site's image.
+type customTools struct {
+	ImageID string `json:"image_id"`
+	PHP     bool   `json:"php"`
+}
+
+// probeCustomPHPFn is the probe itself, a seam so the cache can be tested
+// without building an image.
+var probeCustomPHPFn = func(image string) bool {
+	return RunSilent("run", "--rm", "--entrypoint", "php", PlatformImage(image), "--version") == nil
+}
+
+func customToolsPath(siteName string) string {
+	return filepath.Join(config.DataDir(), "container-tools", siteName+".json")
+}
+
+// CustomImageHasPHP reports whether a site's custom image carries a php binary.
+// The answer is probed once and cached against the image ID, since a probe
+// starts a container and every `lerd php` in the project would otherwise pay
+// for one. A rebuilt image changes the ID and is probed again.
+func CustomImageHasPHP(siteName string) bool {
+	image := CustomImageName(siteName)
+	id := customImageID(image)
+	if id == "" {
+		return false
+	}
+	if cached, ok := readCustomTools(siteName); ok && cached.ImageID == id {
+		return cached.PHP
+	}
+	has := probeCustomPHPFn(image)
+	writeCustomTools(siteName, customTools{ImageID: id, PHP: has})
+	return has
+}
+
+// customImageID returns the local image's ID, or "" when it isn't built yet.
+func customImageID(image string) string {
+	out, err := Run("image", "inspect", PlatformImage(image), "--format", "{{.Id}}")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out)
+}
+
+func readCustomTools(siteName string) (customTools, bool) {
+	data, err := os.ReadFile(customToolsPath(siteName))
+	if err != nil {
+		return customTools{}, false
+	}
+	var c customTools
+	if json.Unmarshal(data, &c) != nil {
+		return customTools{}, false
+	}
+	return c, true
+}
+
+// writeCustomTools stores the answer, and stays quiet when it cannot: a cache
+// that fails to persist costs a probe next time, nothing more.
+func writeCustomTools(siteName string, c customTools) {
+	path := customToolsPath(siteName)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return
+	}
+	data, err := json.Marshal(c)
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, data, 0644)
+}
+
+// ForgetCustomImageTools drops the cached answer for a site, so a removed or
+// rebuilt image is never answered for from a stale file.
+func ForgetCustomImageTools(siteName string) {
+	_ = os.Remove(customToolsPath(siteName))
+}

--- a/internal/podman/custom_tools_test.go
+++ b/internal/podman/custom_tools_test.go
@@ -1,0 +1,87 @@
+package podman
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// stubCustomPHPProbe counts probes so a test can tell a cached answer from a
+// fresh one.
+func stubCustomPHPProbe(t *testing.T, has bool) *int {
+	t.Helper()
+	calls := 0
+	orig := probeCustomPHPFn
+	t.Cleanup(func() { probeCustomPHPFn = orig })
+	probeCustomPHPFn = func(string) bool {
+		calls++
+		return has
+	}
+	return &calls
+}
+
+// stubCustomImageID makes the image look built, with the ID the test names. An
+// empty id stands for an image podman does not have.
+func stubCustomImageID(t *testing.T, id string) {
+	t.Helper()
+	orig := execCommand
+	t.Cleanup(func() { execCommand = orig })
+	exit := 0
+	if id == "" {
+		exit = 1
+	}
+	execCommand = fakeExec(id, "", exit)
+}
+
+func TestCustomImageHasPHP_CachesPerImageID(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	stubCustomImageID(t, "sha256:aaa")
+	calls := stubCustomPHPProbe(t, true)
+
+	if !CustomImageHasPHP("app") {
+		t.Fatal("first answer = false, want true")
+	}
+	if !CustomImageHasPHP("app") {
+		t.Fatal("second answer = false, want the cached true")
+	}
+	if *calls != 1 {
+		t.Errorf("probes = %d, want the image probed once", *calls)
+	}
+}
+
+func TestCustomImageHasPHP_ReprobesAfterRebuild(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	stubCustomImageID(t, "sha256:aaa")
+	calls := stubCustomPHPProbe(t, false)
+
+	if CustomImageHasPHP("app") {
+		t.Fatal("answer = true, want false for an image without php")
+	}
+	// A rebuild changes the ID, so the stale answer must not be reused.
+	stubCustomImageID(t, "sha256:bbb")
+	stubCustomPHPProbe(t, true)
+	if !CustomImageHasPHP("app") {
+		t.Error("answer = false after a rebuild that added php")
+	}
+	if *calls != 1 {
+		t.Errorf("first probe ran %d times, want once", *calls)
+	}
+}
+
+// An image that is not built yet is not routed to, and nothing is cached for it.
+func TestCustomImageHasPHP_UnbuiltImage(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dir)
+	stubCustomImageID(t, "")
+	calls := stubCustomPHPProbe(t, true)
+
+	if CustomImageHasPHP("app") {
+		t.Error("answer = true for an image that does not exist")
+	}
+	if *calls != 0 {
+		t.Errorf("probes = %d, want none without an image", *calls)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "lerd", "container-tools", "app.json")); !os.IsNotExist(err) {
+		t.Error("an unbuilt image left a cache file")
+	}
+}


### PR DESCRIPTION
## Summary

FPMContainerForDir already handled custom-FPM sites, but port-bearing custom containers were still routed to the shared FPM container.

This change:
- routes PHP tooling for custom-container sites and their worktrees to lerd-custom-<site>
- adds a regression test for port-bearing custom containers
- documents the behavior

## Verification

- go test ./internal/php passed in the Go 1.25 container
- go test -tags nogui ./internal/cli passed
- the normal GUI-enabled CLI test requires libayatana-appindicator3-dev, which is installed by CI but absent from the test container