### PR TITLE
fix: let a framework start vite its own way, and route its proxy to match

### DIFF
--- a/internal/cli/store_vite_worker_test.go
+++ b/internal/cli/store_vite_worker_test.go
@@ -25,7 +25,9 @@ var viteFromVersion = map[string]int{
 // Serving a dev server under the site's domain is a property of the tool, not of
 // the framework running it, so every definition that can run vite declares the
 // worker in one shape. The check gates it on vite being installed, which is what
-// keeps it invisible to a project that never added a dev server.
+// keeps it invisible to a project that never added a dev server. The command is
+// the one part that varies: a framework that starts vite through its own console
+// command says so with dev_server rather than running npm.
 func TestStoreFrameworks_DeclareViteWorker(t *testing.T) {
 	root := filepath.Join("..", "..", "lerd-frameworks", "frameworks")
 	dirs, err := os.ReadDir(root)
@@ -81,7 +83,14 @@ func TestStoreFrameworks_DeclareViteWorker(t *testing.T) {
 			if v.Restart != "on-failure" {
 				t.Errorf("%s: vite worker restart = %q, want on-failure", name, v.Restart)
 			}
-			if v.Command != "npm run dev" {
+			// A worker that declares the dev server it starts reaches vite
+			// through the framework's own console command, which is what
+			// dev_server is for, so its command is its own.
+			if v.DevServer != nil {
+				if v.DevServer.Tool != "vite" {
+					t.Errorf("%s: vite worker declares dev server %q", name, v.DevServer.Tool)
+				}
+			} else if v.Command != "npm run dev" {
 				t.Errorf("%s: vite worker command = %q, want npm run dev", name, v.Command)
 			}
 			if v.Check == nil || v.Check.File != "node_modules/vite" {

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -2517,9 +2517,32 @@ func (fw *Framework) DetectProxies(dir string) []NamedProxy {
 		if w.Check != nil && !MatchesRule(dir, *w.Check) {
 			continue
 		}
-		out = append(out, NamedProxy{Worker: name, Proxy: w.Proxy})
+		out = append(out, NamedProxy{Worker: name, Proxy: proxyForProject(dir, name, w)})
 	}
 	return out
+}
+
+// proxyForProject resolves a worker's proxy for one project: the paths a server
+// answers on can depend on the same value its command does, and Winter's vite
+// serves each package under a base named after it. Substituting the worker's
+// tune values here means one value routes the proxy and starts the server,
+// rather than the definition naming a path only one project can use. A copy,
+// since the definition is shared by every site running the framework.
+func proxyForProject(dir, name string, w FrameworkWorker) *WorkerProxy {
+	values := TuneValues(dir, name, w)
+	if len(values) == 0 {
+		return w.Proxy
+	}
+	p := *w.Proxy
+	p.Path = ExpandTunePlaceholders(p.Path, values)
+	if len(p.Paths) > 0 {
+		paths := make([]string, len(p.Paths))
+		for i, raw := range p.Paths {
+			paths[i] = ExpandTunePlaceholders(raw, values)
+		}
+		p.Paths = paths
+	}
+	return &p
 }
 
 // DetectProxy returns the first worker proxy that applies, for callers that

--- a/internal/config/proxy_tune_test.go
+++ b/internal/config/proxy_tune_test.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func viteLikeFramework() *Framework {
+	paths := []string{"/themes/{theme}/assets/dist"}
+	return &Framework{
+		Name: "winterish",
+		Workers: map[string]FrameworkWorker{
+			"vite": {
+				Command:     "php artisan vite:watch theme-demo",
+				TuneCommand: "php artisan vite:watch theme-{theme}",
+				Proxy:       &WorkerProxy{Paths: paths, Port: "pinned"},
+			},
+		},
+	}
+}
+
+// The server answers under a base named after the package its command names, so
+// the proxy has to follow the same value rather than the definition's example.
+func TestDetectProxies_fillsPathsFromTheTuneDefault(t *testing.T) {
+	fw := viteLikeFramework()
+	got := fw.DetectProxies(t.TempDir())
+	if len(got) != 1 {
+		t.Fatalf("got %d proxies, want 1", len(got))
+	}
+	if p := got[0].Proxy.Paths[0]; p != "/themes/demo/assets/dist" {
+		t.Errorf("path = %q, want the tune default filled in", p)
+	}
+	if declared := fw.Workers["vite"].Proxy.Paths[0]; declared != "/themes/{theme}/assets/dist" {
+		t.Errorf("the definition was mutated: %q", declared)
+	}
+}
+
+func TestDetectProxies_projectValueWinsOverTheDefault(t *testing.T) {
+	dir := t.TempDir()
+	yaml := "framework: winterish\nworker_options:\n  vite:\n    theme: aurora\n"
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := viteLikeFramework().DetectProxies(dir)
+	if len(got) != 1 {
+		t.Fatalf("got %d proxies, want 1", len(got))
+	}
+	if p := got[0].Proxy.Paths[0]; p != "/themes/aurora/assets/dist" {
+		t.Errorf("path = %q, want the project's own theme", p)
+	}
+}
+
+// A placeholder nothing supplies stays put: routing a proxy at a literal
+// "{theme}" is wrong, but quietly routing it at the wrong package is worse.
+func TestExpandTunePlaceholders_leavesAnUnknownTokenAlone(t *testing.T) {
+	got := ExpandTunePlaceholders("/themes/{theme}/assets/dist", map[string]string{"other": "x"})
+	if got != "/themes/{theme}/assets/dist" {
+		t.Errorf("got %q, want the token left in place", got)
+	}
+}
+
+// A definition with no placeholders keeps the path it declared.
+func TestDetectProxies_leavesAPlainPathAlone(t *testing.T) {
+	fw := &Framework{
+		Name: "plain",
+		Workers: map[string]FrameworkWorker{
+			"reverb": {
+				Command: "php artisan reverb:start",
+				Proxy:   &WorkerProxy{Paths: []string{"/app"}},
+			},
+		},
+	}
+	got := fw.DetectProxies(t.TempDir())
+	if len(got) != 1 || got[0].Proxy.Paths[0] != "/app" {
+		t.Errorf("got %+v, want /app untouched", got)
+	}
+}

--- a/internal/config/worker_tune.go
+++ b/internal/config/worker_tune.go
@@ -81,6 +81,43 @@ func tuneDefault(command, before, after string, from int) (string, int) {
 	return command[start : start+end], start + end
 }
 
+// TuneValues returns the values a project actually runs a worker with: the
+// defaults its tune_command declares, with whatever the project persisted for it
+// layered on top.
+func TuneValues(dir, name string, w FrameworkWorker) map[string]string {
+	flags := WorkerTuneFlags(w)
+	if len(flags) == 0 {
+		return nil
+	}
+	values := make(map[string]string, len(flags))
+	for _, f := range flags {
+		if f.Default != "" {
+			values[f.Name] = f.Default
+		}
+	}
+	for k, v := range ProjectWorkerOptions(dir, name) {
+		if v != "" {
+			values[k] = v
+		}
+	}
+	return values
+}
+
+// ExpandTunePlaceholders fills a worker's {placeholder} tokens in s. A token
+// with no value is left as it is, so a caller never silently routes somewhere
+// the worker is not.
+func ExpandTunePlaceholders(s string, values map[string]string) string {
+	if s == "" || len(values) == 0 {
+		return s
+	}
+	return tunePlaceholderRe.ReplaceAllStringFunc(s, func(token string) string {
+		if v := values[strings.Trim(token, "{}")]; v != "" {
+			return v
+		}
+		return token
+	})
+}
+
 // RenderTuneCommand substitutes values into the worker's tune_command. With
 // nothing overridden the plain command is returned verbatim, so a start with no
 // options runs exactly what the definition declares.


### PR DESCRIPTION
Two things a definition needs before a framework that reaches vite through its own console command can be served.

The store test pins every vite worker to npm run dev. That held while every definition in the store reached vite the same way, but dev_server exists for the ones that do not: a framework whose own console command starts vite declares the tool there, because reading the command cannot tell. The rest of the shape stays pinned, a worker that declares the tool still has to run on the host, per worktree, replace the build, restart on failure and gate on vite being installed, and a worker that declares nothing still has to be npm run dev.

The second is the proxy path. A worker that declares a tune_command and a proxy has one value the project chooses and a path fixed in the definition, and where the server answers under a path derived from that value the two have to agree. The paths now fill the same {placeholder} tokens the command does, from the definition's defaults and whatever the project persisted in worker_options. A path with no placeholder is untouched, and a token nothing supplies stays as it is rather than routing somewhere the worker is not.

Winter CMS is what needed both, in lerd-env/frameworks#74. Driven locally against a real project: with the skeleton's theme the page fetches its assets from the site's own origin and editing the css logs an hmr update; on a project whose theme was renamed, lerd vite:start --theme=aurora moved the vhost location to /themes/aurora/assets/dist, the server bound the pinned port behind it, and the page's tags followed.

Closes #1759
Closes #1761