### PR TITLE
feat: let the store route a globally installed CLI onto the host PHP

### DIFF
--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -61,6 +61,20 @@ The layer is merged onto the resolved definition when the project has the packag
 
 Having the package means composer installed it, not that the project named it. The manifest is read first, and then `composer.lock`, which is the only place a dependency that arrived under a meta-package shows up, and the only place a package that another one `replace`s or `provide`s exists at all: `tempest/framework` stands in for `tempest/database`, so a stock Tempest project has that code installed while its `composer.json` names neither. A `check:` on a worker, command, setup step or doctor check is answered the same way, since what it is really asking is whether the thing it runs is there. Detection is the exception and reads the manifest alone: a library repo testing against Laravel has `laravel/framework` in its lock, and that must not make it a Laravel site.
 
+### A CLI composer installed globally
+
+`host_binaries` names the executables a package installs that cannot run through the shim at all:
+
+```yaml
+package: laravel/cloud-cli
+host_binaries:
+  - cloud
+```
+
+`composer global require` puts a binary on your PATH as a wrapper into the PHP container, which is what makes a globally required tool work at all. A CLI that authenticates over a browser callback is the one shape that cannot survive that: it binds a loopback listener on a port it picks per run, and the browser dialling `127.0.0.1` on the host reaches nothing, because the listener sits in the container's network namespace. Publishing a port ahead of time is no help when the port is chosen at runtime.
+
+A binary named here runs on lerd's own pinned PHP instead, downloaded to `~/.local/share/lerd/bin` the first time one is needed, at the version the directory you run it from resolves to. Nothing else about the call changes: same working directory, same environment, same arguments. It is matched by name against what `composer global require` installed, so it holds wherever composer put it and whatever `COMPOSER_HOME` is, and only for a package the global install actually carries. That is why this is a name rather than a `host_commands` pattern: a tool that belongs to no project has no framework to be resolved through, and no path that is the same on two machines.
+
 ### When a package major changes what lerd runs
 
 A package that has kept its interface is one file and says nothing about versions. When a major renames a command, moves a binary, or changes what a worker should run, that major gets a file of its own, `<vendor>-<name>@<major>.yaml`, and the index entry lists it:

--- a/internal/cli/composer_exec.go
+++ b/internal/cli/composer_exec.go
@@ -52,16 +52,23 @@ func runComposer(args []string) error {
 	return nil
 }
 
-// composerGlobalBinDir resolves the directory where composer drops binaries
-// for globally required packages, honouring COMPOSER_HOME and XDG.
-func composerGlobalBinDir() string {
+// composerHomeDir resolves composer's own home, honouring COMPOSER_HOME and
+// XDG. It is a composer project like any other: the manifest and lock naming
+// what `composer global require` installed live here.
+func composerHomeDir() string {
 	if v := os.Getenv("COMPOSER_HOME"); v != "" {
-		return filepath.Join(v, "vendor", "bin")
+		return v
 	}
 	home, _ := os.UserHomeDir()
 	xdg := os.Getenv("XDG_CONFIG_HOME")
 	if xdg == "" {
 		xdg = filepath.Join(home, ".config")
 	}
-	return filepath.Join(xdg, "composer", "vendor", "bin")
+	return filepath.Join(xdg, "composer")
+}
+
+// composerGlobalBinDir resolves the directory where composer drops binaries
+// for globally required packages.
+func composerGlobalBinDir() string {
+	return filepath.Join(composerHomeDir(), "vendor", "bin")
 }

--- a/internal/cli/composer_exec.go
+++ b/internal/cli/composer_exec.go
@@ -72,3 +72,26 @@ func composerHomeDir() string {
 func composerGlobalBinDir() string {
 	return filepath.Join(composerHomeDir(), "vendor", "bin")
 }
+
+// composerHomeDirs lists every directory composer may be using as its home on
+// this machine, not just the one lerd would pick.
+//
+// composer only takes the XDG location when something asks it to: an XDG_
+// variable in the environment, or /etc/xdg on disk. With neither, which is the
+// normal case on macOS, it uses ~/.composer. A machine can therefore end up
+// with global packages in both, installed by composer runs that disagreed, and
+// looking in one of them finds a tool that is really in the other.
+func composerHomeDirs() []string {
+	if v := os.Getenv("COMPOSER_HOME"); v != "" {
+		return []string{v}
+	}
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		return []string{composerHomeDir()}
+	}
+	dirs := []string{composerHomeDir()}
+	if legacy := filepath.Join(home, ".composer"); legacy != dirs[0] {
+		dirs = append(dirs, legacy)
+	}
+	return dirs
+}

--- a/internal/cli/framework.go
+++ b/internal/cli/framework.go
@@ -134,6 +134,9 @@ func packageDeclares(p config.StorePackageInfo) string {
 	if len(p.Commands) > 0 {
 		parts = append(parts, strings.Join(p.Commands, ", "))
 	}
+	for _, b := range p.HostBinaries {
+		parts = append(parts, b+" on the host")
+	}
 	if p.Setup > 0 {
 		parts = append(parts, fmt.Sprintf("%d setup", p.Setup))
 	}

--- a/internal/cli/global_host_cli.go
+++ b/internal/cli/global_host_cli.go
@@ -27,7 +27,17 @@ func runGlobalHostCLI(cwd string, args []string, extraEnv []string) (int, bool, 
 		return 0, false, nil
 	}
 	script := args[i]
-	if filepath.Dir(script) != composerGlobalBinDir() {
+	// Matched against every home composer may be using, not only the one lerd
+	// would pick: a tool installed under the other one is still a global tool,
+	// and looking in one place silently left it in the container.
+	composerHome := ""
+	for _, dir := range composerHomeDirs() {
+		if filepath.Dir(script) == filepath.Join(dir, "vendor", "bin") {
+			composerHome = dir
+			break
+		}
+	}
+	if composerHome == "" {
 		return 0, false, nil
 	}
 	// Under the native runtime PHP already runs on the host, so there is no
@@ -36,7 +46,9 @@ func runGlobalHostCLI(cwd string, args []string, extraEnv []string) (int, bool, 
 	if _, native := nativeRuntimeVersion(cwd); native {
 		return 0, false, nil
 	}
-	if !config.GlobalHostBinary(composerHomeDir(), filepath.Base(script)) {
+	// Asked of the home the binary actually came from, so the manifest read is
+	// the one that installed it.
+	if !config.GlobalHostBinary(composerHome, filepath.Base(script)) {
 		return 0, false, nil
 	}
 	// lerd's own pinned build rather than whatever php the machine happens to

--- a/internal/cli/global_host_cli.go
+++ b/internal/cli/global_host_cli.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// runGlobalHostCLI runs a globally installed composer binary on lerd's own PHP
+// rather than in the container, when the store says it cannot work there, and
+// reports whether it took the call. The case it exists for is a CLI that
+// authenticates over a browser callback: it binds a loopback listener on a port
+// it picks per run, and the browser dialling 127.0.0.1 on the host reaches
+// nothing, because the listener is in the container's network namespace.
+//
+// This is the global sibling of a framework's host_commands. A tool composer
+// installed globally belongs to no project, so nothing about it can be resolved
+// through the framework of whatever directory it happens to be run from, and
+// the declaration is matched against the binary's name instead.
+func runGlobalHostCLI(cwd string, args []string, extraEnv []string) (int, bool, error) {
+	i := phpScriptArgIndex(args)
+	if i < 0 || i >= len(args) {
+		return 0, false, nil
+	}
+	script := args[i]
+	if filepath.Dir(script) != composerGlobalBinDir() {
+		return 0, false, nil
+	}
+	// Under the native runtime PHP already runs on the host, so there is no
+	// boundary to escape and the native path is the one that knows which
+	// extensions and ini this machine's PHP was set up with.
+	if _, native := nativeRuntimeVersion(cwd); native {
+		return 0, false, nil
+	}
+	if !config.GlobalHostBinary(composerHomeDir(), filepath.Base(script)) {
+		return 0, false, nil
+	}
+	// lerd's own pinned build rather than whatever php the machine happens to
+	// carry: a lerd install is not required to have a host PHP at all, and the
+	// version the project resolves to is the one the tool's code expects.
+	version, err := phpVersionForDir(cwd)
+	if err != nil {
+		return 0, true, err
+	}
+	php, err := ensureHostPHPBinary(os.Stderr, version)
+	if err != nil {
+		return 0, true, fmt.Errorf("%s cannot run inside the PHP container, and lerd has no PHP on this machine to run it with: %w", filepath.Base(script), err)
+	}
+	cmd := exec.Command(php, args...)
+	cmd.Dir = cwd
+	cmd.Env = append(os.Environ(), extraEnv...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return ee.ExitCode(), true, nil
+		}
+		return 0, true, err
+	}
+	return 0, true, nil
+}

--- a/internal/cli/global_host_cli_homes_test.go
+++ b/internal/cli/global_host_cli_homes_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// seedGlobalPackage declares a binary as host-only and registers the package in
+// the composer home given, which is what the routing decision reads.
+func seedGlobalPackage(t *testing.T, composerHome, bin string) {
+	t.Helper()
+	store := filepath.Join(os.Getenv("XDG_DATA_HOME"), "lerd", "frameworks")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(store, "index.json"),
+		[]byte(`{"frameworks":[],"packages":[{"name":"acme/cloud-cli"}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(config.StorePackagesDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(config.StorePackagesDir(), "acme-cloud-cli.yaml"),
+		[]byte("package: acme/cloud-cli\nhost_binaries:\n  - "+bin+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(composerHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(composerHome, "composer.json"),
+		[]byte(`{"require": {"acme/cloud-cli": "^1.0"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// composer only takes the XDG location when an XDG_ variable or /etc/xdg says
+// so, and otherwise uses ~/.composer. A machine can have global packages in
+// either, and a tool in the one lerd did not pick was left running in the
+// container with its browser callback unreachable, which is the whole point of
+// moving it to the host.
+func TestRunGlobalHostCLI_findsABinaryInTheLegacyComposerHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("COMPOSER_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	legacy := filepath.Join(home, ".composer")
+	seedGlobalPackage(t, legacy, "cloud")
+
+	bin := filepath.Join(legacy, "vendor", "bin", "cloud")
+	if _, took, _ := runGlobalHostCLI(t.TempDir(), []string{bin, "login"}, nil); !took {
+		t.Error("a global binary under ~/.composer must still be taken out of the container")
+	}
+}
+
+// The XDG home keeps working, so a machine that uses that one is unaffected.
+func TestRunGlobalHostCLI_findsABinaryInTheXDGComposerHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("COMPOSER_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	xdg := filepath.Join(home, ".config", "composer")
+	seedGlobalPackage(t, xdg, "cloud")
+
+	bin := filepath.Join(xdg, "vendor", "bin", "cloud")
+	if _, took, _ := runGlobalHostCLI(t.TempDir(), []string{bin, "login"}, nil); !took {
+		t.Error("a global binary under the XDG home must be taken out of the container")
+	}
+}
+
+// COMPOSER_HOME is explicit, so nothing else should be consulted.
+func TestRunGlobalHostCLI_honoursComposerHomeExactly(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	explicit := filepath.Join(home, "elsewhere")
+	t.Setenv("COMPOSER_HOME", explicit)
+	seedGlobalPackage(t, explicit, "cloud")
+
+	// The same name under a home COMPOSER_HOME did not name is not it.
+	other := filepath.Join(home, ".composer", "vendor", "bin", "cloud")
+	if _, took, _ := runGlobalHostCLI(t.TempDir(), []string{other, "login"}, nil); took {
+		t.Error("COMPOSER_HOME is explicit; another home must not be consulted")
+	}
+	if _, took, _ := runGlobalHostCLI(t.TempDir(), []string{filepath.Join(explicit, "vendor", "bin", "cloud")}, nil); !took {
+		t.Error("the binary under COMPOSER_HOME must be taken")
+	}
+}

--- a/internal/cli/global_host_cli_test.go
+++ b/internal/cli/global_host_cli_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// storeless isolates a test from the machine's own store and composer home, so
+// nothing here reads what the developer running it happens to have installed.
+func storeless(t *testing.T) string {
+	t.Helper()
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("COMPOSER_HOME", home)
+	return home
+}
+
+func TestRunGlobalHostCLI_leavesAProjectScriptAlone(t *testing.T) {
+	storeless(t)
+	if _, took, _ := runGlobalHostCLI(t.TempDir(), []string{"artisan", "migrate"}, nil); took {
+		t.Error("a project's own script must run in the container")
+	}
+}
+
+func TestRunGlobalHostCLI_leavesAnInvocationWithNoScriptAlone(t *testing.T) {
+	storeless(t)
+	if _, took, _ := runGlobalHostCLI(t.TempDir(), []string{"-r", "echo 1;"}, nil); took {
+		t.Error("php -r runs no file and must stay in the container")
+	}
+}
+
+func TestRunGlobalHostCLI_leavesAnUndeclaredGlobalBinaryAlone(t *testing.T) {
+	home := storeless(t)
+	bin := filepath.Join(home, "vendor", "bin", "psysh")
+	if _, took, _ := runGlobalHostCLI(t.TempDir(), []string{bin}, nil); took {
+		t.Error("a global binary no package declares must run in the container")
+	}
+}

--- a/internal/cli/php_exec.go
+++ b/internal/cli/php_exec.go
@@ -119,6 +119,11 @@ func RunPHPVersionCaptureEnv(cwd, version string, args []string, extraEnv []stri
 	if code, took, err := runDeclaredHostCommand(cwd, args, extraEnv); took {
 		return code, err
 	}
+	// The same for a CLI composer installed globally, which has no project and
+	// so no framework to declare it.
+	if code, took, err := runGlobalHostCLI(cwd, args, extraEnv); took {
+		return code, err
+	}
 	recordCwdActivity(cwd) // keep the site awake under idle-suspend while you work in the terminal
 	// The CLI SAPI ignores a project's .user.ini, so a framework declaring
 	// php.cli_ini gets it as -d on every PHP process lerd starts for it.

--- a/internal/config/framework_package.go
+++ b/internal/config/framework_package.go
@@ -436,6 +436,10 @@ type StorePackageInfo struct {
 	Commands []string
 	Setup    int
 	Doctor   int
+	// HostBinaries are the globally installed binaries the package routes out of
+	// the container, the one declaration that contributes nothing to a framework
+	// and would otherwise leave the package looking empty in a listing.
+	HostBinaries []string
 }
 
 // ListStorePackages describes the package layer for projectDir, which may be
@@ -460,6 +464,7 @@ func ListStorePackages(projectDir string) []StorePackageInfo {
 			for _, c := range pkg.Commands {
 				info.Commands = append(info.Commands, c.Name)
 			}
+			info.HostBinaries = pkg.HostBinaries
 			info.Setup = len(pkg.Setup)
 			if pkg.Doctor != nil {
 				info.Doctor = len(pkg.Doctor.Checks)

--- a/internal/config/framework_package.go
+++ b/internal/config/framework_package.go
@@ -48,7 +48,15 @@ type FrameworkPackage struct {
 	Commands   []FrameworkCommand         `yaml:"commands,omitempty"`
 	// HostCommands are the console commands this package's runtime cannot run
 	// inside the container, and the binary that runs them instead.
-	HostCommands []HostCommand       `yaml:"host_commands,omitempty"`
+	HostCommands []HostCommand `yaml:"host_commands,omitempty"`
+	// HostBinaries names the executables this package installs that cannot run
+	// through the shim at all, matched by name wherever composer put them. A CLI
+	// that authenticates over a browser callback binds a loopback listener on a
+	// port it picks per run, and the browser dialling 127.0.0.1 on the host
+	// reaches nothing, because the listener is in the container's namespace.
+	// Unlike HostCommands these belong to no project: composer installs them
+	// globally, so there is no framework to resolve them through.
+	HostBinaries []string            `yaml:"host_binaries,omitempty"`
 	Setup        []FrameworkSetupCmd `yaml:"setup,omitempty"`
 	Doctor       *FrameworkDoctor    `yaml:"doctor,omitempty"`
 	// Removes takes entries away from the resolved framework, for a major of the
@@ -57,6 +65,28 @@ type FrameworkPackage struct {
 	// staying silent: the copy a declaration was lifted out of is still in the
 	// framework's own version files, and silence there means keep it.
 	Removes *FrameworkPackageRemoves `yaml:"removes,omitempty"`
+}
+
+// GlobalHostBinary reports whether the store declares bin, an executable
+// composer installed globally under composerHome, as one that has to run on a
+// host PHP. Only packages the global install actually requires are consulted,
+// so a bin name never reaches for a definition this machine has no reason to
+// hold, and a basename collision between two packages cannot answer for one the
+// machine never installed.
+func GlobalHostBinary(composerHome, bin string) bool {
+	if composerHome == "" || bin == "" {
+		return false
+	}
+	for _, entry := range cachedStorePackages() {
+		if !ComposerHasInstalled(composerHome, entry.Name) {
+			continue
+		}
+		pkg := resolveStorePackage(entry, composerHome)
+		if pkg != nil && slices.Contains(pkg.HostBinaries, bin) {
+			return true
+		}
+	}
+	return false
 }
 
 // FrameworkPackageRemoves names entries, by the name each is declared under,

--- a/internal/config/global_host_binary_test.go
+++ b/internal/config/global_host_binary_test.go
@@ -1,0 +1,38 @@
+package config
+
+import "testing"
+
+// composer's home is a composer project like any other, so the sandbox project
+// stands in for it: a manifest naming what `composer global require` installed.
+func TestGlobalHostBinary(t *testing.T) {
+	_, composerHome := packageSandbox(t, []string{`{"name":"acme/cloud-cli"}`}, "acme/cloud-cli")
+	writePackage(t, "acme-cloud-cli", "package: acme/cloud-cli\nhost_binaries:\n  - cloud\n")
+
+	if !GlobalHostBinary(composerHome, "cloud") {
+		t.Error("a declared global binary must run on the host")
+	}
+	if GlobalHostBinary(composerHome, "psysh") {
+		t.Error("a binary no package declares must stay in the container")
+	}
+}
+
+func TestGlobalHostBinary_packageNotInstalledGlobally(t *testing.T) {
+	_, composerHome := packageSandbox(t, []string{`{"name":"acme/cloud-cli"}`})
+	writePackage(t, "acme-cloud-cli", "package: acme/cloud-cli\nhost_binaries:\n  - cloud\n")
+
+	if GlobalHostBinary(composerHome, "cloud") {
+		t.Error("a package this machine never installed must not answer for a binary name")
+	}
+}
+
+// The index is what the machine is allowed to read, the same as for a project's
+// package layer, so a file left behind by an earlier catalogue cannot keep
+// routing a binary out of the container.
+func TestGlobalHostBinary_packageOutsideTheIndexIsIgnored(t *testing.T) {
+	_, composerHome := packageSandbox(t, nil, "acme/cloud-cli")
+	writePackage(t, "acme-cloud-cli", "package: acme/cloud-cli\nhost_binaries:\n  - cloud\n")
+
+	if GlobalHostBinary(composerHome, "cloud") {
+		t.Error("package outside the index must not be consulted")
+	}
+}

--- a/internal/config/global_host_binary_test.go
+++ b/internal/config/global_host_binary_test.go
@@ -36,3 +36,18 @@ func TestGlobalHostBinary_packageOutsideTheIndexIsIgnored(t *testing.T) {
 		t.Error("package outside the index must not be consulted")
 	}
 }
+
+// A package whose only declaration is a host binary contributes nothing to a
+// framework, so without this the listing shows it as declaring nothing at all.
+func TestListStorePackages_reportsHostBinaries(t *testing.T) {
+	_, composerHome := packageSandbox(t, []string{`{"name":"acme/cloud-cli"}`}, "acme/cloud-cli")
+	writePackage(t, "acme-cloud-cli", "package: acme/cloud-cli\nhost_binaries:\n  - cloud\n")
+
+	got := ListStorePackages(composerHome)
+	if len(got) != 1 {
+		t.Fatalf("listed %d packages, want 1", len(got))
+	}
+	if len(got[0].HostBinaries) != 1 || got[0].HostBinaries[0] != "cloud" {
+		t.Errorf("host binaries = %v, want [cloud]", got[0].HostBinaries)
+	}
+}


### PR DESCRIPTION
A CLI composer installed globally reaches the shell as a wrapper into the PHP container, which is what makes a global tool work at all, and is exactly wrong for one that authenticates over a browser callback. It binds a loopback listener on a port it picks per run, and the browser dialling 127.0.0.1 on the host finds nothing there, because the listener is in the container's network namespace. `php:ports` cannot publish a port that is chosen at runtime, and `path:disable` is machine wide.

A package definition can now name those binaries in `host_binaries`, and lerd runs them on its own pinned PHP before anything starts a container. They are matched by name rather than by path, since a tool that belongs to no project has no framework to be resolved through, and no path that is the same on two machines. Only a package the global install actually carries is consulted, so a name never answers for something this machine never installed.

Under the native runtime PHP already runs on the host, so there is no boundary to escape and the native path keeps the call.

The declaration for `laravel/cloud-cli` is lerd-env/frameworks#70.

Refs #1724