### PR TITLE
fix: stop a scaffold from landing inside the Podman Machine VM

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -623,3 +623,19 @@ lerd machine reset
 
 This stops the VM, removes it, and re-initialises it. Databases and site data are preserved (they live on the host); container images are rebuilt automatically on the next `lerd start`. See [Start, Stop & Autostart → `lerd machine reset`](usage/lifecycle.md#lerd-machine-reset-macos).
 :::
+
+::: details A project on an external drive is created inside the VM (macOS)
+Symptom: on macOS, `lerd new` on a path outside your home directory reports the project as created, then the run warns `chdir /Volumes/<drive>/<project>: no such file or directory` and the folder is nowhere on the drive.
+
+Cause: on macOS every bind mount is resolved inside the Podman Machine VM, and the VM only sees the host trees it was given when it was created. A drive mounted under `/Volumes` is often not among them, so the container sees an empty directory at that path, composer writes the whole project into the VM, and it never lands on the disk.
+
+lerd now checks that the container is really looking at your directory before it scaffolds, and stops with an explanation instead of creating a project you cannot find.
+
+Machines lerd creates share `/Users`, `/private`, `/var/folders` and `/Volumes` with the VM, but a machine created before lerd asked for `/Volumes` (or one created by hand with `podman machine init`) keeps Podman's own defaults and never got it. Podman writes the guest mount units once at init, so this cannot be repaired by editing the machine config; recreate the VM instead:
+
+```bash
+lerd machine reset
+```
+
+`lerd start` points this out on its own when something is already served from outside your home directory. If the drive is still invisible after a reset, macOS is withholding access to it from the VM process rather than lerd failing to ask; keep the project under your home directory.
+:::

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -639,3 +639,18 @@ lerd machine reset
 
 `lerd start` points this out on its own when something is already served from outside your home directory. If the drive is still invisible after a reset, macOS is withholding access to it from the VM process rather than lerd failing to ask; keep the project under your home directory.
 :::
+
+::: details An external drive will not eject while lerd is running (macOS)
+Symptom: `diskutil unmount` or the eject button refuses with `dissented by PID ... com.apple.Virtualization.VirtualMachine`.
+
+Cause: the Podman Machine VM shares `/Volumes` for as long as it runs, so macOS treats every drive under it as in use. Stopping the containers is not enough, the VM itself has to go down:
+
+```bash
+lerd stop
+podman machine stop
+```
+
+The drive ejects after that, and `lerd start` brings the VM and your other sites back. Plugging the drive in again is picked up by a running VM on its own, no restart needed.
+
+While the drive is away, lerd starts normally and every other site is unaffected: the missing path is dropped from the container mounts and the site on the drive stops being served. Your files are untouched, but the site is removed from `lerd sites`, so bring it back with `lerd link` and, if it was on HTTPS, `lerd secure` from the project directory.
+:::

--- a/internal/cli/mountprobe.go
+++ b/internal/cli/mountprobe.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// containerSeesHostDir is the seam the scaffold guard calls; tests replace it.
+var containerSeesHostDir = probeContainerSeesHostDir
+
+// probeContainerSeesHostDir reports whether dir, bind-mounted into the PHP
+// container, is really the host's own directory. On macOS every mount source is
+// resolved inside the Podman Machine VM, which shares only the host trees it was
+// given at init. A path it does not share becomes an empty stand-in in the VM,
+// so a container writing there succeeds and the files never appear on the Mac
+// (issue #1725). Asking the container is deliberate: the reasons a share can be
+// missing are several, and the symptom is the same for all of them.
+func probeContainerSeesHostDir(dir, phpVersion string) bool {
+	return containerSeesHostDirOn(runtime.GOOS, dir, fpmSeesFile(dir, phpVersion))
+}
+
+// containerSeesHostDirOn is the platform-free core: it drops a marker on the
+// host and asks sees whether the container finds it. A Linux bind mount is the
+// host's directory by construction, and the VM always shares the host home, so
+// neither case is worth a container round trip. A marker that cannot be written
+// leaves the answer at yes, since an unwritable directory is a problem the
+// create command itself will report in its own terms.
+func containerSeesHostDirOn(goos, dir string, sees func(marker string) bool) bool {
+	if goos != "darwin" {
+		return true
+	}
+	if home, _ := os.UserHomeDir(); home != "" && (dir == home || strings.HasPrefix(dir, strings.TrimSuffix(home, "/")+"/")) {
+		return true
+	}
+	marker := filepath.Join(dir, fmt.Sprintf(".lerd-mount-probe-%d", os.Getpid()))
+	if err := os.WriteFile(marker, nil, 0644); err != nil {
+		return true
+	}
+	defer os.Remove(marker)
+	return sees(marker)
+}
+
+// fpmSeesFile asks the PHP-FPM container serving dir whether a host path is
+// there. Under the native runtime there is no container and no VM between the
+// two, so the question is already answered. Anything that stops the check from
+// running answers yes for the same reason as above: this guard exists to catch
+// a mount that lies, not to turn every podman hiccup into a scaffold failure.
+func fpmSeesFile(dir, phpVersion string) func(string) bool {
+	return func(marker string) bool {
+		if _, native := nativeRuntimeVersion(dir); native {
+			return true
+		}
+		_, container, err := ensureFPMRunning(dir, phpVersion, fpmContainerForDir(dir, phpVersion))
+		if err != nil {
+			return true
+		}
+		return podman.Cmd("exec", container, "test", "-e", marker).Run() == nil
+	}
+}

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -115,6 +115,20 @@ func prepareScaffoldParent(target string) error {
 		return fmt.Errorf("cannot scaffold into %s: lerd does not mount temporary system directories (/tmp, /var/tmp, /run) into containers, so composer would have no such directory to run in. Pick a path under your home directory, or park the parent first with 'lerd park %s'", parent, parent)
 	}
 	ensurePathMounted(parent, version)
+	if !containerSeesHostDir(parent, version) {
+		return fmt.Errorf("cannot scaffold into %s: the PHP container sees an empty directory there rather than the one on this machine, so the project would be created inside the Podman Machine VM and never appear on disk. That happens when the path is not shared with the VM, which is the usual answer for a drive mounted under /Volumes. Run 'lerd machine reset' to recreate the VM with every mount lerd asks for, or scaffold under your home directory instead", parent)
+	}
+	return nil
+}
+
+// scaffoldLanded confirms the create command wrote to the host. A container
+// whose bind mount does not reach the real directory takes the whole project
+// with it and composer still exits 0, so a run only reports success once the
+// project is on disk.
+func scaffoldLanded(target string) error {
+	if info, err := os.Stat(target); err != nil || !info.IsDir() {
+		return fmt.Errorf("the create command reported success but %s is not on disk, so it was written inside the container instead. That happens when the project path is not shared with the Podman Machine VM, which is the usual answer for a drive mounted under /Volumes. Run 'lerd machine reset' to recreate the VM with every mount lerd asks for, or scaffold under your home directory instead", target)
+	}
 	return nil
 }
 
@@ -285,6 +299,9 @@ func runNew(target, frameworkName, frameworkVersion string, extraArgs []string) 
 
 	if err := runScaffold(plan, filepath.Dir(target), scaffoldVersion); err != nil {
 		return fmt.Errorf("scaffold command failed: %w", err)
+	}
+	if err := scaffoldLanded(target); err != nil {
+		return err
 	}
 
 	feedback.Success("created "+filepath.Base(target), time.Since(start))

--- a/internal/cli/new_mountprobe_test.go
+++ b/internal/cli/new_mountprobe_test.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A Linux bind mount is the host's own directory, so the guard answers without
+// starting a container.
+func TestContainerSeesHostDirSkipsLinux(t *testing.T) {
+	probed := false
+	if !containerSeesHostDirOn("linux", t.TempDir(), func(string) bool { probed = true; return false }) {
+		t.Error("a Linux path must be reported as visible")
+	}
+	if probed {
+		t.Error("Linux must not be probed")
+	}
+}
+
+// The Podman Machine VM always shares the host home, so a project under it
+// needs no round trip either.
+func TestContainerSeesHostDirSkipsHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	probed := false
+	dir := filepath.Join(home, "Sites")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if !containerSeesHostDirOn("darwin", dir, func(string) bool { probed = true; return false }) {
+		t.Error("a path under the host home must be reported as visible")
+	}
+	if probed {
+		t.Error("a path under the host home must not be probed")
+	}
+}
+
+// The reported failure: the container answers no, because the mount resolves to
+// an empty stand-in inside the VM rather than the external drive.
+func TestContainerSeesHostDirDetectsUnsharedPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	dir := t.TempDir()
+	var seen string
+	got := containerSeesHostDirOn("darwin", dir, func(marker string) bool {
+		seen = marker
+		return false
+	})
+	if got {
+		t.Error("a path the container cannot see must be reported as unshared")
+	}
+	if filepath.Dir(seen) != dir {
+		t.Errorf("probed %q, want a marker inside %q", seen, dir)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("the probe left %v behind", entries)
+	}
+}
+
+// A container that finds the marker is looking at the host's own directory.
+func TestContainerSeesHostDirAcceptsSharedPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	dir := t.TempDir()
+	if !containerSeesHostDirOn("darwin", dir, func(marker string) bool {
+		_, err := os.Stat(marker)
+		return err == nil
+	}) {
+		t.Error("a marker the container can read must report the path as shared")
+	}
+}
+
+// A directory that cannot take the marker is the create command's problem to
+// report, not a mount failure to invent.
+func TestContainerSeesHostDirIgnoresUnwritableDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if !containerSeesHostDirOn("darwin", filepath.Join(t.TempDir(), "absent"), func(string) bool { return false }) {
+		t.Error("an unwritable directory must not be reported as unshared")
+	}
+}
+
+// The scaffold must stop before composer runs when the parent is mounted but
+// the mount does not reach the host.
+func TestPrepareScaffoldParentRejectsUnsharedParent(t *testing.T) {
+	stubMountSeams(t, true, false)
+	orig := containerSeesHostDir
+	containerSeesHostDir = func(string, string) bool { return false }
+	t.Cleanup(func() { containerSeesHostDir = orig })
+
+	err := prepareScaffoldParent(filepath.Join(t.TempDir(), "drive", "app"))
+	if err == nil {
+		t.Fatal("expected an error for a parent the container cannot reach")
+	}
+	if !strings.Contains(err.Error(), "/Volumes") {
+		t.Errorf("error = %v, want it to name the external drive case", err)
+	}
+}
+
+// composer exits 0 having written the whole project inside the VM, so success
+// is only reported once the project is on the host.
+func TestScaffoldLanded(t *testing.T) {
+	dir := t.TempDir()
+	if err := scaffoldLanded(dir); err != nil {
+		t.Errorf("scaffoldLanded on an existing directory: %v", err)
+	}
+
+	missing := filepath.Join(dir, "new-project")
+	err := scaffoldLanded(missing)
+	if err == nil {
+		t.Fatal("expected an error when the project is not on disk")
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Errorf("error = %v, want it to name the target", err)
+	}
+}

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -143,11 +143,14 @@ func stubMountSeams(t *testing.T, autoMountable, visible bool) *string {
 	t.Helper()
 	mounted := new(string)
 	origMount, origAuto, origVisible := ensurePathMounted, pathAutoMountable, pathVisible
+	origSees := containerSeesHostDir
 	ensurePathMounted = func(path, phpVersion string) { *mounted = path }
 	pathAutoMountable = func(path string) bool { return autoMountable }
 	pathVisible = func(path, phpVersion string) bool { return visible }
+	containerSeesHostDir = func(path, phpVersion string) bool { return true }
 	t.Cleanup(func() {
 		ensurePathMounted, pathAutoMountable, pathVisible = origMount, origAuto, origVisible
+		containerSeesHostDir = origSees
 	})
 	return mounted
 }

--- a/internal/cli/startstop_darwin.go
+++ b/internal/cli/startstop_darwin.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -123,41 +124,120 @@ func machineInitArgs(name string, targetMemoryMiB int64, provider string) []stri
 	return args
 }
 
-// machineMissingHomeMount reports whether the named machine's config lacks the
-// host home mount, i.e. it was initialised by the lerd <= 1.24.0 bug. Returns
-// false on any read/parse error so we never recreate a machine we can't
-// positively diagnose as broken.
-//
-// This must be repaired by recreating the VM, not by editing the config:
-// Podman writes the guest's virtiofs .mount units once at init via Ignition and
-// `machine start` never regenerates them, so adding /Users to the config JSON
-// attaches the host-side device but leaves the guest with no mount unit; the
-// path still never appears inside the VM.
-func machineMissingHomeMount(name string) bool {
+// machineMountSources returns the host paths the named machine shares with the
+// VM. The second result is false when the config cannot be read or carries no
+// mount list at all, which every caller treats as "cannot tell" rather than
+// "shares nothing", so a machine we cannot diagnose is never touched.
+func machineMountSources(name string) ([]string, bool) {
 	path := getMachineJSONPath(name)
 	if path == "" {
-		return false
+		return nil, false
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return false
+		return nil, false
 	}
 	var config map[string]any
 	if err := json.Unmarshal(data, &config); err != nil {
-		return false
+		return nil, false
 	}
 	mounts, ok := config["Mounts"].([]any)
 	if !ok {
-		return false
+		return nil, false
 	}
+	var sources []string
 	for _, mAny := range mounts {
 		if m, ok := mAny.(map[string]any); ok {
-			if src, _ := m["Source"].(string); src == homeMachineMount {
-				return false // home mount present
+			if src, _ := m["Source"].(string); src != "" {
+				sources = append(sources, src)
 			}
 		}
 	}
-	return true
+	return sources, true
+}
+
+// machineMissingMounts lists the required host trees the named machine never
+// had shared with it, in requiredMachineMounts order. A machine created before
+// lerd asked for /Volumes keeps Podman's own defaults and so is missing it,
+// which is why a project on an external drive resolves to an empty directory
+// inside the VM (issue #1725).
+//
+// Any of these must be repaired by recreating the VM, not by editing the
+// config: Podman writes the guest's virtiofs .mount units once at init via
+// Ignition and `machine start` never regenerates them, so adding a path to the
+// config JSON attaches the host-side device but leaves the guest with no mount
+// unit; the path still never appears inside the VM.
+func machineMissingMounts(name string) []string {
+	sources, ok := machineMountSources(name)
+	if !ok {
+		return nil
+	}
+	shared := make(map[string]bool, len(sources))
+	for _, s := range sources {
+		shared[s] = true
+	}
+	var missing []string
+	for _, m := range requiredMachineMounts {
+		if !shared[m] {
+			missing = append(missing, m)
+		}
+	}
+	return missing
+}
+
+// machineMissingHomeMount reports whether the named machine's config lacks the
+// host home mount, i.e. it was initialised by the lerd <= 1.24.0 bug. This is
+// the one missing mount worth recreating a machine over unasked, because such a
+// machine can start no container at all.
+func machineMissingHomeMount(name string) bool {
+	return slices.Contains(machineMissingMounts(name), homeMachineMount)
+}
+
+// outOfHomeServedPaths returns the site and parked directories that live
+// outside the host home, which are exactly the paths a missing machine mount
+// can strand. Used to keep the advisory below off the screen of the installs
+// it has nothing to say to.
+func outOfHomeServedPaths() []string {
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		return nil
+	}
+	var candidates []string
+	if cfg, err := config.LoadGlobal(); err == nil && cfg != nil {
+		candidates = append(candidates, cfg.ParkedDirectories...)
+	}
+	if reg, err := config.LoadSites(); err == nil {
+		for i := range reg.Sites {
+			candidates = append(candidates, reg.Sites[i].Path)
+		}
+	}
+	return outOfHomePaths(home, candidates)
+}
+
+// outOfHomePaths keeps the paths that sit outside home, which is the whole of
+// the rule above with the config lookups taken out of it.
+func outOfHomePaths(home string, candidates []string) []string {
+	prefix := strings.TrimSuffix(home, "/") + "/"
+	var out []string
+	for _, p := range candidates {
+		if p != "" && p != home && !strings.HasPrefix(p, prefix) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// noteMissingMachineMounts points at `lerd machine reset` when an existing
+// machine is missing a mount other than the home one. It is a line rather than
+// a recreate: the machine works, and rebuilding every container image behind
+// the user's back to add a path most installs never use is the wrong trade. It
+// stays quiet unless something is actually served from outside the home, since
+// that is the only case where the missing mount changes anything.
+func noteMissingMachineMounts(missing []string) {
+	if len(missing) == 0 || len(outOfHomeServedPaths()) == 0 {
+		return
+	}
+	feedback.Note(fmt.Sprintf("This Podman Machine does not share %s with the VM, so anything served from there is invisible to the containers. Run 'lerd machine reset' to recreate it with every mount; databases and site data are preserved.", strings.Join(missing, ", ")))
 }
 
 // recreateBrokenMachine destroys and re-initialises a machine that is missing
@@ -276,9 +356,12 @@ func ensurePodmanMachineRunning() error {
 		// init bug and can't be repaired in place (Ignition writes the guest
 		// mount units once at init; a config edit + restart won't add /Users).
 		// Recreate it, then fall through to start.
-		if machineMissingHomeMount(m.name) {
+		missingMounts := machineMissingMounts(m.name)
+		if slices.Contains(missingMounts, homeMachineMount) {
 			recreateBrokenMachine(m.name, m.running, targetMemoryMiB)
 		} else {
+			noteMissingMachineMounts(missingMounts)
+
 			needsRootful := !m.rootful
 			needsMemory := false
 			if inspectMem, err := machineQuery("machine", "inspect",

--- a/internal/cli/startstop_darwin_test.go
+++ b/internal/cli/startstop_darwin_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -93,5 +94,63 @@ func TestMachineMissingHomeMount(t *testing.T) {
 	// recreate on uncertainty).
 	if machineMissingHomeMount("does-not-exist") {
 		t.Error("missing config should not be reported as broken")
+	}
+}
+
+func TestMachineMissingMounts(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	machineDir := filepath.Join(tmp, ".config", "containers", "podman", "machine", "applehv")
+	if err := os.MkdirAll(machineDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	write := func(name string, sources []string) {
+		mounts := make([]any, len(sources))
+		for i, s := range sources {
+			mounts[i] = map[string]any{"Source": s, "Target": s, "Type": "virtiofs"}
+		}
+		data, _ := json.Marshal(map[string]any{"Name": name, "Mounts": mounts})
+		if err := os.WriteFile(filepath.Join(machineDir, name+".json"), data, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cases := []struct {
+		name    string
+		sources []string
+		want    []string
+	}{
+		// A machine created before lerd asked for /Volumes keeps Podman's own
+		// defaults, so an external drive is never shared with the VM (#1725).
+		{"podman-defaults", []string{"/Users", "/private", "/var/folders"}, []string{"/Volumes"}},
+		{"complete", []string{"/Users", "/private", "/var/folders", "/Volumes"}, nil},
+		{"home-only", []string{"/Users"}, []string{"/private", "/var/folders", "/Volumes"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			write(c.name, c.sources)
+			got := machineMissingMounts(c.name)
+			if !slices.Equal(got, c.want) {
+				t.Errorf("machineMissingMounts(%v) = %v, want %v", c.sources, got, c.want)
+			}
+		})
+	}
+
+	// A config we cannot read tells us nothing, so nothing is reported missing.
+	if got := machineMissingMounts("does-not-exist"); got != nil {
+		t.Errorf("unreadable config reported %v missing, want none", got)
+	}
+}
+
+// The advisory speaks only to installs that serve something from outside the
+// home, since that is the only place a missing mount changes anything.
+func TestOutOfHomePaths(t *testing.T) {
+	home := t.TempDir()
+	inside := filepath.Join(home, "Sites")
+	outside := "/Volumes/Dock/projects"
+	got := outOfHomePaths(home, []string{inside, outside, home, ""})
+	if !slices.Equal(got, []string{outside}) {
+		t.Errorf("outOfHomePaths = %v, want %v", got, []string{outside})
 	}
 }

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -1373,8 +1373,10 @@ func EnsurePathMounted(path, phpVersion string) {
 		if strings.Contains(string(existing), volumePrefix) {
 			// The quadlet is already right, but writing one never touches a
 			// running container: whoever wrote this line may have left the
-			// container running without the mount (#914).
+			// container running without the mount (#914). The platform unit can
+			// be behind for the same reason, so re-sync it before restarting.
 			if UnitMissingMounts(q.unitName, []string{path}) {
+				_, _ = WriteQuadletDiff(q.unitName, string(existing))
 				changedUnits = append(changedUnits, q.unitName)
 			}
 			continue
@@ -1384,7 +1386,10 @@ func EnsurePathMounted(path, phpVersion string) {
 		if updated == string(existing) {
 			continue
 		}
-		if writeErr := os.WriteFile(q.path, []byte(updated), 0644); writeErr != nil {
+		// WriteQuadletDiff, never a raw write: macOS turns each quadlet into a
+		// launchd plist on write, and a container restarted from a stale plist
+		// comes back without the new mount (#1725).
+		if changed, writeErr := WriteQuadletDiff(q.unitName, updated); writeErr != nil || !changed {
 			continue
 		}
 		changedUnits = append(changedUnits, q.unitName)

--- a/internal/podman/mountdrift_test.go
+++ b/internal/podman/mountdrift_test.go
@@ -198,3 +198,85 @@ func TestEnsurePathMountedCoversCustomFPMSites(t *testing.T) {
 		t.Errorf("restarted %v, want lerd-cfpm-shop", lc.restarted)
 	}
 }
+
+// #1725 on macOS: a new Volume line reached the quadlet file but not the
+// launchd plist, so the restarted container came back without the mount and the
+// scaffold guard refused a path lerd had just been told to mount.
+func TestEnsurePathMountedSyncsPlatformUnits(t *testing.T) {
+	home := t.TempDir()
+	cfgHome := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+	resetPathMountAttempts()
+
+	quadlets := filepath.Join(cfgHome, "containers", "systemd")
+	if err := os.MkdirAll(quadlets, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := "[Container]\nVolume=%h:%h:rw\n"
+	for _, name := range []string{"lerd-php84-fpm", "lerd-nginx"} {
+		if err := os.WriteFile(filepath.Join(quadlets, name+".container"), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fakeInspect(t, "true#/home/george|")
+	prevLC := UnitLifecycle
+	UnitLifecycle = &restartRecorder{}
+	t.Cleanup(func() { UnitLifecycle = prevLC })
+
+	var synced []string
+	prevHook := AfterQuadletWriteFn
+	AfterQuadletWriteFn = func(name, _ string) error {
+		synced = append(synced, name)
+		return nil
+	}
+	t.Cleanup(func() { AfterQuadletWriteFn = prevHook })
+
+	EnsurePathMounted("/Volumes/Dock", "8.4")
+
+	if len(synced) != 2 {
+		t.Fatalf("synced %v, want both lerd-php84-fpm and lerd-nginx", synced)
+	}
+}
+
+// The same stale plist as #1725, reached from the other side: the quadlet
+// already carries the Volume line, so only the plist and the container are
+// behind. Restarting without re-syncing brings the container back unmounted.
+func TestEnsurePathMountedSyncsPlatformUnitsOnDrift(t *testing.T) {
+	home := t.TempDir()
+	cfgHome := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+	resetPathMountAttempts()
+
+	quadlets := filepath.Join(cfgHome, "containers", "systemd")
+	if err := os.MkdirAll(quadlets, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := "[Container]\nVolume=%h:%h:rw\nVolume=/Volumes/Dock:/Volumes/Dock:rw\n"
+	for _, name := range []string{"lerd-php84-fpm", "lerd-nginx"} {
+		if err := os.WriteFile(filepath.Join(quadlets, name+".container"), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fakeInspect(t, "true#/home/george|")
+	prevLC := UnitLifecycle
+	UnitLifecycle = &restartRecorder{}
+	t.Cleanup(func() { UnitLifecycle = prevLC })
+
+	var synced []string
+	prevHook := AfterQuadletWriteFn
+	AfterQuadletWriteFn = func(name, _ string) error {
+		synced = append(synced, name)
+		return nil
+	}
+	t.Cleanup(func() { AfterQuadletWriteFn = prevHook })
+
+	EnsurePathMounted("/Volumes/Dock", "8.4")
+
+	if len(synced) != 2 {
+		t.Fatalf("synced %v, want both lerd-php84-fpm and lerd-nginx", synced)
+	}
+}


### PR DESCRIPTION
On macOS every bind mount is resolved inside the Podman Machine VM, and the VM only sees the host trees it was given when it was created. A project path it does not share, an external drive under /Volumes being the usual case, resolves to an empty directory in there. Composer then creates the whole project inside the VM, exits zero, and nothing ever appears on the Mac. lerd printed its success line all the same, and the only hint was a chdir warning from the link that ran next.

The scaffold now asks the container whether it is really looking at the host directory before it starts, by dropping a marker and checking for it from the inside, and refuses with an explanation when it is not. It also confirms the project is on disk before reporting success, so a create command cannot be credited with a directory that is not there. Both checks do nothing on Linux and under the native runtime, where the container and the host already share a filesystem.

The machine check that only looked for the home mount now reports every required mount a machine lacks. A machine created before lerd started asking for /Volumes keeps Podman's own defaults, which is how an external drive ends up unshared, and Podman bakes the guest mount units at init so it can only be fixed by recreating the VM. A missing home mount still recreates unasked, since a machine in that state can start nothing at all, but anything else only prints a line pointing at lerd machine reset, and only when a site or parked directory actually lives outside the home. Rebuilding every container image behind someone's back to add a path most installs never use is not a trade worth making for them.

Refs #1725
