### PR TITLE
Stop moving a PHP version the project asked for without saying so

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,7 +163,7 @@ A portable, self-contained description of a project's local environment. Created
 
 | Field | Description |
 |---|---|
-| `php_version` | PHP version for this project (highest priority, overrides `.php-version` and `composer.json`) |
+| `php_version` | PHP version for this project (highest priority, overrides `.php-version` and `composer.json`). The framework definition's range still applies, and `lerd link` reports when it moves the pin |
 | `node_version` | Node version (highest priority, overrides `.nvmrc`, `.node-version`, and `package.json`); writes `.node-version` on apply if the file does not already exist |
 | `framework` | Framework name (overrides auto-detection) |
 | `framework_def` | Full framework definition, embedded automatically for custom (non-Laravel) frameworks so the project is portable across machines |

--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -5,7 +5,7 @@
 | Command | Description |
 |---|---|
 | `lerd use <version>` | Set the global PHP version and build the FPM image if needed |
-| `lerd isolate <version>` | Pin PHP version for cwd: writes `.php-version` and updates `.lerd.yaml` if it exists, then re-links |
+| `lerd isolate <version>` | Pin PHP version for cwd: writes `.php-version` and updates `.lerd.yaml` if it exists, then re-links. Refuses a version the framework or the project's `composer.json` rules out; `--force` pins it anyway |
 | `lerd php:list` | List all installed PHP-FPM versions |
 | `lerd php:rebuild [version] [--local]` | Force-rebuild PHP-FPM images, or add a version this machine does not have yet; `--local` builds from source instead of pulling a base |
 | `lerd fetch [version...] [--local]` | Pull pre-built PHP FPM base images from ghcr.io; `--local` builds from source instead |
@@ -41,7 +41,11 @@ A git worktree resolves ahead of the site it belongs to. A worktree inherits its
 
 When a command needs a version that is not installed and you decline the install, lerd offers to switch to one you already have and pins the choice. Inside a worktree that pin is written on the checkout itself, so the switch travels with the branch and the parent site keeps the version it was on.
 
-So that the project agrees with what actually runs, `lerd link` pins the resolved version into `.php-version`, the same file `lerd isolate` and the dashboard's PHP dropdown write. A pin the framework does not support is rewritten to the version lerd runs, and a version outside the framework's range is clamped rather than accepted, so the file, the site registry and the container can never drift apart. Sites with no lerd-managed PHP version (host-proxy, and custom containers whose version comes from their Containerfile) are left untouched.
+So that the project agrees with what actually runs, `lerd link` pins the resolved version into `.php-version`, the same file `lerd isolate` and the dashboard's PHP dropdown write. A version outside the framework's range is clamped rather than accepted, so the file, the site registry and the container can never drift apart, and when the clamp moves a version `php_version` asked for, the link says so rather than reporting the version it landed on as the choice. Sites with no lerd-managed PHP version (host-proxy, and custom containers whose version comes from their Containerfile) are left untouched.
+
+`lerd isolate` answers differently, because there a human named the version: a request the framework range or the project's own `composer.json` rules out is refused and nothing is written, so a file the project commits is never edited to agree with a version its owner did not choose. The refusal names what the version had to satisfy and the closest installed version that does, and `--force` pins it regardless.
+
+A framework definition describes the framework, `composer.json` describes the application that has to boot, and both apply. Where the two cannot both be met, the project wins: an app served by a definition whose cap sits below what its own dependencies require would otherwise be linked onto a version that fails at the first request.
 
 ---
 
@@ -127,7 +131,7 @@ cd ~/Lerd/my-app
 lerd isolate 8.5
 ```
 
-This writes `.php-version: 8.5` (so CLI `php`, asdf, and other tools see the right version) and, when `.lerd.yaml` already exists in the project, also updates its `php_version` field to keep lerd's priority-1 override in sync. The site is re-linked automatically so nginx picks up the new version immediately.
+This writes `.php-version: 8.5` (so CLI `php`, asdf, and other tools see the right version) and, when `.lerd.yaml` already exists in the project, also updates its `php_version` field to keep lerd's priority-1 override in sync. The site is re-linked automatically so nginx picks up the new version immediately. If 8.5 is outside what the framework or the project supports, the pin is refused with both files left as they were, and `lerd isolate 8.5 --force` applies it anyway.
 
 The UI PHP version selector and the MCP `site` tool's `php` action follow the same rules; they always write both files when applicable.
 

--- a/internal/cli/isolate.go
+++ b/internal/cli/isolate.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -14,12 +15,27 @@ import (
 
 // NewIsolateCmd returns the isolate command.
 func NewIsolateCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "isolate <version>",
 		Short: "Pin the PHP version for the current directory",
 		Args:  cobra.ExactArgs(1),
 		RunE:  runIsolate,
 	}
+	cmd.Flags().BoolVar(&isolateForce, "force", false, "pin a version the framework or the project's composer.json rules out")
+	return cmd
+}
+
+var isolateForce bool
+
+// pinRefusal turns a refused pin into the command's own answer, naming the flag
+// that overrides it. Nothing was written, so the user is being told what to do
+// next rather than what was done to their project.
+func pinRefusal(err error, requested string) error {
+	var rangeErr *siteops.PHPRangeError
+	if !errors.As(err, &rangeErr) {
+		return err
+	}
+	return fmt.Errorf("%w\n       run 'lerd isolate %s --force' to pin it anyway", err, requested)
 }
 
 func runIsolate(_ *cobra.Command, args []string) error {
@@ -35,15 +51,12 @@ func runIsolate(_ *cobra.Command, args []string) error {
 	// Worktree path: the override travels with the branch, so the parent site's
 	// own version is left alone.
 	if site, branch, ok := FindParentSiteForWorktree(cwd); ok {
-		res, err := siteops.SetSitePHPVersion(site, version, siteops.PHPVersionOpts{Branch: branch})
+		res, err := siteops.SetSitePHPVersion(site, version, siteops.PHPVersionOpts{Branch: branch, Force: isolateForce})
 		if err != nil {
-			return err
+			return pinRefusal(err, args[0])
 		}
 		feedback.Begin()
 		feedback.Done("PHP pinned to " + feedback.Val(res.Version) + " · worktree " + branch + " of " + site.Name)
-		if res.Clamped {
-			feedback.Note(res.Requested + " isn't usable here; clamped to " + res.Version)
-		}
 		reportImageGap(res)
 		return nil
 	}
@@ -64,15 +77,12 @@ func runIsolate(_ *cobra.Command, args []string) error {
 		return nil
 	}
 
-	res, err := siteops.SetSitePHPVersion(site, version, siteops.PHPVersionOpts{})
+	res, err := siteops.SetSitePHPVersion(site, version, siteops.PHPVersionOpts{Force: isolateForce})
 	if err != nil {
-		return err
+		return pinRefusal(err, args[0])
 	}
 	feedback.Begin()
 	feedback.Done("PHP pinned to " + feedback.Val(res.Version))
-	if res.Clamped {
-		feedback.Note(res.Requested + " isn't usable here; clamped to " + res.Version + " and updated .lerd.yaml / .php-version")
-	}
 	if res.Demoted {
 		feedback.Note("FrankenPHP has no image for PHP " + res.Version + "; the site now runs on FPM")
 	}

--- a/internal/linker/apply.go
+++ b/internal/linker/apply.go
@@ -227,9 +227,18 @@ func offerBetterPHP(plan *Plan, p Policy, d Deps, r Reporter) error {
 	if plan.PHPMin == "" && plan.PHPMax == "" {
 		return nil
 	}
+	// A pin that was moved is reported whatever happens next: the file says one
+	// version and the site runs another, and only the link knows why.
+	if plan.PHPPinned != "" {
+		r.Line(fmt.Sprintf("PHP %s is pinned in .lerd.yaml and %s supports %s–%s, so this site runs on %s",
+			plan.PHPPinned, plan.FrameworkLabel, plan.PHPMin, plan.PHPMax, plan.Site.PHPVersion))
+	}
 	if plan.PHPSuggestion == "" || p.Prompt == nil || d.EnsureFPMQuadlet == nil {
-		r.Line(fmt.Sprintf("Using PHP %s (%s supports %s–%s)",
-			plan.Site.PHPVersion, plan.FrameworkLabel, plan.PHPMin, plan.PHPMax))
+		// The pin line above already named the version and the range.
+		if plan.PHPPinned == "" {
+			r.Line(fmt.Sprintf("Using PHP %s (%s supports %s–%s)",
+				plan.Site.PHPVersion, plan.FrameworkLabel, plan.PHPMin, plan.PHPMax))
+		}
 		return nil
 	}
 

--- a/internal/linker/policy.go
+++ b/internal/linker/policy.go
@@ -124,6 +124,10 @@ type Plan struct {
 	// the one Site carries. Empty when the chosen version is already the best
 	// installed one, or when the policy forbids building images.
 	PHPSuggestion string
+	// PHPPinned is the version .lerd.yaml asked for when the framework's range
+	// moved the site off it, so the link can say so instead of reporting the
+	// version it landed on as though it had been the request.
+	PHPPinned string
 	// PHPMin and PHPMax are the framework's supported range, for the message
 	// that accompanies a clamped version. Both empty when unconstrained.
 	PHPMin, PHPMax string

--- a/internal/linker/resolve.go
+++ b/internal/linker/resolve.go
@@ -115,6 +115,9 @@ func Resolve(dir string, cfg *config.GlobalConfig, p Policy) (*Plan, error) {
 	phpVersion, nodeVersion := versions.PHP, versions.Node
 	if proj != nil && proj.PHPVersion != "" {
 		phpVersion = phpDet.ClampToRange(proj.PHPVersion, versions.PHPMin, versions.PHPMax)
+		if phpVersion != proj.PHPVersion {
+			plan.PHPPinned = proj.PHPVersion
+		}
 	}
 	// A version the framework's range moved us off is worth reporting, and when
 	// a better one could be installed the caller may offer to build it.

--- a/internal/linker/resolve_test.go
+++ b/internal/linker/resolve_test.go
@@ -282,3 +282,36 @@ func TestResolveFramework_namesNothingForAProjectThatDeclaresNothing(t *testing.
 		t.Errorf("ResolveFramework = (%q, %v), want empty and unknown", name, known)
 	}
 }
+
+// A pin the framework's range moves has to be visible. The link used to report
+// the version it landed on with nothing said about the request, so a project
+// pinning 8.5 and running 8.2 looked like it had been honoured.
+func TestResolve_reportsAPinTheFrameworkRangeMoved(t *testing.T) {
+	dir := projectDir(t, "legacy", "php_version: \"8.5\"\n")
+
+	storeDir := config.StoreFrameworksDir()
+	if err := os.MkdirAll(storeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	def := "name: laravel\nlabel: Laravel\nversion: \"9\"\npublic_dir: public\n" +
+		"php:\n  min: \"8.0\"\n  max: \"8.2\"\n" +
+		"detect:\n  - composer: laravel/framework\n"
+	if err := os.WriteFile(filepath.Join(storeDir, "laravel@9.yaml"), []byte(def), 0644); err != nil {
+		t.Fatal(err)
+	}
+	composer := `{"require":{"php":"^8.0","laravel/framework":"^9.1"}}`
+	if err := os.WriteFile(filepath.Join(dir, "composer.json"), []byte(composer), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	plan, err := Resolve(dir, testConfig(), CLIPolicy("", false, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.PHPPinned != "8.5" {
+		t.Errorf("PHPPinned = %q, want the 8.5 the project asked for", plan.PHPPinned)
+	}
+	if plan.Site.PHPVersion == "8.5" {
+		t.Error("php = 8.5, want the framework's range to have moved it")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3899,9 +3899,6 @@ func execSitePHP(args map[string]any) (any, *rpcError) {
 	}
 
 	msg := fmt.Sprintf("PHP version for %s set to %s.", siteName, res.Version)
-	if res.Clamped {
-		msg = fmt.Sprintf("PHP version for %s set to %s: %s is outside the range its framework supports.", siteName, res.Version, res.Requested)
-	}
 	// The image gap is the whole reason a version switch loses an extension, so
 	// it is reported before the runtime-specific tail.
 	switch {

--- a/internal/php/constraint_test.go
+++ b/internal/php/constraint_test.go
@@ -95,3 +95,76 @@ func TestSatisfiesConstraint_BothSpellingsOfOr(t *testing.T) {
 		}
 	}
 }
+
+// A framework definition's range describes the framework; composer.json
+// describes what this project actually boots on. Where they disagree the
+// project has to win, so the answer needs to be checkable on its own.
+func TestSatisfies(t *testing.T) {
+	cases := []struct {
+		version    string
+		constraint string
+		want       bool
+	}{
+		{"8.1", ">=8.1", true},
+		{"8.0", ">=8.1", false},
+		{"8.1", "^7.3|^8.0", true},
+		{"8.5", "", true},
+	}
+	for _, c := range cases {
+		if got := Satisfies(c.version, c.constraint); got != c.want {
+			t.Errorf("Satisfies(%q, %q) = %v, want %v", c.version, c.constraint, got, c.want)
+		}
+	}
+}
+
+// A project is governed by more than one constraint at a time: the framework
+// definition's range and its own composer requirement. Both have to hold.
+func TestSatisfiesAll(t *testing.T) {
+	cases := []struct {
+		version     string
+		constraints []string
+		want        bool
+	}{
+		{"8.1", []string{">=8.0 <=8.2", ">=8.1"}, true},
+		{"8.0", []string{">=8.0 <=8.2", ">=8.1"}, false},
+		{"8.5", []string{">=8.0 <=8.2", ">=8.1"}, false},
+		{"8.4", []string{"", ">=8.1"}, true},
+		{"8.4", nil, true},
+	}
+	for _, c := range cases {
+		if got := SatisfiesAll(c.version, c.constraints...); got != c.want {
+			t.Errorf("SatisfiesAll(%q, %v) = %v, want %v", c.version, c.constraints, got, c.want)
+		}
+	}
+}
+
+func TestBestInstalledFor(t *testing.T) {
+	installedPHP(t, "8.0", "8.1", "8.4", "8.5")
+
+	if got := BestInstalledFor(">=8.0 <=8.2", ">=8.1"); got != "8.1" {
+		t.Errorf("best = %q, want 8.1", got)
+	}
+	if got := BestInstalledFor(">=8.0 <=8.2", ">=8.4"); got != "" {
+		t.Errorf("best = %q, want nothing installed to satisfy both", got)
+	}
+	if got := BestInstalledFor("", ">=8.4"); got != "8.5" {
+		t.Errorf("best = %q, want 8.5", got)
+	}
+}
+
+// Whether two constraints can both be met is a property of the constraints, not
+// of this machine: a fresh install with no PHP built yet must reach the same
+// answer as a developer's box with five versions on it.
+func TestConstraintsOverlap(t *testing.T) {
+	installedPHP(t) // nothing installed at all
+
+	if !ConstraintsOverlap(">=8.0 <=8.2", ">=8.1") {
+		t.Error("overlap = false, want 8.1 and 8.2 to satisfy both")
+	}
+	if ConstraintsOverlap(">=8.0 <=8.2", ">=8.4") {
+		t.Error("overlap = true, want no version to satisfy both")
+	}
+	if !ConstraintsOverlap(">=8.3 <=8.5", "") {
+		t.Error("overlap = false, want an empty constraint to constrain nothing")
+	}
+}

--- a/internal/php/detector.go
+++ b/internal/php/detector.go
@@ -400,6 +400,54 @@ func ComposerPHPConstraint(dir string) string {
 	return strings.TrimSpace(composer.Require["php"])
 }
 
+// Satisfies reports whether version meets a composer-style constraint. An empty
+// constraint constrains nothing, so everything satisfies it.
+func Satisfies(version, constraint string) bool {
+	return constraint == "" || satisfiesConstraint(version, constraint)
+}
+
+// SatisfiesAll reports whether version meets every constraint given. Empty
+// constraints are skipped, so a project with no composer requirement is judged
+// on the framework definition alone.
+func SatisfiesAll(version string, constraints ...string) bool {
+	for _, c := range constraints {
+		if !Satisfies(version, c) {
+			return false
+		}
+	}
+	return true
+}
+
+// BestInstalledFor returns the newest installed version satisfying every
+// constraint, or "" when the constraints have no installed version in common.
+func BestInstalledFor(constraints ...string) string {
+	installed, err := ListInstalled()
+	if err != nil {
+		return ""
+	}
+	for i := len(installed) - 1; i >= 0; i-- {
+		if SatisfiesAll(installed[i], constraints...) {
+			return installed[i]
+		}
+	}
+	return ""
+}
+
+// ConstraintsOverlap reports whether any PHP version could satisfy every
+// constraint at once. It sweeps the whole plausible range of releases rather
+// than what is installed here, so the answer is about the constraints
+// themselves and does not change with the machine.
+func ConstraintsOverlap(constraints ...string) bool {
+	for major := 5; major <= 9; major++ {
+		for minor := 0; minor <= 9; minor++ {
+			if SatisfiesAll(fmt.Sprintf("%d.%d", major, minor), constraints...) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ClampToConstraint returns version when it satisfies constraint, else the best
 // installed version that does, else the constraint's own minimum. Unlike a
 // min/max range this keeps an alternation intact, so a project requiring

--- a/internal/siteops/link.go
+++ b/internal/siteops/link.go
@@ -26,6 +26,10 @@ type VersionResult struct {
 	// borrowed definition; its PHP range is not enforced (PHPMin/PHPMax stay
 	// empty) since it describes a different version than the project.
 	FrameworkGuessed bool
+	// RangeOverruled is true when a real definition's range was set aside
+	// because no installed version could satisfy it and the project's own
+	// composer requirement at once.
+	RangeOverruled bool
 }
 
 // DetectSiteVersions resolves the framework, PHP version (clamped to framework
@@ -45,6 +49,18 @@ func DetectSiteVersions(dir, framework, defaultPHP, defaultNode string) VersionR
 				result.PHPMin = fw.PHP.Min
 				result.PHPMax = fw.PHP.Max
 			}
+		}
+	}
+
+	// A definition can be the right one for the framework and still be the wrong
+	// authority for the project in front of it: a Winter CMS install is served
+	// the Laravel definition its lock names, capped below what its own
+	// composer.json requires. Where nothing installed satisfies both, the
+	// project wins, since it is the one that has to boot.
+	if project := phpDet.ComposerPHPConstraint(dir); project != "" && (result.PHPMin != "" || result.PHPMax != "") {
+		if !phpDet.ConstraintsOverlap(phpRangeConstraint(result.PHPMin, result.PHPMax), project) {
+			result.PHPMin, result.PHPMax = "", ""
+			result.RangeOverruled = true
 		}
 	}
 

--- a/internal/siteops/link_test.go
+++ b/internal/siteops/link_test.go
@@ -111,3 +111,43 @@ func TestCleanupRelink_NoExisting(t *testing.T) {
 		t.Error("expected secured=false for non-existent path")
 	}
 }
+
+// The Winter CMS case. The definition is the real one for the Laravel major the
+// lock names, so its range applies, but the project itself requires more PHP
+// than that range allows. Nothing can satisfy both, and serving the framework's
+// cap gives a site that 500s on its own platform check, so the project wins.
+func TestDetectSiteVersions_ProjectRequirementOverrulesRange(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	storeDir := config.StoreFrameworksDir()
+	if err := os.MkdirAll(storeDir, 0755); err != nil {
+		t.Fatalf("mkdir store: %v", err)
+	}
+	def := "name: laravel\nlabel: Laravel\nversion: \"9\"\npublic_dir: public\n" +
+		"php:\n  min: \"8.0\"\n  max: \"8.2\"\n" +
+		"detect:\n  - composer: laravel/framework\n"
+	if err := os.WriteFile(filepath.Join(storeDir, "laravel@9.yaml"), []byte(def), 0644); err != nil {
+		t.Fatalf("write def: %v", err)
+	}
+
+	dir := t.TempDir()
+	composer := `{"require":{"php":">=8.4","laravel/framework":"^9.1"}}`
+	if err := os.WriteFile(filepath.Join(dir, "composer.json"), []byte(composer), 0644); err != nil {
+		t.Fatalf("write composer: %v", err)
+	}
+
+	result := DetectSiteVersions(dir, "laravel", "8.5", "22")
+	if !result.RangeOverruled {
+		t.Error("RangeOverruled = false, want the definition's range set aside")
+	}
+	if result.PHPMin != "" || result.PHPMax != "" {
+		t.Errorf("range = %q-%q, want it dropped so the pin survives", result.PHPMin, result.PHPMax)
+	}
+	// No PHP is installed in the staged tree, so the answer is the lowest
+	// version the project's own requirement allows rather than a built image.
+	if result.PHP != "8.4" {
+		t.Errorf("PHP = %q, want 8.4, the floor the project requires", result.PHP)
+	}
+}

--- a/internal/siteops/phpversion.go
+++ b/internal/siteops/phpversion.go
@@ -30,26 +30,50 @@ var (
 	imageExistsFn      = podman.FPMImageExists
 	detectWorktreesFn  = gitpkg.DetectWorktrees
 
-	// phpConstraintFor is what the site is allowed to run, as a composer-style
-	// constraint. The framework definition is the authority only when it is the
-	// real one for the project's version: a borrowed definition describes a
-	// different release (Laravel 6 served by the Laravel 10 def), and clamping to
-	// its range would refuse the version the project actually requires. In that
-	// case, and when no framework was recognised at all, the project's own
-	// composer.json is what it says it supports.
+	// phpConstraintsFor is everything the site has to satisfy at once. The
+	// framework definition's range is one claim, the project's own composer
+	// requirement is the other, and both hold. A borrowed definition describes a
+	// different release, so it is left out, and so is a real one whose range
+	// cannot be met alongside what the project requires: the
+	// definition describes the framework, composer describes the app that has to
+	// boot, and a version the app rejects fails at the first request. The two
+	// are compared as constraints, not against what is installed, so the answer
+	// does not change with the machine.
 	// getFrameworkFn is the definition lookup, a seam so the constraint choice
 	// can be tested without a framework store on disk.
 	getFrameworkFn = config.GetFrameworkForDir
 
-	phpConstraintFor = func(site *config.Site) string {
+	phpConstraintsFor = func(site *config.Site) []string {
+		project := php.ComposerPHPConstraint(site.Path)
+		framework := ""
 		if site.Framework != "" {
 			if fw, ok := getFrameworkFn(site.Framework, site.Path); ok && !fw.VersionGuessed {
-				return phpRangeConstraint(fw.PHP.Min, fw.PHP.Max)
+				framework = phpRangeConstraint(fw.PHP.Min, fw.PHP.Max)
 			}
 		}
-		return php.ComposerPHPConstraint(site.Path)
+		switch {
+		case framework == "":
+			return compactConstraints(project)
+		case project == "":
+			return compactConstraints(framework)
+		case !php.ConstraintsOverlap(framework, project):
+			return compactConstraints(project)
+		}
+		return compactConstraints(framework, project)
 	}
 )
+
+// compactConstraints drops the empty entries, so a caller can hand over whatever
+// it found without checking each one.
+func compactConstraints(constraints ...string) []string {
+	out := make([]string, 0, len(constraints))
+	for _, c := range constraints {
+		if c != "" {
+			out = append(out, c)
+		}
+	}
+	return out
+}
 
 // phpRangeConstraint renders a framework definition's min/max as the constraint
 // shape everything else in this path speaks.
@@ -69,14 +93,16 @@ func phpRangeConstraint(min, max string) string {
 type PHPVersionOpts struct {
 	// Branch targets a worktree of the site rather than the site itself.
 	Branch string
+	// Force applies a version the site's constraints refuse. The caller has
+	// told the user what they are overriding.
+	Force bool
 }
 
 // PHPVersionResult reports what the switch actually did, so each caller can
 // render it in its own idiom rather than the funnel printing for everyone.
 type PHPVersionResult struct {
 	Requested string // what the caller asked for
-	Version   string // what was applied, after clamping
-	Clamped   bool   // the framework's range overrode the request
+	Version   string // what was applied
 	Demoted   bool   // the site fell back from FrankenPHP to FPM
 
 	// Missing lists declared entries this version's image tried to load and
@@ -90,6 +116,27 @@ type PHPVersionResult struct {
 	NotInstalled bool
 }
 
+// PHPRangeError reports a version the site is not allowed to run, and what it
+// would have to satisfy to be allowed. It carries the facts rather than a
+// sentence, so each caller phrases the refusal in its own idiom.
+type PHPRangeError struct {
+	Site        string
+	Requested   string
+	Constraints []string
+	// Best is the newest installed version that satisfies every constraint, or
+	// "" when this machine has none.
+	Best string
+}
+
+func (e *PHPRangeError) Error() string {
+	msg := fmt.Sprintf("PHP %s is outside what %s can run (needs %s)",
+		e.Requested, e.Site, strings.Join(e.Constraints, " and "))
+	if e.Best != "" {
+		msg += fmt.Sprintf("; the closest installed version is %s", e.Best)
+	}
+	return msg
+}
+
 // SetSitePHPVersion switches a site (or one of its worktrees) to a PHP version
 // and runs every step that switch depends on. It is the single source of truth
 // for "what happens when a site changes PHP version"; CLI, UI, and MCP all call
@@ -97,8 +144,10 @@ type PHPVersionResult struct {
 //
 // Steps:
 //  1. Refuse runtimes that have no PHP version of their own.
-//  2. Clamp to the framework's supported range, so the pin never advertises a
-//     version the watcher clamps back on its next pass.
+//  2. Refuse a version the framework definition or the project's own composer
+//     requirement rules out, unless the caller forces it. Nothing is written on
+//     a refusal, so a request lerd cannot honour never reaches the files the
+//     project commits.
 //  3. Pin .php-version and .lerd.yaml.
 //  4. Persist site.PHPVersion to the registry.
 //  5. Re-link FrankenPHP, or fall back to FPM below its minimum version.
@@ -123,9 +172,13 @@ func SetSitePHPVersion(site *config.Site, version string, opts PHPVersionOpts) (
 		return res, fmt.Errorf("site %q is a host-proxy site, which runs your dev command on the host", site.Name)
 	}
 
-	if clamped := php.ClampToConstraint(version, phpConstraintFor(site)); clamped != version {
-		res.Version, res.Clamped = clamped, true
-		version = clamped
+	if constraints := phpConstraintsFor(site); !opts.Force && !php.SatisfiesAll(version, constraints...) {
+		return res, &PHPRangeError{
+			Site:        site.Name,
+			Requested:   version,
+			Constraints: constraints,
+			Best:        php.BestInstalledFor(constraints...),
+		}
 	}
 	gap := imageGapFn(version)
 	res.Missing, res.Stale, res.NotInstalled = gap.missing, gap.stale, gap.notInstalled

--- a/internal/siteops/phpversion_test.go
+++ b/internal/siteops/phpversion_test.go
@@ -1,6 +1,7 @@
 package siteops
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -62,15 +63,15 @@ func stubPHPVersionDeps(t *testing.T, min, max string) *int {
 	t.Helper()
 	reloads := 0
 	origReload := nginxReloadFn
-	origRange := phpConstraintFor
+	origRange := phpConstraintsFor
 	origGap := imageGapFn
 	t.Cleanup(func() {
 		nginxReloadFn = origReload
-		phpConstraintFor = origRange
+		phpConstraintsFor = origRange
 		imageGapFn = origGap
 	})
 	nginxReloadFn = func() error { reloads++; return nil }
-	phpConstraintFor = func(*config.Site) string { return phpRangeConstraint(min, max) }
+	phpConstraintsFor = func(*config.Site) []string { return compactConstraints(phpRangeConstraint(min, max)) }
 	imageGapFn = func(string) imageGapResult { return imageGapResult{} }
 	return &reloads
 }
@@ -95,8 +96,8 @@ func TestSetSitePHPVersion_appliesToParentSite(t *testing.T) {
 		t.Fatalf("SetSitePHPVersion: %v", err)
 	}
 
-	if res.Version != "8.2" || res.Clamped {
-		t.Errorf("result = %+v, want version 8.2 unclamped", res)
+	if res.Version != "8.2" {
+		t.Errorf("result = %+v, want version 8.2", res)
 	}
 	if got := readPHPVersionFile(t, site.Path); got != "8.2" {
 		t.Errorf(".php-version = %q, want 8.2", got)
@@ -116,28 +117,51 @@ func TestSetSitePHPVersion_appliesToParentSite(t *testing.T) {
 	}
 }
 
-// The framework's supported range wins over the request. MCP skipped this
-// check entirely before the funnel, so a site could pin a version the watcher
-// clamped straight back on its next pass.
-func TestSetSitePHPVersion_clampsToFrameworkRange(t *testing.T) {
+// The framework's supported range wins over the request, and a request it
+// refuses changes nothing at all: the registry, the .php-version pin and the
+// project's committed .lerd.yaml are all left as they were, so the user is told
+// what they cannot have rather than handed something they did not ask for.
+func TestSetSitePHPVersion_refusesOutsideFrameworkRange(t *testing.T) {
 	site := phpVersionTestSite(t, asFPM)
 	stubPHPVersionDeps(t, "8.3", "8.5")
 
-	res, err := SetSitePHPVersion(site, "8.1", PHPVersionOpts{})
+	_, err := SetSitePHPVersion(site, "8.1", PHPVersionOpts{})
+	var rangeErr *PHPRangeError
+	if !errors.As(err, &rangeErr) {
+		t.Fatalf("err = %v, want a PHPRangeError", err)
+	}
+	if rangeErr.Requested != "8.1" || len(rangeErr.Constraints) == 0 {
+		t.Errorf("error = %+v, want the request and what it had to satisfy", rangeErr)
+	}
+	if _, err := os.Stat(filepath.Join(site.Path, ".php-version")); !os.IsNotExist(err) {
+		t.Error("a refused pin wrote .php-version")
+	}
+	if site.PHPVersion != "8.4" {
+		t.Errorf("site.PHPVersion = %q, want the original 8.4", site.PHPVersion)
+	}
+	stored, err := config.FindSite("app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.PHPVersion != "8.4" {
+		t.Errorf("registry = %q, want the original 8.4", stored.PHPVersion)
+	}
+}
+
+// Forcing is the escape hatch, and it applies exactly what was asked for.
+func TestSetSitePHPVersion_forcePinsOutsideRange(t *testing.T) {
+	site := phpVersionTestSite(t, asFPM)
+	stubPHPVersionDeps(t, "8.3", "8.5")
+
+	res, err := SetSitePHPVersion(site, "8.1", PHPVersionOpts{Force: true})
 	if err != nil {
 		t.Fatalf("SetSitePHPVersion: %v", err)
 	}
-
-	if res.Version != "8.3" || res.Requested != "8.1" || !res.Clamped {
-		t.Errorf("result = %+v, want 8.1 clamped to 8.3", res)
+	if res.Version != "8.1" {
+		t.Errorf("version = %q, want the forced 8.1", res.Version)
 	}
-	// The pin file must carry the clamped version, not the request: a
-	// .php-version lerd overrides on every pass is a lie other tools trust.
-	if got := readPHPVersionFile(t, site.Path); got != "8.3" {
-		t.Errorf(".php-version = %q, want the clamped 8.3", got)
-	}
-	if site.PHPVersion != "8.3" {
-		t.Errorf("site.PHPVersion = %q, want 8.3", site.PHPVersion)
+	if got := readPHPVersionFile(t, site.Path); got != "8.1" {
+		t.Errorf(".php-version = %q, want 8.1", got)
 	}
 }
 
@@ -455,12 +479,12 @@ func TestPHPConstraintFor_GuessedFrameworkUsesComposer(t *testing.T) {
 	}
 
 	site := &config.Site{Name: "legacy", Path: dir, Framework: "laravel"}
-	got := phpConstraintFor(site)
-	if got != "^7.3|^8.0" {
-		t.Errorf("constraint = %q, want the project's own ^7.3|^8.0", got)
+	got := phpConstraintsFor(site)
+	if !reflect.DeepEqual(got, []string{"^7.3|^8.0"}) {
+		t.Errorf("constraints = %v, want the project's own ^7.3|^8.0", got)
 	}
-	if v := php.ClampToConstraint("7.4", got); v != "7.4" {
-		t.Errorf("7.4 was clamped to %q on a project that requires it", v)
+	if !php.SatisfiesAll("7.4", got...) {
+		t.Error("7.4 was refused on a project that requires it")
 	}
 }
 
@@ -483,8 +507,8 @@ func TestPHPConstraintFor_RealFrameworkStillGoverns(t *testing.T) {
 	}
 
 	site := &config.Site{Name: "modern", Path: dir, Framework: "laravel"}
-	if got := phpConstraintFor(site); got != ">=8.3 <=8.5" {
-		t.Errorf("constraint = %q, want the definition's own range", got)
+	if got := phpConstraintsFor(site); !reflect.DeepEqual(got, []string{">=8.3 <=8.5", "^7.3|^8.0"}) {
+		t.Errorf("constraints = %v, want the definition's range and the project's own", got)
 	}
 }
 
@@ -496,7 +520,34 @@ func TestPHPConstraintFor_NoFrameworkUsesComposer(t *testing.T) {
 		t.Fatal(err)
 	}
 	site := &config.Site{Name: "plain", Path: dir}
-	if got := phpConstraintFor(site); got != "^8.2" {
-		t.Errorf("constraint = %q, want ^8.2", got)
+	if got := phpConstraintsFor(site); !reflect.DeepEqual(got, []string{"^8.2"}) {
+		t.Errorf("constraints = %v, want ^8.2", got)
+	}
+}
+
+// A definition can be the real one for the framework and still be wrong for the
+// project in front of it: a Winter CMS install is detected as Laravel and served
+// the Laravel 9 definition, capped at 8.2, while its own composer.json requires
+// more than that. Nothing can satisfy both, so the project wins, since it is the
+// one that has to boot.
+func TestPHPConstraintsFor_ProjectWinsWhenRangeCannotServeIt(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "composer.json"),
+		[]byte(`{"require":{"php":">=8.4"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := getFrameworkFn
+	t.Cleanup(func() { getFrameworkFn = orig })
+	getFrameworkFn = func(string, string) (*config.Framework, bool) {
+		return &config.Framework{
+			Name: "laravel", Version: "9",
+			PHP: config.FrameworkPHP{Min: "8.0", Max: "8.2"},
+		}, true
+	}
+
+	site := &config.Site{Name: "winter", Path: dir, Framework: "laravel"}
+	if got := phpConstraintsFor(site); !reflect.DeepEqual(got, []string{">=8.4"}) {
+		t.Errorf("constraints = %v, want the project's own >=8.4", got)
 	}
 }

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -3866,9 +3866,6 @@ func handlePHPExtensions(w http.ResponseWriter, r *http.Request, version string)
 // never silently lands a site on an image missing its extensions.
 func phpSwitchWarning(res siteops.PHPVersionResult) string {
 	var parts []string
-	if res.Clamped {
-		parts = append(parts, fmt.Sprintf("PHP %s is outside the range this framework supports, so %s was used instead.", res.Requested, res.Version))
-	}
 	if res.Demoted {
 		parts = append(parts, fmt.Sprintf("FrankenPHP has no image for PHP %s, so the site was switched to FPM.", res.Version))
 	}


### PR DESCRIPTION
A framework definition describes the framework, composer.json describes the application that has to boot, and both now apply to what a site is allowed to run. Where the two cannot both be met the project wins. That is the case that surfaced this: a Winter CMS install is detected as Laravel and served the definition its lock names, whose cap sits below what its own dependencies require, so it linked onto a version that answered 500 on the platform check before a single route ran.

lerd isolate no longer clamps. A version the range or the project rules out is refused and nothing is written, so the registry, the .php-version pin and the committed .lerd.yaml stay as they were. The refusal names what the version had to satisfy and the closest installed version that does, and --force pins it anyway for the times the user knows better.

The link still clamps, since it has to produce something, but it now reports a pin it moved instead of printing the version it landed on as though that had been the request.

Whether two constraints can be met at once is decided from the constraints themselves rather than from what happens to be installed, so a fresh machine with no images built reaches the same answer as a developer box with five.

Closes #1720