### PR TITLE
Open a worker's logs from its toggle

### DIFF
--- a/docs/features/web-ui.md
+++ b/docs/features/web-ui.md
@@ -119,6 +119,7 @@ Selecting a site opens the detail panel with:
 - **Reverb toggle**: start or stop the Reverb WebSocket server; only shown when the project uses Reverb (detected via composer or `.env`)
 - **Framework worker toggles**: additional workers defined by the site's framework (e.g. Symfony `messenger`, Laravel `horizon`) appear as indigo toggles
 - **Stripe toggle**: start or stop the Stripe webhook listener
+- **Worker logs shortcut**: every worker toggle carries a small log-lines button on its right that opens the Logs tab with that worker's journal already selected, the same segment the queue's options gear sits in. The selected source lives in the address (`#sites/<domain>/logs/<worker>`), so a worker's logs can be linked and bookmarked directly
 - **Pause / Resume**: suspend a site's nginx vhost without unlinking it; the site stays registered and FPM keeps running. When a paused site is selected, the detail pane hides the overview/logs/tinker/dumps tabs and shows a centered Resume placeholder so it's obvious the site is offline on purpose rather than broken
 
   ![Paused site detail with the Resume placeholder](/assets/screenshots/site-detail-paused.png)

--- a/docs/usage/framework-workers.md
+++ b/docs/usage/framework-workers.md
@@ -241,6 +241,8 @@ journalctl --user -u lerd-messenger-myapp -f
 
 In the dashboard, a worker keeps its Logs tab whatever state it is in, drawn muted while it is stopped. The journal outlives the unit, so the tab is still the place to read why a worker died after it has gone down, or after the health banner stopped it.
 
+Each worker's toggle carries a shortcut straight to that journal: the log-lines button on the right of the toggle opens the Logs tab with the worker's source already selected, without hunting through the tab strip.
+
 ## Managing custom workers
 
 Use `lerd worker add` to add project-specific or global custom workers without manually editing YAML:

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -919,6 +919,7 @@
   "sites_controls_vite": "Vite",
   "sites_controls_viteToggle_off": "Vite-Dev-Server starten",
   "sites_controls_viteToggle_on": "Vite-Dev-Server stoppen",
+  "sites_controls_workerLogs": "{label}-Logs",
   "sites_controls_workerOptions": "Worker-Optionen",
   "sites_controls_workerOptionsFailed": "Worker-Optionen konnten nicht gespeichert werden: {error}",
   "sites_controls_workerOptionsHint": "Wird in .lerd.yaml gespeichert, damit das ganze Projekt denselben Worker startet. Ein leeres Feld nutzt den Framework-Standard.",

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -919,6 +919,7 @@
   "sites_controls_vite": "Vite",
   "sites_controls_viteToggle_off": "Start Vite dev server",
   "sites_controls_viteToggle_on": "Stop Vite dev server",
+  "sites_controls_workerLogs": "{label} logs",
   "sites_controls_workerOptions": "Worker options",
   "sites_controls_workerOptionsFailed": "Could not save the worker options: {error}",
   "sites_controls_workerOptionsHint": "Saved to .lerd.yaml, so the whole project runs the same worker. Leave a field empty to use the framework default.",

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -919,6 +919,7 @@
   "sites_controls_vite": "Vite",
   "sites_controls_viteToggle_off": "Iniciar servidor Vite",
   "sites_controls_viteToggle_on": "Detener servidor Vite",
+  "sites_controls_workerLogs": "Registros de {label}",
   "sites_controls_workerOptions": "Opciones del worker",
   "sites_controls_workerOptionsFailed": "No se pudieron guardar las opciones del worker: {error}",
   "sites_controls_workerOptionsHint": "Se guarda en .lerd.yaml, así todo el proyecto ejecuta el mismo worker. Deja el campo vacío para usar el valor por defecto del framework.",

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -919,6 +919,7 @@
   "sites_controls_vite": "Vite",
   "sites_controls_viteToggle_off": "Démarrer le serveur Vite",
   "sites_controls_viteToggle_on": "Arrêter le serveur Vite",
+  "sites_controls_workerLogs": "Journaux de {label}",
   "sites_controls_workerOptions": "Options du worker",
   "sites_controls_workerOptionsFailed": "Impossible d'enregistrer les options du worker : {error}",
   "sites_controls_workerOptionsHint": "Enregistré dans .lerd.yaml, pour que tout le projet lance le même worker. Laissez un champ vide pour la valeur par défaut du framework.",

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -919,6 +919,7 @@
   "sites_controls_vite": "Vite",
   "sites_controls_viteToggle_off": "Mulai server Vite",
   "sites_controls_viteToggle_on": "Hentikan server Vite",
+  "sites_controls_workerLogs": "Log {label}",
   "sites_controls_workerOptions": "Opsi worker",
   "sites_controls_workerOptionsFailed": "Gagal menyimpan opsi worker: {error}",
   "sites_controls_workerOptionsHint": "Disimpan di .lerd.yaml, jadi seluruh proyek menjalankan worker yang sama. Kosongkan untuk memakai bawaan framework.",

--- a/internal/ui/web/messages/it.json
+++ b/internal/ui/web/messages/it.json
@@ -919,6 +919,7 @@
   "sites_controls_vite": "Vite",
   "sites_controls_viteToggle_off": "Avvia il dev server di Vite",
   "sites_controls_viteToggle_on": "Ferma il dev server di Vite",
+  "sites_controls_workerLogs": "Log di {label}",
   "sites_controls_workerOptions": "Opzioni del worker",
   "sites_controls_workerOptionsFailed": "Impossibile salvare le opzioni del worker: {error}",
   "sites_controls_workerOptionsHint": "Salvato in .lerd.yaml, così tutto il progetto avvia lo stesso worker. Lascia il campo vuoto per usare il valore predefinito del framework.",

--- a/internal/ui/web/messages/ja.json
+++ b/internal/ui/web/messages/ja.json
@@ -919,6 +919,7 @@
   "sites_controls_vite": "Vite",
   "sites_controls_viteToggle_off": "Vite 開発サーバーを開始",
   "sites_controls_viteToggle_on": "Vite 開発サーバーを停止",
+  "sites_controls_workerLogs": "{label} のログ",
   "sites_controls_workerOptions": "ワーカーのオプション",
   "sites_controls_workerOptionsFailed": "ワーカーのオプションを保存できませんでした: {error}",
   "sites_controls_workerOptionsHint": ".lerd.yaml に保存され、プロジェクト全体が同じワーカーを起動します。空欄にするとフレームワークの既定値を使います。",

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -919,6 +919,7 @@
   "sites_controls_vite": "Vite",
   "sites_controls_viteToggle_off": "Vite-dev-server starten",
   "sites_controls_viteToggle_on": "Vite-dev-server stoppen",
+  "sites_controls_workerLogs": "{label}-logs",
   "sites_controls_workerOptions": "Workeropties",
   "sites_controls_workerOptionsFailed": "Kon de workeropties niet opslaan: {error}",
   "sites_controls_workerOptionsHint": "Wordt opgeslagen in .lerd.yaml, zodat het hele project dezelfde worker draait. Laat een veld leeg voor de standaard van het framework.",

--- a/internal/ui/web/messages/pl.json
+++ b/internal/ui/web/messages/pl.json
@@ -919,6 +919,7 @@
   "sites_controls_vite": "Vite",
   "sites_controls_viteToggle_off": "Uruchom serwer dev Vite",
   "sites_controls_viteToggle_on": "Zatrzymaj serwer dev Vite",
+  "sites_controls_workerLogs": "Logi {label}",
   "sites_controls_workerOptions": "Opcje workera",
   "sites_controls_workerOptionsFailed": "Nie udało się zapisać opcji workera: {error}",
   "sites_controls_workerOptionsHint": "Zapisywane w .lerd.yaml, więc cały projekt uruchamia tego samego workera. Puste pole oznacza wartość domyślną frameworka.",

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -919,6 +919,7 @@
   "sites_controls_vite": "Vite",
   "sites_controls_viteToggle_off": "Iniciar servidor Vite",
   "sites_controls_viteToggle_on": "Parar servidor Vite",
+  "sites_controls_workerLogs": "Logs de {label}",
   "sites_controls_workerOptions": "Opções do worker",
   "sites_controls_workerOptionsFailed": "Não foi possível guardar as opções do worker: {error}",
   "sites_controls_workerOptionsHint": "Guardado em .lerd.yaml, para que todo o projeto execute o mesmo worker. Deixe o campo vazio para usar o valor por omissão do framework.",

--- a/internal/ui/web/messages/ro.json
+++ b/internal/ui/web/messages/ro.json
@@ -919,6 +919,7 @@
   "sites_controls_vite": "Vite",
   "sites_controls_viteToggle_off": "Pornește serverul de dezvoltare Vite",
   "sites_controls_viteToggle_on": "Oprește serverul de dezvoltare Vite",
+  "sites_controls_workerLogs": "Jurnale {label}",
   "sites_controls_workerOptions": "Opțiuni worker",
   "sites_controls_workerOptionsFailed": "Opțiunile workerului nu au putut fi salvate: {error}",
   "sites_controls_workerOptionsHint": "Se salvează în .lerd.yaml, ca tot proiectul să pornească același worker. Un câmp gol înseamnă valoarea implicită a framework-ului.",

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -919,6 +919,7 @@
   "sites_controls_vite": "Vite",
   "sites_controls_viteToggle_off": "Vite dev sunucusunu başlat",
   "sites_controls_viteToggle_on": "Vite dev sunucusunu durdur",
+  "sites_controls_workerLogs": "{label} logları",
   "sites_controls_workerOptions": "Worker seçenekleri",
   "sites_controls_workerOptionsFailed": "Worker seçenekleri kaydedilemedi: {error}",
   "sites_controls_workerOptionsHint": ".lerd.yaml dosyasına kaydedilir, böylece tüm proje aynı worker’ı çalıştırır. Boş bırakılan alan framework varsayılanını kullanır.",

--- a/internal/ui/web/messages/vi.json
+++ b/internal/ui/web/messages/vi.json
@@ -919,6 +919,7 @@
   "sites_controls_vite": "Vite",
   "sites_controls_viteToggle_off": "Khởi động Vite dev server",
   "sites_controls_viteToggle_on": "Dừng Vite dev server",
+  "sites_controls_workerLogs": "Nhật ký {label}",
   "sites_controls_workerOptions": "Tùy chọn worker",
   "sites_controls_workerOptionsFailed": "Không lưu được tùy chọn worker: {error}",
   "sites_controls_workerOptionsHint": "Được lưu vào .lerd.yaml để cả dự án chạy cùng một worker. Để trống thì dùng mặc định của framework.",

--- a/internal/ui/web/messages/zh.json
+++ b/internal/ui/web/messages/zh.json
@@ -919,6 +919,7 @@
   "sites_controls_vite": "Vite",
   "sites_controls_viteToggle_off": "启动 Vite 开发服务器",
   "sites_controls_viteToggle_on": "停止 Vite 开发服务器",
+  "sites_controls_workerLogs": "{label} 日志",
   "sites_controls_workerOptions": "工作进程选项",
   "sites_controls_workerOptionsFailed": "无法保存工作进程选项：{error}",
   "sites_controls_workerOptionsHint": "保存在 .lerd.yaml 中，整个项目都会运行同一条命令。留空则使用框架默认值。",

--- a/internal/ui/web/src/components/LogsButton.svelte
+++ b/internal/ui/web/src/components/LogsButton.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { m } from '../paraglide/messages.js';
+
+  // The logs half of a worker's segmented control: one click lands on that
+  // worker's journal instead of the Logs tab plus a hunt through its sources.
+  interface Props {
+    label: string;
+    rounding?: string;
+    onclick: () => void;
+  }
+  let { label, rounding = 'rounded-r-md', onclick }: Props = $props();
+
+  const title = $derived(m.sites_controls_workerLogs({ label }));
+</script>
+
+<button
+  type="button"
+  {title}
+  aria-label={title}
+  {onclick}
+  class="inline-flex items-center justify-center h-7 w-8 {rounding} border border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-card hover:bg-gray-50 dark:hover:bg-white/5 transition-colors text-gray-400 dark:text-gray-500"
+>
+  <svg
+    class="w-3.5 h-3.5"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <line x1="4" y1="6" x2="20" y2="6" />
+    <line x1="4" y1="10" x2="14" y2="10" />
+    <line x1="4" y1="14" x2="18" y2="14" />
+    <line x1="4" y1="18" x2="11" y2="18" />
+  </svg>
+</button>

--- a/internal/ui/web/src/tabs/sites/HorizonControl.svelte
+++ b/internal/ui/web/src/tabs/sites/HorizonControl.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import ToggleButton from '$components/ToggleButton.svelte';
+  import LogsButton from '$components/LogsButton.svelte';
   import { m } from '../../paraglide/messages.js';
 
   // Horizon on/off and its watch-files (horizon:listen) reload toggle, rendered
@@ -16,6 +17,7 @@
     reloadLoading?: boolean;
     onToggle: () => void;
     onToggleReload: () => void;
+    onLogs?: () => void;
   }
   let {
     running,
@@ -25,7 +27,8 @@
     horizonLoading = false,
     reloadLoading = false,
     onToggle,
-    onToggleReload
+    onToggleReload,
+    onLogs
   }: Props = $props();
 
   const showReload = $derived(running || reloadLoading);
@@ -62,7 +65,7 @@
     {asleep}
     loading={horizonLoading}
     disabled={horizonLoading}
-    rounding={showReload ? 'rounded-l-md border-r-0' : 'rounded-md'}
+    rounding={showReload || onLogs ? 'rounded-l-md border-r-0' : 'rounded-md'}
     title={failing
       ? m.sites_controls_horizonToggle_failing()
       : running
@@ -81,7 +84,9 @@
         ? m.sites_controls_horizonReloadToggle_on()
         : m.sites_controls_horizonReloadToggle_off()}
       onclick={clickReload}
-      class="inline-flex items-center justify-center h-7 w-8 rounded-r-md border border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-card hover:bg-gray-50 dark:hover:bg-white/5 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      class="inline-flex items-center justify-center h-7 w-8 {onLogs
+        ? 'border-r-0'
+        : 'rounded-r-md'} border border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-card hover:bg-gray-50 dark:hover:bg-white/5 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
     >
       <svg
         class="w-3.5 h-3.5 transition-colors {iconClass} {spinning ? 'animate-[spin_0.6s_ease-in-out]' : ''}"
@@ -98,5 +103,9 @@
         <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
       </svg>
     </button>
+  {/if}
+
+  {#if onLogs}
+    <LogsButton label={m.sites_controls_horizon()} onclick={onLogs} />
   {/if}
 </div>

--- a/internal/ui/web/src/tabs/sites/SiteControls.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteControls.svelte
@@ -14,8 +14,10 @@
     toggleWorker,
     saveWorkerOptions,
     setWorktreeDBIsolated,
+    siteHasLogSources,
     loadSites
   } from '$stores/sites';
+  import { goToTab } from '$stores/route';
   import { loadServices } from '$stores/services';
   import { phpVersions, phpOptionsForSite } from '$stores/phpVersions';
   import { nodeVersions } from '$stores/nodeVersions';
@@ -49,6 +51,14 @@
   // Workers idle-suspend has stopped: shown as "asleep" on their toggles rather
   // than a plain "off", so they don't look broken.
   const asleepWorkers = $derived(new Set(site.idle_suspended_workers || []));
+
+  // Every worker toggle carries a shortcut to its own journal, deep-linking the
+  // Logs tab at that source. Left off when the site has no Logs tab to land on.
+  const canReadLogs = $derived(siteHasLogSources(site));
+  function logsFor(source: string): (() => void) | undefined {
+    if (!canReadLogs) return undefined;
+    return () => goToTab('sites', `${site.domain}/logs/${source}`);
+  }
 
   const effectivePhp = $derived(activeWorktree?.php_version ?? site.php_version ?? '');
   const effectiveNode = $derived(activeWorktree?.node_version ?? site.node_version ?? '');
@@ -380,14 +390,15 @@
         </span>
       {:else}
         {#each wtWorkers as w (w.name)}
-          <ToggleButton
+          <WorkerControl
             label={w.label || w.name}
-            on={Boolean(w.running)}
+            running={Boolean(w.running)}
             failing={Boolean(w.failing)}
             unreachable={Boolean(w.unreachable)}
             loading={isPending('worker:' + w.name)}
             disabled={isPending('worker:' + w.name)}
-            onclick={() => transition('worker:' + w.name, !w.running, () => toggleWorker(site, w, activeWorktreeBranch))}
+            onToggle={() => transition('worker:' + w.name, !w.running, () => toggleWorker(site, w, activeWorktreeBranch))}
+            onLogs={logsFor('worker:' + w.name)}
             title={w.running ? m.sites_controls_workerToggle_on({ label: w.label || w.name }) : m.sites_controls_workerToggle_off({ label: w.label || w.name })}
           />
         {/each}
@@ -404,6 +415,7 @@
           options={site.worker_options?.queue || []}
           onToggle={() => transition('queue', !site.queue_running, () => toggleQueue(site))}
           onSaveOptions={(values) => saveOptions('queue', values)}
+          onLogs={logsFor('queue')}
           title={site.queue_failing ? m.sites_controls_queueToggle_failing() : site.queue_running ? m.sites_controls_queueToggle_on() : m.sites_controls_queueToggle_off()}
         />
       {/if}
@@ -418,31 +430,34 @@
           reloadLoading={reloadRestarting}
           onToggle={() => transition('horizon', !site.horizon_running, () => toggleHorizon(site))}
           onToggleReload={onToggleHorizonReload}
+          onLogs={logsFor('horizon')}
         />
       {/if}
 
       {#if site.has_schedule_worker}
-        <ToggleButton
+        <WorkerControl
           label={m.sites_controls_schedule()}
-          on={Boolean(site.schedule_running)}
+          running={Boolean(site.schedule_running)}
           asleep={asleepWorkers.has('schedule')}
           failing={Boolean(site.schedule_failing)}
           loading={isPending('schedule')}
           disabled={isPending('schedule')}
-          onclick={() => transition('schedule', !site.schedule_running, () => toggleSchedule(site))}
+          onToggle={() => transition('schedule', !site.schedule_running, () => toggleSchedule(site))}
+          onLogs={logsFor('schedule')}
           title={site.schedule_running ? m.sites_controls_scheduleToggle_on() : m.sites_controls_scheduleToggle_off()}
         />
       {/if}
 
       {#if site.has_reverb}
-        <ToggleButton
+        <WorkerControl
           label={m.sites_controls_reverb()}
-          on={Boolean(site.reverb_running)}
+          running={Boolean(site.reverb_running)}
           asleep={asleepWorkers.has('reverb')}
           failing={Boolean(site.reverb_failing)}
           loading={isPending('reverb')}
           disabled={isPending('reverb')}
-          onclick={() => transition('reverb', !site.reverb_running, () => toggleReverb(site))}
+          onToggle={() => transition('reverb', !site.reverb_running, () => toggleReverb(site))}
+          onLogs={logsFor('reverb')}
           title={site.reverb_running ? m.sites_controls_reverbToggle_on() : m.sites_controls_reverbToggle_off()}
         />
       {/if}
@@ -455,6 +470,7 @@
           webhookPath={site.stripe_webhook_path}
           onToggle={() => transition('stripe', !site.stripe_running, () => toggleStripe(site))}
           onSaveConfig={(path) => setStripeConfig(site, path)}
+          onLogs={logsFor('stripe')}
         />
       {/if}
 
@@ -472,6 +488,7 @@
           options={site.worker_options?.[w.name] || []}
           onToggle={() => transition('worker:' + w.name, !w.running, () => toggleWorker(site, w))}
           onSaveOptions={(values) => saveOptions(w.name, values)}
+          onLogs={logsFor('worker:' + w.name)}
           title={isVite
             ? w.running
               ? m.sites_controls_viteToggle_on()

--- a/internal/ui/web/src/tabs/sites/SiteLogs.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteLogs.svelte
@@ -3,6 +3,7 @@
   import DetailTabs, { type TabItem } from '$components/DetailTabs.svelte';
   import AppLogsTab from './AppLogsTab.svelte';
   import { type Site, fpmContainer } from '$stores/sites';
+  import { routeRest, goToTab } from '$stores/route';
   import { m } from '../../paraglide/messages.js';
 
   function fpmTabLabelI18n(site: Site): string {
@@ -72,6 +73,20 @@
 
   let active = $state<TabId>('app');
 
+  // A worker's toggle links straight at its journal (#sites/<domain>/logs/<id>),
+  // so the selected source lives in the hash and a tab click mirrors back into
+  // it. Without the mirror the link would go dead once the user picked another
+  // tab by hand: the hash would still name the old source and never change.
+  $effect(() => {
+    const source = $routeRest.split('/').slice(2).join('/');
+    if (source) active = source;
+  });
+
+  function selectSource(id: TabId) {
+    active = id;
+    goToTab('sites', `${site.domain}/logs/${id}`);
+  }
+
   // If the active tab isn't available, snap to the first one. Falling back to
   // '' (not 'fpm') matters for static sites with no tabs: defaulting to 'fpm'
   // would stream the shared FPM container's logs even though the tab is hidden.
@@ -117,7 +132,7 @@
 </script>
 
 <div class="flex-1 flex flex-col overflow-hidden min-h-0">
-  <DetailTabs {tabs} {active} onchange={(id) => (active = id)} />
+  <DetailTabs {tabs} {active} onchange={selectSource} />
   {#if active === 'app' && site.has_app_logs}
     {#key site.domain + '@' + activeWorktreeBranch}
       <AppLogsTab {site} branch={activeWorktreeBranch} />

--- a/internal/ui/web/src/tabs/sites/SiteLogs.test.ts
+++ b/internal/ui/web/src/tabs/sites/SiteLogs.test.ts
@@ -1,6 +1,7 @@
-import { render } from '@testing-library/svelte';
-import { describe, it, expect } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import { describe, it, expect, afterEach } from 'vitest';
 import SiteLogs from './SiteLogs.svelte';
+import { routeRest } from '$stores/route';
 import type { Site } from '$stores/sites';
 
 function site(over: Partial<Site> = {}): Site {
@@ -8,6 +9,8 @@ function site(over: Partial<Site> = {}): Site {
 }
 
 describe('SiteLogs tabs', () => {
+  afterEach(() => routeRest.set(''));
+
   it('keeps a stopped worker tab so its logs stay readable', () => {
     const { getByText } = render(SiteLogs, {
       props: {
@@ -39,5 +42,37 @@ describe('SiteLogs tabs', () => {
     const { queryByText } = render(SiteLogs, { props: { site: site() } });
     expect(queryByText('Queue')).toBeNull();
     expect(queryByText('Vite')).toBeNull();
+  });
+});
+
+describe('SiteLogs source deep link', () => {
+  afterEach(() => routeRest.set(''));
+
+  it('opens the source the route names, so a worker toggle can link at it', () => {
+    routeRest.set('app.test/logs/worker:vite');
+    const { getByText } = render(SiteLogs, {
+      props: {
+        site: site({
+          has_queue_worker: true,
+          framework_workers: [{ name: 'vite', label: 'Vite', running: true }]
+        })
+      }
+    });
+    expect(getByText('Vite').className).toContain('text-lerd-red');
+    expect(getByText('Queue').className).not.toContain('text-lerd-red');
+  });
+
+  it('mirrors a tab click into the hash so the link stays live', async () => {
+    routeRest.set('app.test/logs/worker:vite');
+    const { getByText } = render(SiteLogs, {
+      props: {
+        site: site({
+          has_queue_worker: true,
+          framework_workers: [{ name: 'vite', label: 'Vite', running: true }]
+        })
+      }
+    });
+    await fireEvent.click(getByText('Queue'));
+    expect(location.hash).toBe('#sites/app.test/logs/queue');
   });
 });

--- a/internal/ui/web/src/tabs/sites/StripeControl.svelte
+++ b/internal/ui/web/src/tabs/sites/StripeControl.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import ToggleButton from '$components/ToggleButton.svelte';
+  import LogsButton from '$components/LogsButton.svelte';
   import StripeConfigModal from './StripeConfigModal.svelte';
   import { m } from '../../paraglide/messages.js';
 
@@ -14,8 +15,17 @@
     webhookPath?: string;
     onToggle: () => void;
     onSaveConfig: (path: string) => void;
+    onLogs?: () => void;
   }
-  let { running, asleep = false, loading = false, webhookPath = '', onToggle, onSaveConfig }: Props = $props();
+  let {
+    running,
+    asleep = false,
+    loading = false,
+    webhookPath = '',
+    onToggle,
+    onSaveConfig,
+    onLogs
+  }: Props = $props();
 
   let modalOpen = $state(false);
 </script>
@@ -36,7 +46,9 @@
     title={m.sites_controls_stripeConfig()}
     aria-label={m.sites_controls_stripeConfig()}
     onclick={() => (modalOpen = true)}
-    class="inline-flex items-center justify-center h-7 w-8 rounded-r-md border border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-card hover:bg-gray-50 dark:hover:bg-white/5 transition-colors text-gray-400 dark:text-gray-500"
+    class="inline-flex items-center justify-center h-7 w-8 {onLogs
+      ? 'border-r-0'
+      : 'rounded-r-md'} border border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-card hover:bg-gray-50 dark:hover:bg-white/5 transition-colors text-gray-400 dark:text-gray-500"
   >
     <svg
       class="w-3.5 h-3.5"
@@ -53,6 +65,9 @@
       />
     </svg>
   </button>
+  {#if onLogs}
+    <LogsButton label={m.sites_controls_stripe()} onclick={onLogs} />
+  {/if}
 </div>
 
 <StripeConfigModal

--- a/internal/ui/web/src/tabs/sites/WorkerControl.svelte
+++ b/internal/ui/web/src/tabs/sites/WorkerControl.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
   import ToggleButton from '$components/ToggleButton.svelte';
+  import LogsButton from '$components/LogsButton.svelte';
   import WorkerOptionsModal from './WorkerOptionsModal.svelte';
   import { m } from '../../paraglide/messages.js';
   import type { WorkerOption } from '$stores/sites';
 
-  // A worker toggle plus the gear its definition earns: one field per
-  // tune_command placeholder. A worker that declares none renders as the plain
-  // toggle, so every worker row can go through this one component.
+  // A worker toggle plus the segments its definition earns: a gear with one
+  // field per tune_command placeholder, and a shortcut to its journal. A worker
+  // that earns neither renders as the plain toggle, so every worker row can go
+  // through this one component.
   interface Props {
     label: string;
     running: boolean;
@@ -19,6 +21,7 @@
     options?: WorkerOption[];
     onToggle: () => void;
     onSaveOptions?: (values: Record<string, string>) => void;
+    onLogs?: () => void;
   }
   let {
     label,
@@ -31,13 +34,17 @@
     title = '',
     options = [],
     onToggle,
-    onSaveOptions = () => {}
+    onSaveOptions = () => {},
+    onLogs
   }: Props = $props();
 
   let modalOpen = $state(false);
+
+  const hasGear = $derived(options.length > 0);
+  const segmented = $derived(hasGear || Boolean(onLogs));
 </script>
 
-{#if options.length === 0}
+<div class="inline-flex items-center">
   <ToggleButton
     {label}
     on={running}
@@ -47,28 +54,18 @@
     {loading}
     {disabled}
     {title}
+    rounding={segmented ? 'rounded-l-md border-r-0' : 'rounded-md'}
     onclick={onToggle}
   />
-{:else}
-  <div class="inline-flex items-center">
-    <ToggleButton
-      {label}
-      on={running}
-      {asleep}
-      {failing}
-      {unreachable}
-      {loading}
-      {disabled}
-      {title}
-      rounding="rounded-l-md border-r-0"
-      onclick={onToggle}
-    />
+  {#if hasGear}
     <button
       type="button"
       title={m.sites_controls_workerOptions()}
       aria-label={m.sites_controls_workerOptions()}
       onclick={() => (modalOpen = true)}
-      class="inline-flex items-center justify-center h-7 w-8 rounded-r-md border border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-card hover:bg-gray-50 dark:hover:bg-white/5 transition-colors text-gray-400 dark:text-gray-500"
+      class="inline-flex items-center justify-center h-7 w-8 {onLogs
+        ? 'border-r-0'
+        : 'rounded-r-md'} border border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-card hover:bg-gray-50 dark:hover:bg-white/5 transition-colors text-gray-400 dark:text-gray-500"
     >
       <svg
         class="w-3.5 h-3.5"
@@ -85,8 +82,13 @@
         />
       </svg>
     </button>
-  </div>
+  {/if}
+  {#if onLogs}
+    <LogsButton {label} onclick={onLogs} />
+  {/if}
+</div>
 
+{#if hasGear}
   <WorkerOptionsModal
     open={modalOpen}
     {label}

--- a/internal/ui/web/src/tabs/sites/WorkerControl.test.svelte
+++ b/internal/ui/web/src/tabs/sites/WorkerControl.test.svelte
@@ -8,14 +8,16 @@
     options?: WorkerOption[];
     onToggle?: () => void;
     onSaveOptions?: (values: Record<string, string>) => void;
+    onLogs?: () => void;
   }
   let {
     label = 'Queue',
     running = false,
     options = [],
     onToggle = () => {},
-    onSaveOptions = () => {}
+    onSaveOptions = () => {},
+    onLogs
   }: Props = $props();
 </script>
 
-<WorkerControl {label} {running} {options} {onToggle} {onSaveOptions} />
+<WorkerControl {label} {running} {options} {onToggle} {onSaveOptions} {onLogs} />

--- a/internal/ui/web/src/tabs/sites/WorkerControl.test.ts
+++ b/internal/ui/web/src/tabs/sites/WorkerControl.test.ts
@@ -19,6 +19,20 @@ describe('WorkerControl', () => {
     expect(container.querySelectorAll('button')).toHaveLength(2);
   });
 
+  it('adds a logs shortcut for a worker whose journal is readable', async () => {
+    const onLogs = vi.fn();
+    render(Harness, { props: { onLogs } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Queue logs' }));
+    expect(onLogs).toHaveBeenCalled();
+  });
+
+  it('keeps the gear and the logs shortcut side by side', () => {
+    const { container } = render(Harness, { props: { options: queueOptions, onLogs: () => {} } });
+    expect(container.querySelectorAll('button')).toHaveLength(3);
+    expect(screen.getByRole('button', { name: 'Worker options' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Queue logs' })).toBeInTheDocument();
+  });
+
   it('prefills the committed value and offers the definition default', async () => {
     render(Harness, { props: { options: queueOptions } });
     await fireEvent.click(screen.getByRole('button', { name: 'Worker options' }));


### PR DESCRIPTION
Reading a worker's journal used to mean leaving the Runtime and workers row, switching to the Logs tab, and picking the worker out of the tab strip. Every worker toggle now carries a second segment that does it in one click, opening the Logs tab with that worker's source already selected. It sits in the same segmented control the queue's options gear does, wearing a log lines glyph so it doesn't read as the header's terminal action.

The selected source lives in the address as sites/<domain>/logs/<source>, so a worker's logs can be linked and bookmarked, and picking a source from the tab strip writes it back there. Without that mirror the shortcut would go dead the moment someone switched tabs by hand, since the address would still name the old source and never change.

Queue, Horizon, Schedule, Reverb, Stripe, framework workers and per worktree workers all get it. Schedule, Reverb and the worktree workers moved onto the shared worker control on the way, so the segment is declared once rather than per worker. Sites with no Logs tab to land on, a static site with nothing to stream, keep the plain toggle.

Closes #1740
