### PR TITLE
fix: read a loopback wiring as wiring in the service check

### DIFF
--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -294,25 +294,7 @@ func bareHostPortSuffix(key, token string, updates, containerToHost, serviceCont
 // non-canonical version reports its real published port; the default preset is
 // the fallback for services not separately registered.
 func servicePortMappings(name string) []string {
-	var ports []string
-	if svc, err := config.LoadCustomService(name); err == nil && len(svc.Ports) > 0 {
-		ports = svc.Ports
-	} else if svc, err := config.DefaultPresetMeta(name); err == nil && len(svc.Ports) > 0 {
-		ports = svc.Ports
-	}
-	if len(ports) == 0 {
-		return nil
-	}
-	// Apply a published-port override so a host-proxy app's loopback target
-	// follows the moved port (e.g. lerd-mysql 3306 → 3307 when a host MySQL owns
-	// 3306, set manually via `lerd service port` or by the port-ownership guard).
-	// The override lives in global config, not the preset/quadlet meta the lookups
-	// above read, so without this the host-proxy .env would keep pointing at the
-	// vacated default — and connect to the host server instead of lerd's container.
-	if pp := config.ServicePublishedPort(name); pp > 0 {
-		ports = podman.SetPrimaryHostPort(ports, pp)
-	}
-	return ports
+	return serviceops.HostPortMappings(name)
 }
 
 // splitHostContainerPort parses a podman port mapping ("3411:3306", or

--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -217,12 +217,12 @@ func ReferencesContainer(content, serviceName string) bool {
 	return false
 }
 
-// ReferencesLoopback reports whether an env file points at a service through
-// the host rather than through container DNS: the loopback address with the
-// service's published port, or the service's own domain. A site whose PHP runs
-// on the host (native runtime, host proxy) is wired that way, so looking only
-// for the lerd-<service> hostname reads every one of them as unwired.
-func ReferencesLoopback(content string, hostPorts []string, domain string) bool {
+// ReferencesHostWiring reports whether an env file points at a service through
+// the host rather than through container DNS: the service's published port, or
+// its own domain. A site whose PHP runs on the host (native runtime, host
+// proxy) is wired that way, so looking only for the lerd-<service> hostname
+// reads every one of them as unwired.
+func ReferencesHostWiring(content string, hostPorts []string, domain string) bool {
 	for _, line := range strings.Split(content, "\n") {
 		if strings.HasPrefix(strings.TrimSpace(line), "#") {
 			continue
@@ -231,8 +231,13 @@ func ReferencesLoopback(content string, hostPorts []string, domain string) bool 
 		if domain != "" && lineReferencesNeedle(line, domain) {
 			return true
 		}
+		_, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		value = strings.Trim(strings.TrimSpace(value), `"'`)
 		for _, port := range hostPorts {
-			if port != "" && lineReferencesPort(line, port) {
+			if port != "" && valueReferencesPort(value, port) {
 				return true
 			}
 		}
@@ -240,25 +245,33 @@ func ReferencesLoopback(content string, hostPorts []string, domain string) bool 
 	return false
 }
 
-// lineReferencesPort reports whether line carries port as a whole number, so
-// 6379 is not found inside 16379 or 63790.
-func lineReferencesPort(line, port string) bool {
+// valueReferencesPort reports whether value addresses port: the whole value
+// (REDIS_PORT=6379) or the port field of a host:port (MEILISEARCH_HOST=
+// http://127.0.0.1:7701). Matching the digits anywhere instead would read an
+// APP_KEY or a password that happens to spell 6379 as a redis connection.
+func valueReferencesPort(value, port string) bool {
 	for i := 0; ; {
-		j := strings.Index(line[i:], port)
+		j := strings.Index(value[i:], port)
 		if j < 0 {
 			return false
 		}
 		start, end := i+j, i+j+len(port)
-		beforeOK := start == 0 || !isDigit(line[start-1])
-		afterOK := end >= len(line) || !isDigit(line[end])
-		if beforeOK && afterOK {
+		afterPortField := start == 0 || value[start-1] == ':'
+		endOfPortField := end >= len(value) || !isPortNeighbourByte(value[end])
+		if afterPortField && endOfPortField {
 			return true
 		}
 		i = start + 1
 	}
 }
 
-func isDigit(b byte) bool { return b >= '0' && b <= '9' }
+// isPortNeighbourByte reports whether b continues the field a port sits in, so
+// 6379 is not found inside 63790 or a base64 run.
+func isPortNeighbourByte(b byte) bool {
+	return (b >= '0' && b <= '9') ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z')
+}
 
 // stripInlineComment drops a trailing "# ..." comment from an .env line. A '#'
 // only starts a comment when preceded by whitespace (dotenv convention), so a

--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -217,6 +217,49 @@ func ReferencesContainer(content, serviceName string) bool {
 	return false
 }
 
+// ReferencesLoopback reports whether an env file points at a service through
+// the host rather than through container DNS: the loopback address with the
+// service's published port, or the service's own domain. A site whose PHP runs
+// on the host (native runtime, host proxy) is wired that way, so looking only
+// for the lerd-<service> hostname reads every one of them as unwired.
+func ReferencesLoopback(content string, hostPorts []string, domain string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		line = stripInlineComment(line)
+		if domain != "" && lineReferencesNeedle(line, domain) {
+			return true
+		}
+		for _, port := range hostPorts {
+			if port != "" && lineReferencesPort(line, port) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// lineReferencesPort reports whether line carries port as a whole number, so
+// 6379 is not found inside 16379 or 63790.
+func lineReferencesPort(line, port string) bool {
+	for i := 0; ; {
+		j := strings.Index(line[i:], port)
+		if j < 0 {
+			return false
+		}
+		start, end := i+j, i+j+len(port)
+		beforeOK := start == 0 || !isDigit(line[start-1])
+		afterOK := end >= len(line) || !isDigit(line[end])
+		if beforeOK && afterOK {
+			return true
+		}
+		i = start + 1
+	}
+}
+
+func isDigit(b byte) bool { return b >= '0' && b <= '9' }
+
 // stripInlineComment drops a trailing "# ..." comment from an .env line. A '#'
 // only starts a comment when preceded by whitespace (dotenv convention), so a
 // '#' inside a value (e.g. a password) is preserved.

--- a/internal/envfile/envfile_test.go
+++ b/internal/envfile/envfile_test.go
@@ -433,23 +433,35 @@ func TestReadValues_firstOccurrenceWinsLikeReadKey(t *testing.T) {
 // A site whose PHP runs on the host reaches a service on loopback and its
 // published port, or through the service's own domain, never through the
 // lerd-<service> container name.
-func TestReferencesLoopback(t *testing.T) {
-	env := "REDIS_HOST=127.0.0.1\nREDIS_PORT=6379\nAWS_ENDPOINT=https://rustfs.test\n# MAIL_PORT=1026\n"
+func TestReferencesHostWiring(t *testing.T) {
+	env := "REDIS_HOST=127.0.0.1\nREDIS_PORT=6379\nMEILISEARCH_HOST=http://127.0.0.1:7701\n" +
+		"AWS_ENDPOINT=https://rustfs.test\n# MAIL_PORT=1026\n"
 	cases := []struct {
 		name  string
 		ports []string
 		host  string
 		want  bool
 	}{
-		{"published port", []string{"6379"}, "", true},
+		{"published port as the whole value", []string{"6379"}, "", true},
+		{"published port in a url", []string{"7701"}, "", true},
 		{"service domain", nil, "rustfs.test", true},
 		{"port only in a comment", []string{"1026"}, "", false},
 		{"port that is a substring of another", []string{"637"}, "", false},
-		{"nothing points at it", []string{"7701"}, "meilisearch.test", false},
+		{"nothing points at it", []string{"3307"}, "meilisearch.test", false},
 	}
 	for _, c := range cases {
-		if got := ReferencesLoopback(env, c.ports, c.host); got != c.want {
-			t.Errorf("%s: ReferencesLoopback() = %v, want %v", c.name, got, c.want)
+		if got := ReferencesHostWiring(env, c.ports, c.host); got != c.want {
+			t.Errorf("%s: ReferencesHostWiring() = %v, want %v", c.name, got, c.want)
 		}
+	}
+}
+
+// A port is an address, not a number that happens to appear: a key or a
+// password carrying the digits is not a wiring, or a site would report a
+// service as reached because its APP_KEY spelled the port.
+func TestReferencesHostWiring_ignoresPortDigitsInsideAValue(t *testing.T) {
+	env := "APP_KEY=base64:Zk6379QpLm\nDB_PASSWORD=s3cret6379\nMAIL_FROM=team6379@example.test\n"
+	if ReferencesHostWiring(env, []string{"6379"}, "") {
+		t.Error("ReferencesHostWiring() = true, want false: no value points at the port")
 	}
 }

--- a/internal/envfile/envfile_test.go
+++ b/internal/envfile/envfile_test.go
@@ -429,3 +429,27 @@ func TestReadValues_firstOccurrenceWinsLikeReadKey(t *testing.T) {
 		t.Errorf("ReadKey DB_HOST = %q, want first", got)
 	}
 }
+
+// A site whose PHP runs on the host reaches a service on loopback and its
+// published port, or through the service's own domain, never through the
+// lerd-<service> container name.
+func TestReferencesLoopback(t *testing.T) {
+	env := "REDIS_HOST=127.0.0.1\nREDIS_PORT=6379\nAWS_ENDPOINT=https://rustfs.test\n# MAIL_PORT=1026\n"
+	cases := []struct {
+		name  string
+		ports []string
+		host  string
+		want  bool
+	}{
+		{"published port", []string{"6379"}, "", true},
+		{"service domain", nil, "rustfs.test", true},
+		{"port only in a comment", []string{"1026"}, "", false},
+		{"port that is a substring of another", []string{"637"}, "", false},
+		{"nothing points at it", []string{"7701"}, "meilisearch.test", false},
+	}
+	for _, c := range cases {
+		if got := ReferencesLoopback(env, c.ports, c.host); got != c.want {
+			t.Errorf("%s: ReferencesLoopback() = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/internal/serviceops/ports.go
+++ b/internal/serviceops/ports.go
@@ -585,3 +585,23 @@ func RestorePublishedPorts(name string, snap PublishedPortSnapshot) error {
 	firePublishedPortShiftForced(name, snap.PublishedPort)
 	return nil
 }
+
+// HostPortMappings returns a service's "host:container" port specs, with any
+// published-port override applied. The address a host-side app uses to reach a
+// service is derived from these, and so is the check that asks whether an env
+// file already points there.
+func HostPortMappings(name string) []string {
+	var ports []string
+	if svc, err := config.LoadCustomService(name); err == nil && len(svc.Ports) > 0 {
+		ports = svc.Ports
+	} else if svc, err := config.DefaultPresetMeta(name); err == nil && len(svc.Ports) > 0 {
+		ports = svc.Ports
+	}
+	if len(ports) == 0 {
+		return nil
+	}
+	if pp := config.ServicePublishedPort(name); pp > 0 {
+		ports = podman.SetPrimaryHostPort(ports, pp)
+	}
+	return ports
+}

--- a/internal/sitedoctor/service_wiring.go
+++ b/internal/sitedoctor/service_wiring.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
+	"github.com/geodro/lerd/internal/serviceops"
 )
 
 // checkServiceWiring compares the services a project picks in its .lerd.yaml
@@ -22,6 +23,21 @@ import (
 // its config names the lerd-<service> container, which is a text question every
 // format answers the same way.
 func checkServiceWiring(path, envFile string, fw *config.Framework) (Check, bool) {
+	return checkServiceWiringOn(path, envFile, fw, siteReachesServicesOnLoopback(path))
+}
+
+// siteReachesServicesOnLoopback reports whether a site's PHP runs on the host,
+// which is where its env points at loopback and a published port rather than at
+// a container name.
+func siteReachesServicesOnLoopback(path string) bool {
+	site, err := config.FindSiteByPath(path)
+	if err != nil || site == nil {
+		return false
+	}
+	return site.IsNative() || site.IsHostProxy()
+}
+
+func checkServiceWiringOn(path, envFile string, fw *config.Framework, loopback bool) (Check, bool) {
 	if fw == nil || len(fw.Env.Services) == 0 {
 		return Check{}, false
 	}
@@ -48,9 +64,13 @@ func checkServiceWiring(path, envFile string, fw *config.Framework) (Check, bool
 		if !frameworkWiresService(fw, name) {
 			continue
 		}
-		if !envfile.ReferencesContainer(string(content), name) {
-			unwired = append(unwired, name)
+		if envfile.ReferencesContainer(string(content), name) {
+			continue
 		}
+		if loopback && envfile.ReferencesLoopback(string(content), hostPorts(name), config.ServiceDomain(name)) {
+			continue
+		}
+		unwired = append(unwired, name)
 	}
 	if len(unwired) == 0 {
 		return Check{Name: "service_wiring", Status: StatusOK, Detail: "every service the project picks is wired into " + envFile}, true
@@ -106,4 +126,20 @@ func frameworkWiresService(fw *config.Framework, name string) bool {
 		}
 	}
 	return false
+}
+
+// hostPorts is the published host ports of a service, as strings, so an env
+// value carrying one can be recognised. A mapping is "3411:3306", or
+// "127.0.0.1:3307:3306" when it names an address, so the host port is always
+// the field before the container port. A seam: tests name their own ports
+// rather than depending on an installed service store.
+var hostPorts = func(name string) []string {
+	var ports []string
+	for _, mapping := range serviceops.HostPortMappings(name) {
+		parts := strings.Split(strings.TrimSuffix(mapping, "/tcp"), ":")
+		if len(parts) >= 2 {
+			ports = append(ports, parts[len(parts)-2])
+		}
+	}
+	return ports
 }

--- a/internal/sitedoctor/service_wiring.go
+++ b/internal/sitedoctor/service_wiring.go
@@ -67,7 +67,7 @@ func checkServiceWiringOn(path, envFile string, fw *config.Framework, loopback b
 		if envfile.ReferencesContainer(string(content), name) {
 			continue
 		}
-		if loopback && envfile.ReferencesLoopback(string(content), hostPorts(name), config.ServiceDomain(name)) {
+		if loopback && envfile.ReferencesHostWiring(string(content), hostPorts(name), config.ServiceDomain(name)) {
 			continue
 		}
 		unwired = append(unwired, name)

--- a/internal/sitedoctor/service_wiring_test.go
+++ b/internal/sitedoctor/service_wiring_test.go
@@ -172,3 +172,58 @@ func TestCheckServiceWiring_skipsWhenTheEnvFileIsMissing(t *testing.T) {
 		t.Errorf("check = %+v, want none when the env file is absent", c)
 	}
 }
+
+// A site whose PHP runs on the host points at 127.0.0.1 and the service's
+// published port, so the container name the check used to look for is never
+// there and every picked service read as unwired, with a fix that rewrote the
+// same values and changed nothing.
+func TestCheckServiceWiring_loopbackWiringCounts(t *testing.T) {
+	dir := wiringProject(t, "services:\n  - redis\n", ".env",
+		"REDIS_HOST=127.0.0.1\nREDIS_PORT=6379\n")
+	prev := hostPorts
+	t.Cleanup(func() { hostPorts = prev })
+	hostPorts = func(string) []string { return []string{"6379"} }
+
+	c, ok := checkServiceWiringOn(dir, ".env", wiringFramework(), true)
+	if !ok {
+		t.Fatal("the check must run for a project that picks a service")
+	}
+	if c.Status != StatusOK {
+		t.Errorf("status = %v (%s), want OK", c.Status, c.Detail)
+	}
+}
+
+// The same env on a containerised site is genuinely unwired: that PHP reaches
+// redis by container name, and loopback in its .env points at nothing.
+func TestCheckServiceWiring_loopbackWiringIsNotEnoughForAContainer(t *testing.T) {
+	dir := wiringProject(t, "services:\n  - redis\n", ".env",
+		"REDIS_HOST=127.0.0.1\nREDIS_PORT=6379\n")
+	prev := hostPorts
+	t.Cleanup(func() { hostPorts = prev })
+	hostPorts = func(string) []string { return []string{"6379"} }
+
+	c, ok := checkServiceWiringOn(dir, ".env", wiringFramework(), false)
+	if !ok {
+		t.Fatal("the check must run for a project that picks a service")
+	}
+	if c.Status != StatusWarn {
+		t.Errorf("status = %v (%s), want a warning", c.Status, c.Detail)
+	}
+}
+
+// A loopback site still has to point somewhere: an env with neither the
+// container name nor the published port is the finding the check exists for.
+func TestCheckServiceWiring_loopbackStillReportsNothingPointingAtIt(t *testing.T) {
+	dir := wiringProject(t, "services:\n  - redis\n", ".env", "REDIS_HOST=elsewhere\n")
+	prev := hostPorts
+	t.Cleanup(func() { hostPorts = prev })
+	hostPorts = func(string) []string { return []string{"6379"} }
+
+	c, ok := checkServiceWiringOn(dir, ".env", wiringFramework(), true)
+	if !ok {
+		t.Fatal("the check must run for a project that picks a service")
+	}
+	if c.Status != StatusWarn || !strings.Contains(c.Detail, "redis") {
+		t.Errorf("status = %v (%s), want a warning naming redis", c.Status, c.Detail)
+	}
+}


### PR DESCRIPTION
The doctor kept telling a native site that mailpit, meilisearch, mysql, redis and rustfs were picked in .lerd.yaml with nothing in .env pointing at them, and offered to run lerd env. Running it wrote the connections, reported done, and the warning came back unchanged.

The check looked for the lerd-<service> container name, which is how a containerised site reaches a service and how none of them do it when PHP runs on the host. There the address is 127.0.0.1 with the service published port, or the service own domain for something like rustfs, so every service a native or host-proxy site picked read as unwired no matter what lerd env had just written.

Those sites are now matched on what their env really carries, while a containerised site still has to name the container, since loopback in that env reaches nothing at all. The published port lookup moved into serviceops so the check and the env writer read the same list.