### PR TITLE
Keep the deep-link route when the dashboard hands over to the vhost

### DIFF
--- a/internal/ui/web/src/lib/vhost.test.ts
+++ b/internal/ui/web/src/lib/vhost.test.ts
@@ -8,8 +8,8 @@ function opaque(): Response {
   return { type: 'opaque', ok: false, status: 0 } as Response;
 }
 
-function at(hostname: string, port: string) {
-  const href = { hostname, port, href: `http://${hostname}:${port}/` };
+function at(hostname: string, port: string, hash = '') {
+  const href = { hostname, port, hash, href: `http://${hostname}:${port}/${hash}` };
   Object.defineProperty(window, 'location', { value: href, writable: true, configurable: true });
 }
 
@@ -46,7 +46,16 @@ describe('vhost handover', () => {
   it('moves to the vhost once it answers', async () => {
     at('127.0.0.1', '7073');
     await handOverToVhost();
-    expect(window.location.href).toBe(VHOST_URL);
+    expect(window.location.href).toBe(VHOST_URL + '/');
+  });
+
+  // Every notification deep link lands here with its route in the hash (the
+  // desktop app always loads the loopback address), so the handover has to
+  // carry it across or the click ends on the plain dashboard.
+  it('carries the deep-link hash across to the vhost', async () => {
+    at('127.0.0.1', '7073', '#service/mailpit/view/abc123');
+    await handOverToVhost();
+    expect(window.location.href).toBe(VHOST_URL + '/#service/mailpit/view/abc123');
   });
 
   // nginx refusing the connection means the stack is still down, so staying

--- a/internal/ui/web/src/lib/vhost.ts
+++ b/internal/ui/web/src/lib/vhost.ts
@@ -36,5 +36,8 @@ export async function handOverToVhost(): Promise<void> {
   } catch {
     return;
   }
-  location.href = VHOST_URL;
+  // The hash carries the route, and every notification deep link arrives on
+  // this origin (the desktop app only ever loads the loopback address), so
+  // dropping it here would land every click on the plain dashboard.
+  location.href = VHOST_URL + '/' + location.hash;
 }


### PR DESCRIPTION
A session that starts on 127.0.0.1:7073 is moved to lerd.localhost as soon as nginx answers, so notification permissions and push subscriptions stay on a single origin. The handover pointed the browser at the vhost root and nothing else, which threw away whatever hash the page had been opened with.

That hash is where every notification deep link keeps its route, and the desktop app only ever loads the dashboard from the loopback address, so clicking a captured email focused the app on the plain dashboard instead of the message, and the launcher actions the app ships landed in the same place. The handover now carries the hash across.

Closes #1747