### PR TITLE
fix: let a command run from the UI find lerd itself

### DIFF
--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 )
 
@@ -63,11 +64,19 @@ func BinDir() string {
 // An empty inherited PATH yields the dir alone: a trailing separator would make
 // the shell search the working directory.
 func PathWithBinDir() string {
-	path := BinDir()
-	if existing := os.Getenv("PATH"); existing != "" {
-		path += string(os.PathListSeparator) + existing
+	parts := []string{BinDir()}
+	// A doctor fix or a custom command may call `lerd` itself, and the daemons
+	// that run those are started by launchd, whose PATH is the system default
+	// and carries neither ~/.local/bin nor the shim dir.
+	if exe, err := os.Executable(); err == nil {
+		if dir := filepath.Dir(exe); dir != "" && dir != BinDir() {
+			parts = append(parts, dir)
+		}
 	}
-	return path
+	if existing := os.Getenv("PATH"); existing != "" {
+		parts = append(parts, existing)
+	}
+	return strings.Join(parts, string(os.PathListSeparator))
 }
 
 // NodeGlobalDir is the npm prefix lerd points its node shim at, so

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -170,9 +170,12 @@ func TestDataSubDir(t *testing.T) {
 func TestPathWithBinDir_PrependsShimDir(t *testing.T) {
 	t.Setenv("PATH", "/usr/bin:/bin")
 	got := PathWithBinDir()
-	want := BinDir() + string(os.PathListSeparator) + "/usr/bin:/bin"
-	if got != want {
-		t.Errorf("PathWithBinDir() = %q, want %q", got, want)
+	sep := string(os.PathListSeparator)
+	if !strings.HasPrefix(got, BinDir()+sep) {
+		t.Errorf("PathWithBinDir() = %q, want it to start with %q", got, BinDir())
+	}
+	if !strings.HasSuffix(got, sep+"/usr/bin:/bin") {
+		t.Errorf("PathWithBinDir() = %q, want it to end with the inherited PATH", got)
 	}
 }
 
@@ -180,7 +183,33 @@ func TestPathWithBinDir_PrependsShimDir(t *testing.T) {
 // inherited PATH must not gain a trailing separator.
 func TestPathWithBinDir_EmptyPathHasNoTrailingSeparator(t *testing.T) {
 	t.Setenv("PATH", "")
-	if got := PathWithBinDir(); got != BinDir() {
-		t.Errorf("PathWithBinDir() = %q, want %q", got, BinDir())
+	got := PathWithBinDir()
+	if strings.HasSuffix(got, string(os.PathListSeparator)) {
+		t.Errorf("PathWithBinDir() = %q, want no trailing separator", got)
+	}
+	if !strings.HasPrefix(got, BinDir()) {
+		t.Errorf("PathWithBinDir() = %q, want it to start with %q", got, BinDir())
+	}
+}
+
+// A doctor fix, a worker or a custom command may call `lerd` itself. The
+// daemons that run those are started by launchd, whose PATH is the system
+// default and never carries ~/.local/bin, so the binary has to put its own
+// directory on the PATH it hands to a child.
+func TestPathWithBinDir_IncludesExecutableDir(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin:/bin")
+	exe, err := os.Executable()
+	if err != nil {
+		t.Skip("no executable path on this platform")
+	}
+	dir := filepath.Dir(exe)
+	found := false
+	for _, p := range strings.Split(PathWithBinDir(), string(os.PathListSeparator)) {
+		if p == dir {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("PathWithBinDir() = %q, want it to contain %q", PathWithBinDir(), dir)
 	}
 }


### PR DESCRIPTION
The doctor offers to run lerd env when a site has services in .lerd.yaml that nothing in .env points at. Clicking that fix came back as exit 127, sh: lerd: command not found, while the same line typed in a terminal did the job.

The dashboard and the watcher are started by launchd, which gives a child the system PATH and nothing else, so ~/.local/bin is not on it. The PATH lerd builds for a shell command put the shim dir in front of that, which is what makes php and composer resolve, but lerd itself lives elsewhere and stayed unreachable. Anything the store declares that calls lerd, a doctor fix, a custom command, a worker, failed the same way, and only when it was run from the UI.

That PATH now carries the running binary's own directory as well, so lerd resolves wherever it happens to be installed, without a plist that has to name the path.