### PR TITLE
test: decide the global CLI routing without running it

### DIFF
--- a/internal/cli/global_host_cli.go
+++ b/internal/cli/global_host_cli.go
@@ -27,28 +27,7 @@ func runGlobalHostCLI(cwd string, args []string, extraEnv []string) (int, bool, 
 		return 0, false, nil
 	}
 	script := args[i]
-	// Matched against every home composer may be using, not only the one lerd
-	// would pick: a tool installed under the other one is still a global tool,
-	// and looking in one place silently left it in the container.
-	composerHome := ""
-	for _, dir := range composerHomeDirs() {
-		if filepath.Dir(script) == filepath.Join(dir, "vendor", "bin") {
-			composerHome = dir
-			break
-		}
-	}
-	if composerHome == "" {
-		return 0, false, nil
-	}
-	// Under the native runtime PHP already runs on the host, so there is no
-	// boundary to escape and the native path is the one that knows which
-	// extensions and ini this machine's PHP was set up with.
-	if _, native := nativeRuntimeVersion(cwd); native {
-		return 0, false, nil
-	}
-	// Asked of the home the binary actually came from, so the manifest read is
-	// the one that installed it.
-	if !config.GlobalHostBinary(composerHome, filepath.Base(script)) {
+	if !globalHostCLIWantsHost(cwd, script) {
 		return 0, false, nil
 	}
 	// lerd's own pinned build rather than whatever php the machine happens to
@@ -76,4 +55,37 @@ func runGlobalHostCLI(cwd string, args []string, extraEnv []string) (int, bool, 
 		return 0, true, err
 	}
 	return 0, true, nil
+}
+
+// globalHostCLIWantsHost is the routing decision on its own: whether script is
+// a globally installed binary the store says cannot work inside the container.
+// Separated from the run so it can be exercised without fetching a PHP and
+// executing it, which says nothing about the decision it would be testing.
+func globalHostCLIWantsHost(cwd, script string) bool {
+	composerHome, ok := globalHostCLIHome(script)
+	if !ok {
+		return false
+	}
+	// Under the native runtime PHP already runs on the host, so there is no
+	// boundary to escape and the native path is the one that knows which
+	// extensions and ini this machine's PHP was set up with.
+	if _, native := nativeRuntimeVersion(cwd); native {
+		return false
+	}
+	// Asked of the home the binary actually came from, so the manifest read is
+	// the one that installed it.
+	return config.GlobalHostBinary(composerHome, filepath.Base(script))
+}
+
+// globalHostCLIHome returns the composer home script was installed under.
+// Matched against every home composer may be using, not only the one lerd would
+// pick: a tool installed under the other one is still a global tool, and
+// looking in one place silently left it in the container.
+func globalHostCLIHome(script string) (string, bool) {
+	for _, dir := range composerHomeDirs() {
+		if filepath.Dir(script) == filepath.Join(dir, "vendor", "bin") {
+			return dir, true
+		}
+	}
+	return "", false
 }

--- a/internal/cli/global_host_cli_homes_test.go
+++ b/internal/cli/global_host_cli_homes_test.go
@@ -52,7 +52,7 @@ func TestRunGlobalHostCLI_findsABinaryInTheLegacyComposerHome(t *testing.T) {
 	seedGlobalPackage(t, legacy, "cloud")
 
 	bin := filepath.Join(legacy, "vendor", "bin", "cloud")
-	if _, took, _ := runGlobalHostCLI(t.TempDir(), []string{bin, "login"}, nil); !took {
+	if !globalHostCLIWantsHost(t.TempDir(), bin) {
 		t.Error("a global binary under ~/.composer must still be taken out of the container")
 	}
 }
@@ -69,7 +69,7 @@ func TestRunGlobalHostCLI_findsABinaryInTheXDGComposerHome(t *testing.T) {
 	seedGlobalPackage(t, xdg, "cloud")
 
 	bin := filepath.Join(xdg, "vendor", "bin", "cloud")
-	if _, took, _ := runGlobalHostCLI(t.TempDir(), []string{bin, "login"}, nil); !took {
+	if !globalHostCLIWantsHost(t.TempDir(), bin) {
 		t.Error("a global binary under the XDG home must be taken out of the container")
 	}
 }
@@ -85,10 +85,10 @@ func TestRunGlobalHostCLI_honoursComposerHomeExactly(t *testing.T) {
 
 	// The same name under a home COMPOSER_HOME did not name is not it.
 	other := filepath.Join(home, ".composer", "vendor", "bin", "cloud")
-	if _, took, _ := runGlobalHostCLI(t.TempDir(), []string{other, "login"}, nil); took {
+	if globalHostCLIWantsHost(t.TempDir(), other) {
 		t.Error("COMPOSER_HOME is explicit; another home must not be consulted")
 	}
-	if _, took, _ := runGlobalHostCLI(t.TempDir(), []string{filepath.Join(explicit, "vendor", "bin", "cloud")}, nil); !took {
+	if !globalHostCLIWantsHost(t.TempDir(), filepath.Join(explicit, "vendor", "bin", "cloud")) {
 		t.Error("the binary under COMPOSER_HOME must be taken")
 	}
 }


### PR DESCRIPTION
Taking the positive path through runGlobalHostCLI does not stop at the decision. It resolves a host PHP, downloads one when the machine has none, and executes it, so the three tests covering which composer home a global binary is found in each fetched 12.3 MiB and then ran it against a script that was never meant to be run. They asserted only that the call was taken, which is true whether the download works or not.

The decision moves into globalHostCLIWantsHost, with the home match itself in globalHostCLIHome, and the tests ask that instead. runGlobalHostCLI keeps its behaviour and its doc comment, and the tests that cover it declining a call still go through the whole function, since that path starts and finishes nothing.

Closes #1731
