### PR TITLE
Fix the five findings from the pre-release VM run

### DIFF
--- a/docs/features/frankenphp.md
+++ b/docs/features/frankenphp.md
@@ -52,7 +52,7 @@ Each framework can declare how to launch FrankenPHP via a `frankenphp:` block in
 **Laravel** has two modes:
 
 - **Non-worker (`runtime_worker: false`, default)**: lerd runs `frankenphp php-server -r public/`. Each request boots Laravel from scratch; code edits take effect on the next request, same as FPM. You still get FrankenPHP's HTTP/2, HTTP/3, and TLS, but not Octane's per-request speedup.
-- **Worker (`runtime_worker: true`)**: lerd runs `php artisan octane:start --server=frankenphp --host=0.0.0.0 --port=8000 --workers=auto`. Octane keeps Laravel resident; requests skip the full bootstrap. Octane registers Symfony Console signal handlers which need the `pcntl` PHP extension; it is baked into lerd's derived FrankenPHP image (see the Extensions section) so the container boots straight into Octane.
+- **Worker (`runtime_worker: true`)**: lerd runs `php artisan octane:start --server=frankenphp --host=0.0.0.0 --port=8000 --workers=auto`. Octane keeps Laravel resident; requests skip the full bootstrap. Octane registers Symfony Console signal handlers which need the `pcntl` PHP extension; it is baked into lerd's derived FrankenPHP image (see the Extensions section) so the container boots straight into Octane. Worker mode therefore needs `laravel/octane` in the project: lerd refuses the switch when the package is not installed, rather than starting a container that exits on its first command.
 
 **Symfony** uses FrankenPHP's native worker flag:
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -156,7 +156,7 @@ Supported PHP versions: **8.5**, **8.4**, **8.3**, **8.2**, **8.1**, the prerele
 | Command | Description |
 |---|---|
 | `lerd use <version>` | Set the global PHP version and build the FPM image if needed |
-| `lerd isolate <version>` | Pin PHP version for cwd: writes `.php-version` and updates `.lerd.yaml` if present, then re-links |
+| `lerd isolate <version>` | Pin PHP version for cwd: writes `.php-version` and updates `.lerd.yaml` if present, then re-links. A version with no image on the machine is built first |
 | `lerd php:list` | List all installed PHP-FPM versions |
 | `lerd php:rebuild [version] [--local]` | Force-rebuild PHP-FPM images, or install a version this machine does not have (pulls pre-built base by default; `--local` builds from source) |
 | `lerd fetch [version...] [--local]` | Pull pre-built PHP FPM base images from ghcr.io for the given versions, or every released one when none are named; `--local` builds from source instead |
@@ -260,7 +260,7 @@ Switch the PHP runtime for the current site between shared PHP-FPM and per-site 
 | `lerd db:shell` | Open an interactive MySQL or PostgreSQL shell |
 | `lerd db:snapshot [name] [-A]` | Create a named, restorable snapshot of a database |
 | `lerd db:snapshots [--all]` | List stored database snapshots |
-| `lerd db:restore <name> [-A] [-f]` | Restore a database from a stored snapshot |
+| `lerd db:restore <name> [-A] [-f]` | Restore a database from a stored snapshot. Snapshots are stored with a timestamp appended, so the name you gave `db:snapshot` resolves to the most recent snapshot carrying it |
 | `lerd db:snapshot:rm <name> [-A]` | Delete a stored database snapshot |
 | `lerd db:snapshot:keep <name> [--off]` | Keep an automatic snapshot for good, exempt from retention |
 | `lerd db:snapshot:auto status\|on\|off\|site` | Configure scheduled database snapshots, globally or per site |

--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -5,7 +5,7 @@
 | Command | Description |
 |---|---|
 | `lerd use <version>` | Set the global PHP version and build the FPM image if needed |
-| `lerd isolate <version>` | Pin PHP version for cwd: writes `.php-version` and updates `.lerd.yaml` if it exists, then re-links. Refuses a version the framework or the project's `composer.json` rules out; `--force` pins it anyway |
+| `lerd isolate <version>` | Pin PHP version for cwd: writes `.php-version` and updates `.lerd.yaml` if it exists, then re-links. Builds the version's image first when the machine does not have it yet, so the site is never pointed at a runtime that cannot start. Refuses a version the framework or the project's `composer.json` rules out; `--force` pins it anyway |
 | `lerd php:list` | List all installed PHP-FPM versions |
 | `lerd php:rebuild [version] [--local]` | Force-rebuild PHP-FPM images, or add a version this machine does not have yet; `--local` builds from source instead of pulling a base |
 | `lerd php:update [version]` | Update PHP to the newest published patch. On the native runtime this downloads the new build and restarts the pools; on the container runtime it rebuilds the images from the newest base |

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -54,6 +55,12 @@ func runInit(fresh bool) error {
 	feedback.Begin()
 
 	if initShouldRunWizard(hasExisting, fresh) {
+		// The wizard is a full-screen form and cannot open one without a
+		// terminal. Entering it anyway surfaced the form library's own
+		// "error opening TTY", which names nothing the user can act on.
+		if !initInteractiveFn() {
+			return errors.New("lerd init runs a wizard and needs a terminal\n       run 'lerd link' to register this project without one, or write .lerd.yaml yourself")
+		}
 		existing, err := config.LoadProjectConfig(cwd)
 		if err != nil {
 			return err
@@ -97,6 +104,9 @@ func runInit(fresh bool) error {
 func initShouldRunWizard(hasExisting, fresh bool) bool {
 	return !hasExisting || fresh
 }
+
+// initInteractiveFn is a seam so the no-terminal refusal can be tested.
+var initInteractiveFn = isInteractive
 
 // nodeVersionDefault prefills the Node field the way the PHP one above it is
 // prefilled: a version already saved in .lerd.yaml wins, otherwise the version

--- a/internal/cli/init_no_terminal_test.go
+++ b/internal/cli/init_no_terminal_test.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// The wizard is a full-screen form, so a shell with no terminal cannot host it.
+// It used to be entered anyway and died on the library's own message,
+// "huh: bubbletea: error opening TTY", which says nothing about what to do.
+func TestInitWithoutTerminalRefusesWithGuidance(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	orig := initInteractiveFn
+	t.Cleanup(func() { initInteractiveFn = orig })
+	initInteractiveFn = func() bool { return false }
+
+	err := runInit(false)
+	if err == nil {
+		t.Fatal("expected lerd init to refuse without a terminal")
+	}
+	if strings.Contains(err.Error(), "bubbletea") || strings.Contains(err.Error(), "TTY") {
+		t.Errorf("the library's own error leaked to the user: %v", err)
+	}
+	if !strings.Contains(err.Error(), "lerd link") {
+		t.Errorf("error should point at the non-interactive way in, got: %v", err)
+	}
+}

--- a/internal/cli/isolate.go
+++ b/internal/cli/isolate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/feedback"
 	phpDet "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/siteops"
 	"github.com/spf13/cobra"
 )
@@ -26,6 +27,23 @@ func NewIsolateCmd() *cobra.Command {
 }
 
 var isolateForce bool
+
+// Seams so the provisioning decision can be tested without a podman build.
+var (
+	isolateImageExistsFn = podman.FPMImageExists
+	isolateProvisionFn   = func(version string) { ensureFPMQuadlets([]string{version}) }
+)
+
+// ensureIsolateImage builds the target version's image before the site is
+// repointed at it. The switch rewrites the vhost and reloads nginx, so a
+// version with no image left the site 502ing behind a command that had reported
+// success and only suggested php:rebuild afterwards.
+func ensureIsolateImage(version string) {
+	if isolateImageExistsFn(version) {
+		return
+	}
+	isolateProvisionFn(version)
+}
 
 // pinRefusal turns a refused pin into the command's own answer, naming the flag
 // that overrides it. Nothing was written, so the user is being told what to do
@@ -51,6 +69,7 @@ func runIsolate(_ *cobra.Command, args []string) error {
 	// Worktree path: the override travels with the branch, so the parent site's
 	// own version is left alone.
 	if site, branch, ok := FindParentSiteForWorktree(cwd); ok {
+		ensureIsolateImage(version)
 		res, err := siteops.SetSitePHPVersion(site, version, siteops.PHPVersionOpts{Branch: branch, Force: isolateForce})
 		if err != nil {
 			return pinRefusal(err, args[0])
@@ -77,6 +96,7 @@ func runIsolate(_ *cobra.Command, args []string) error {
 		return nil
 	}
 
+	ensureIsolateImage(version)
 	res, err := siteops.SetSitePHPVersion(site, version, siteops.PHPVersionOpts{Force: isolateForce})
 	if err != nil {
 		return pinRefusal(err, args[0])

--- a/internal/cli/isolate_provision_test.go
+++ b/internal/cli/isolate_provision_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import "testing"
+
+// Pinning a site to a version with no image used to repoint the vhost at a
+// backend that could not start: the FPM unit failed on
+// `short-name "lerd-php83-fpm:local" did not resolve` and the site served 502
+// until the image was built by hand. The image is built before the switch now.
+func TestIsolateBuildsAMissingImageFirst(t *testing.T) {
+	origExists, origProvision := isolateImageExistsFn, isolateProvisionFn
+	t.Cleanup(func() { isolateImageExistsFn, isolateProvisionFn = origExists, origProvision })
+
+	built := ""
+	isolateImageExistsFn = func(string) bool { return false }
+	isolateProvisionFn = func(v string) { built = v }
+
+	ensureIsolateImage("8.3")
+
+	if built != "8.3" {
+		t.Fatalf("missing image was not built, got %q", built)
+	}
+}
+
+// A version already built is switched to without touching the network.
+func TestIsolateSkipsBuildWhenImageExists(t *testing.T) {
+	origExists, origProvision := isolateImageExistsFn, isolateProvisionFn
+	t.Cleanup(func() { isolateImageExistsFn, isolateProvisionFn = origExists, origProvision })
+
+	called := false
+	isolateImageExistsFn = func(string) bool { return true }
+	isolateProvisionFn = func(string) { called = true }
+
+	ensureIsolateImage("8.5")
+
+	if called {
+		t.Fatal("an existing image should not be rebuilt")
+	}
+}

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -11,6 +11,7 @@ import (
 	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/linker"
 	"github.com/geodro/lerd/internal/serviceops"
+	"github.com/geodro/lerd/internal/siteops"
 	"github.com/geodro/lerd/internal/store"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -215,7 +216,7 @@ func runLink(args []string) error {
 	printLinkSummary(site, start, res.WroteIDEDataSource)
 
 	if plan.Mode != linker.ModeFPM {
-		return linkApplyServices(cwd, site, proj)
+		return linkApplyProject(cwd, site, proj)
 	}
 
 	// Warn before the setup prompt below: an ext-* requirement the image cannot
@@ -247,7 +248,7 @@ func runLink(args []string) error {
 		}
 	}
 
-	return linkApplyServices(cwd, site, proj)
+	return linkApplyProject(cwd, site, proj)
 }
 
 // printLinkSummary prints the green success line and an aligned details block,
@@ -411,6 +412,29 @@ func approveInlineService(svc *config.CustomService) bool {
 // linkEnsureSiteState is the seam the link tests swap for the real per-site
 // provisioning, which needs a running service behind it.
 var linkEnsureSiteState = serviceops.EnsureSiteState
+
+// linkShouldRestoreHTTPS reports whether a link has to put the site back on
+// HTTPS. The project file records how the site is served, so a link that
+// ignores it re-registers a secured project as plain HTTP, which is what an
+// uninstall followed by a fresh install did to every site on the machine.
+// External DNS has no certificate to issue, so there the record is left alone.
+func linkShouldRestoreHTTPS(projSecured, siteSecured, dnsManaged bool) bool {
+	return projSecured && !siteSecured && dnsManaged
+}
+
+// linkApplyProject applies what the project's .lerd.yaml declares about itself
+// once the site is registered: how it is served, then the services it needs.
+func linkApplyProject(cwd string, site config.Site, proj *config.ProjectConfig) error {
+	if proj != nil {
+		gcfg, _ := config.LoadGlobal()
+		if linkShouldRestoreHTTPS(proj.Secured, site.Secured, gcfg != nil && gcfg.DNSManaged()) {
+			if err := siteops.SetSecured(&site, true); err != nil {
+				feedback.Warn("restoring HTTPS for %s: %v", site.Name, err)
+			}
+		}
+	}
+	return linkApplyServices(cwd, site, proj)
+}
 
 func linkApplyServices(cwd string, site config.Site, proj *config.ProjectConfig) error {
 	if proj == nil {

--- a/internal/cli/link_secured_test.go
+++ b/internal/cli/link_secured_test.go
@@ -1,0 +1,27 @@
+package cli
+
+import "testing"
+
+// A project that records secured: true is describing how it is served, so a
+// link has to put the site back on HTTPS. Without this a reinstall re-registered
+// every site as plain HTTP and https refused outright until `lerd secure` was
+// run by hand, which is the one thing the .lerd.yaml was there to prevent.
+func TestLinkShouldRestoreHTTPS(t *testing.T) {
+	cases := []struct {
+		name                                 string
+		projSecured, siteSecured, dnsManaged bool
+		want                                 bool
+	}{
+		{"project says secured and the site is not", true, false, true, true},
+		{"site already secured", true, true, true, false},
+		{"project says nothing", false, false, true, false},
+		{"external DNS has no certificates to issue", true, false, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := linkShouldRestoreHTTPS(tc.projSecured, tc.siteSecured, tc.dnsManaged); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -209,7 +209,24 @@ func switchToFPM(site *config.Site) error {
 	return nil
 }
 
+// requireOctaneForWorkerMode refuses worker mode on a project that cannot run
+// it. FrankenPHP worker mode serves the site through artisan octane, so without
+// laravel/octane the container exits on its first command and systemd retries
+// it until it gives up, leaving the site at 502 behind a switch that reported
+// success.
+func requireOctaneForWorkerMode(sitePath string) error {
+	if config.ComposerHasInstalled(sitePath, "laravel/octane") {
+		return nil
+	}
+	return fmt.Errorf("FrankenPHP worker mode runs the site through Octane, and laravel/octane is not installed in this project\nInstall it with: composer require laravel/octane\nOr switch without it: lerd runtime frankenphp")
+}
+
 func switchToFrankenPHP(site *config.Site, worker bool) error {
+	if worker {
+		if err := requireOctaneForWorkerMode(site.Path); err != nil {
+			return err
+		}
+	}
 	// Workers currently exec into the shared FPM container; stop them so they
 	// can be recreated against the per-site FrankenPHP container below.
 	running := collectRunningWorkers(site)

--- a/internal/cli/runtime_worker_octane_test.go
+++ b/internal/cli/runtime_worker_octane_test.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// FrankenPHP worker mode runs the site through artisan octane, so a project
+// without laravel/octane has nothing to run. Before this the switch reported
+// success and the container crash-looped on "no commands defined in the octane
+// namespace" with the site stuck at 502.
+func TestWorkerModeRefusedWithoutOctane(t *testing.T) {
+	dir := t.TempDir()
+	writeComposer(t, dir, `{"require":{"laravel/framework":"^13.0"}}`)
+
+	err := requireOctaneForWorkerMode(dir)
+	if err == nil {
+		t.Fatal("expected worker mode to be refused without laravel/octane")
+	}
+	if !strings.Contains(err.Error(), "laravel/octane") {
+		t.Errorf("error should name the missing package, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "composer require") {
+		t.Errorf("error should say how to install it, got: %v", err)
+	}
+}
+
+func TestWorkerModeAllowedWithOctane(t *testing.T) {
+	dir := t.TempDir()
+	writeComposer(t, dir, `{"require":{"laravel/framework":"^13.0","laravel/octane":"^2.0"}}`)
+
+	if err := requireOctaneForWorkerMode(dir); err != nil {
+		t.Fatalf("worker mode should be allowed with octane installed: %v", err)
+	}
+}
+
+// The check reads what composer actually installed, so a package pulled in
+// underneath another one still counts.
+func TestWorkerModeAllowedWhenOctaneOnlyInLock(t *testing.T) {
+	dir := t.TempDir()
+	writeComposer(t, dir, `{"require":{"laravel/framework":"^13.0"}}`)
+	if err := os.WriteFile(filepath.Join(dir, "composer.lock"),
+		[]byte(`{"packages":[{"name":"laravel/octane","version":"2.0.0"}],"packages-dev":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := requireOctaneForWorkerMode(dir); err != nil {
+		t.Fatalf("worker mode should be allowed when the lock carries octane: %v", err)
+	}
+}
+
+func writeComposer(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "composer.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/serviceops/snapshot.go
+++ b/internal/serviceops/snapshot.go
@@ -253,6 +253,41 @@ func ListSnapshots(service, database string, includeAll bool) ([]Snapshot, error
 	return out, nil
 }
 
+// resolveSnapshotName turns the name a user typed into the directory a snapshot
+// actually lives in. CreateSnapshot stamps every name with a UTC timestamp, so
+// the label someone chose is never the name on disk, and looking it up
+// literally is why restoring the snapshot just taken reported it missing. An
+// exact directory still wins; otherwise the newest snapshot carrying the label
+// answers, which is what repeating a label is for.
+func resolveSnapshotName(service, database, name string, allDatabases bool) (string, error) {
+	clean, err := sanitizeSnapshotName(name)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(snapshotDir(service, database, clean, allDatabases)); err == nil {
+		return clean, nil
+	}
+	entries, err := os.ReadDir(snapshotScopeDir(service, database, allDatabases))
+	if err != nil {
+		return "", fmt.Errorf("snapshot %q not found", name)
+	}
+	best := ""
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), clean+"-") {
+			continue
+		}
+		// The stamp sorts lexically in time order, so the greatest name is the
+		// most recent without reading every snapshot's metadata back.
+		if e.Name() > best {
+			best = e.Name()
+		}
+	}
+	if best == "" {
+		return "", fmt.Errorf("snapshot %q not found", name)
+	}
+	return best, nil
+}
+
 // DeleteSnapshot removes a stored snapshot, erroring when it does not exist so
 // callers can report the miss clearly.
 func DeleteSnapshot(service, database, name string, allDatabases bool) error {
@@ -261,18 +296,11 @@ func DeleteSnapshot(service, database, name string, allDatabases bool) error {
 			return err
 		}
 	}
-	clean, err := sanitizeSnapshotName(name)
+	clean, err := resolveSnapshotName(service, database, name, allDatabases)
 	if err != nil {
 		return err
 	}
-	dir := snapshotDir(service, database, clean, allDatabases)
-	if _, err := os.Stat(dir); err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("snapshot %q not found", name)
-		}
-		return err
-	}
-	return os.RemoveAll(dir)
+	return os.RemoveAll(snapshotDir(service, database, clean, allDatabases))
 }
 
 // CreateSnapshot dumps the target database (or every database when
@@ -412,7 +440,7 @@ func RestoreSnapshot(t SnapshotTarget, name string, emit func(PhaseEvent)) (Impo
 	if err != nil {
 		return ImportReport{}, err
 	}
-	clean, err := sanitizeSnapshotName(name)
+	clean, err := resolveSnapshotName(t.Service, t.Database, name, t.AllDatabases)
 	if err != nil {
 		return ImportReport{}, err
 	}

--- a/internal/serviceops/snapshot_resolve_test.go
+++ b/internal/serviceops/snapshot_resolve_test.go
@@ -1,0 +1,81 @@
+package serviceops
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// A snapshot created as "before-change" is stored as "before-change-<stamp>",
+// so looking it up under the name the user typed has to find it. Without this
+// the documented round trip (snapshot, change, restore) never resolves.
+func TestResolveSnapshotNameFindsStampedName(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	seedSnapshot(t, Snapshot{Name: "before-change-20260101-101010", Created: time.Now().UTC().Add(-time.Hour), Service: "mysql", Family: "mysql", Database: "demo"})
+
+	got, err := resolveSnapshotName("mysql", "demo", "before-change", false)
+	if err != nil {
+		t.Fatalf("resolveSnapshotName: %v", err)
+	}
+	if got != "before-change-20260101-101010" {
+		t.Fatalf("got %q, want the stamped name", got)
+	}
+}
+
+// Repeated snapshots of one label are supported, so the label resolves to the
+// most recent of them rather than an arbitrary one.
+func TestResolveSnapshotNamePicksNewest(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	seedSnapshot(t, Snapshot{Name: "nightly-20260101-010101", Created: time.Now().UTC().Add(-48 * time.Hour), Service: "mysql", Family: "mysql", Database: "demo"})
+	seedSnapshot(t, Snapshot{Name: "nightly-20260103-030303", Created: time.Now().UTC(), Service: "mysql", Family: "mysql", Database: "demo"})
+
+	got, err := resolveSnapshotName("mysql", "demo", "nightly", false)
+	if err != nil {
+		t.Fatalf("resolveSnapshotName: %v", err)
+	}
+	if got != "nightly-20260103-030303" {
+		t.Fatalf("got %q, want the newest stamped name", got)
+	}
+}
+
+// An exact directory name still wins, so nothing that already worked changes.
+func TestResolveSnapshotNamePrefersExactMatch(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	seedSnapshot(t, Snapshot{Name: "keep", Created: time.Now().UTC(), Service: "mysql", Family: "mysql", Database: "demo"})
+	seedSnapshot(t, Snapshot{Name: "keep-20260105-050505", Created: time.Now().UTC(), Service: "mysql", Family: "mysql", Database: "demo"})
+
+	got, err := resolveSnapshotName("mysql", "demo", "keep", false)
+	if err != nil {
+		t.Fatalf("resolveSnapshotName: %v", err)
+	}
+	if got != "keep" {
+		t.Fatalf("got %q, want the exact name", got)
+	}
+}
+
+// A label matching nothing is still an error, and names what was asked for.
+func TestResolveSnapshotNameMissing(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	if _, err := resolveSnapshotName("mysql", "demo", "absent", false); err == nil {
+		t.Fatal("expected an error for a name with no snapshot behind it")
+	}
+}
+
+// The stamped lookup reaches DeleteSnapshot too, so removing a snapshot by the
+// name it was created under works.
+func TestDeleteSnapshotByCreatedName(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	seedSnapshot(t, Snapshot{Name: "drop-me-20260101-101010", Created: time.Now().UTC(), Service: "mysql", Family: "mysql", Database: "demo"})
+
+	if err := DeleteSnapshot("mysql", "demo", "drop-me", false); err != nil {
+		t.Fatalf("DeleteSnapshot: %v", err)
+	}
+	if _, err := os.Stat(snapshotDir("mysql", "demo", "drop-me-20260101-101010", false)); !os.IsNotExist(err) {
+		t.Error("snapshot dir still present after delete")
+	}
+}


### PR DESCRIPTION
Running tests/release-test-plan.md across the guest matrix against the current main turned up five things worth fixing before the beta goes out. Four of them leave a site at 502 or on the wrong scheme behind a command that reported success, which is the failure mode the plan's 200 rule exists to catch, and the fifth is a crash where a refusal belonged.

Pinning a site to a PHP version the machine had never built repointed it at a runtime that could not start, and only afterwards suggested running php:rebuild. The image is built first now, through the same disclosed build the install path uses.

FrankenPHP worker mode was accepted on a project without laravel/octane, and the per-site container then exited on its first line and restart-looped while the site sat at 502. It refuses now, reading what composer installed rather than what the manifest names.

A project's .lerd.yaml records whether the site is served over HTTPS and link never read it, so an uninstall followed by a fresh install brought every site back as plain HTTP. The file that survives a registry wipe is now the one that decides.

Creating a snapshot stamps its name with a timestamp, so restoring by the name you gave it never resolved. A label resolves to the most recent snapshot carrying it, with an exact name still winning.

And lerd init entered its wizard without a terminal and died on the form library's message about opening the TTY, where a refusal naming lerd link belonged.

Closes #1733
Closes #1734
Closes #1735
Closes #1736
Closes #1737